### PR TITLE
fix(ant): default evaluation options for ant apis that do not take an…

### DIFF
--- a/src/common/ant.ts
+++ b/src/common/ant.ts
@@ -43,8 +43,10 @@ export class ANT implements ANTContract {
   /**
    * Returns the current state of the contract.
    */
-  async getState(params: EvaluationParameters): Promise<ANTState> {
-    const state = await this.contract.getContractState(params);
+  async getState({
+    evaluationOptions,
+  }: EvaluationParameters = {}): Promise<ANTState> {
+    const state = await this.contract.getContractState({ evaluationOptions });
     return state;
   }
 
@@ -60,7 +62,7 @@ export class ANT implements ANTContract {
     evaluationOptions,
   }: {
     evaluationOptions?: EvaluationOptions | Record<string, never> | undefined;
-  }): Promise<Record<string, ANTRecord>> {
+  } = {}): Promise<Record<string, ANTRecord>> {
     const state = await this.contract.getContractState({ evaluationOptions });
     return state.records;
   }
@@ -69,7 +71,7 @@ export class ANT implements ANTContract {
     evaluationOptions,
   }: {
     evaluationOptions?: EvaluationOptions | Record<string, never> | undefined;
-  }): Promise<string> {
+  } = {}): Promise<string> {
     const state = await this.contract.getContractState({ evaluationOptions });
     return state.owner;
   }
@@ -78,7 +80,7 @@ export class ANT implements ANTContract {
     evaluationOptions,
   }: {
     evaluationOptions?: EvaluationOptions | Record<string, never> | undefined;
-  }): Promise<string[]> {
+  } = {}): Promise<string[]> {
     const state = await this.contract.getContractState({ evaluationOptions });
     return state.controllers;
   }
@@ -87,7 +89,7 @@ export class ANT implements ANTContract {
     evaluationOptions,
   }: {
     evaluationOptions?: EvaluationOptions | Record<string, never> | undefined;
-  }): Promise<string> {
+  } = {}): Promise<string> {
     const state = await this.contract.getContractState({ evaluationOptions });
     return state.name;
   }
@@ -96,7 +98,7 @@ export class ANT implements ANTContract {
     evaluationOptions,
   }: {
     evaluationOptions?: EvaluationOptions | Record<string, never> | undefined;
-  }): Promise<string> {
+  } = {}): Promise<string> {
     const state = await this.contract.getContractState({ evaluationOptions });
     return state.ticker;
   }
@@ -105,7 +107,7 @@ export class ANT implements ANTContract {
     evaluationOptions,
   }: {
     evaluationOptions?: EvaluationOptions | Record<string, never> | undefined;
-  }): Promise<Record<string, number>> {
+  } = {}): Promise<Record<string, number>> {
     const state = await this.contract.getContractState({ evaluationOptions });
     return state.balances;
   }


### PR DESCRIPTION
…other parameter

Allows for no object to be passed to APIs that do not require any other inputs
```typescript
const ant = new ANT({ contarctTxId });
const records = ant.getRecords();  // before this had to be ant.getRecords({});
```