### PR TITLE
fix(types): use generic types and make config optional on `init` for ArIO client

### DIFF
--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -23,7 +23,7 @@
     </script>
 
     <script type="module" defer>
-      import { ArIO } from 'https://unpkg.com/@ar.io/sdk@1.0.0';
+      import { ArIO } from '../../bundles/web.bundle.min.js';
 
       const arIO = ArIO.init();
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "prepare": "husky install",
     "example:mjs": "yarn build:esm && node examples/node/index.mjs",
     "example:cjs": "yarn build:cjs && node examples/node/index.cjs",
-    "example:web": "yarn build:web && cp -r bundles/* examples/web && http-server --port 8080 --host -o examples/web"
+    "example:web": "yarn build:web && http-server --port 8080 --host -o examples/web"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",

--- a/src/common.ts
+++ b/src/common.ts
@@ -50,12 +50,12 @@ export type WithSigner<T = NonNullable<unknown>> = {
 export type OptionalSigner<T = NonNullable<unknown>> = {
   signer?: ContractSigner;
 } & T;
-export type ContractConfiguration =
+export type ContractConfiguration<T = NonNullable<unknown>> =
   | {
-      contract: WarpContract<unknown> | RemoteContract<unknown>;
+      contract?: WarpContract<T> | RemoteContract<T>;
     }
   | {
-      contractTxId: string;
+      contractTxId?: string;
     };
 
 export type EvaluationOptions = {

--- a/src/common.ts
+++ b/src/common.ts
@@ -44,10 +44,15 @@ export type TransactionId = string;
 
 // TODO: append this with other configuration options (e.g. local vs. remote evaluation)
 export type ContractSigner = ArweaveSigner | ArconnectSigner;
-export type WithSigner = { signer: ContractSigner }; // TODO: optionally allow JWK in place of signer
+export type WithSigner<T = NonNullable<unknown>> = {
+  signer: ContractSigner;
+} & T; // TODO: optionally allow JWK in place of signer
+export type OptionalSigner<T = NonNullable<unknown>> = {
+  signer?: ContractSigner;
+} & T;
 export type ContractConfiguration =
   | {
-      contract?: WarpContract<unknown> | RemoteContract<unknown>;
+      contract: WarpContract<unknown> | RemoteContract<unknown>;
     }
   | {
       contractTxId: string;
@@ -63,12 +68,14 @@ export type EvaluationParameters<T = NonNullable<unknown>> = {
   evaluationOptions?: EvaluationOptions | Record<string, never> | undefined;
 } & T;
 
-export type WriteParameters<Input> = {
+export type ReadParameters<Input> = {
   functionName: string;
-  inputs: Input;
-  dryWrite?: boolean;
-  // TODO: add syncState and abortSignal options
+  inputs?: Input;
 };
+
+export type WriteParameters<Input> = WithSigner<
+  Required<ReadParameters<Input>>
+>;
 
 export interface BaseContract<T> {
   getState(params: EvaluationParameters): Promise<T>;
@@ -79,10 +86,7 @@ export interface ReadContract {
     functionName,
     inputs,
     evaluationOptions,
-  }: EvaluationParameters<{
-    functionName: string;
-    inputs?: Input;
-  }>): Promise<State>;
+  }: EvaluationParameters<ReadParameters<Input>>): Promise<State>;
 }
 
 export interface WriteContract {
@@ -93,15 +97,6 @@ export interface WriteContract {
   }: EvaluationParameters<
     WriteParameters<Input>
   >): Promise<WriteInteractionResult>;
-}
-
-export interface SmartWeaveContract<T> {
-  getContractState(params: EvaluationParameters): Promise<T>;
-  readInteraction<I, K>({
-    functionName,
-    inputs,
-    evaluationOptions,
-  }: EvaluationParameters<{ functionName: string; inputs?: I }>): Promise<K>;
 }
 
 // TODO: extend with additional methods
@@ -139,9 +134,9 @@ export interface ArIOReadContract extends BaseContract<ArIOState> {
   getEpoch({
     blockHeight,
     evaluationOptions,
-  }: {
+  }: EvaluationParameters<{
     blockHeight: number;
-  } & EvaluationParameters): Promise<EpochDistributionData>;
+  }>): Promise<EpochDistributionData>;
   getCurrentEpoch({
     evaluationOptions,
   }: EvaluationParameters): Promise<EpochDistributionData>;

--- a/src/common/ant.ts
+++ b/src/common/ant.ts
@@ -23,6 +23,7 @@ import {
   ContractSigner,
   EvaluationOptions,
   EvaluationParameters,
+  OptionalSigner,
   WithSigner,
   WriteInteractionResult,
 } from '../types.js';
@@ -83,20 +84,13 @@ export class ANT {
    * ```
    */
   static init(
-    config: ContractConfiguration &
-      WithSigner &
-      ({ contract: WarpContract<ANTState> } | { contractTxId: string }),
+    config: WithSigner<
+      { contract: WarpContract<ANTState> } | { contractTxId: string }
+    >,
   ): ANTWritable;
-  static init(
-    config?: ContractConfiguration &
-      ({ contract?: RemoteContract<ANTState> } | { contractTxId: string }),
-  ): ANTReadable;
-  static init(
-    config: ContractConfiguration & {
-      signer?: ContractSigner;
-    } = {},
-  ) {
-    if (config?.signer) {
+  static init(config?: ContractConfiguration): ANTReadable;
+  static init(config: OptionalSigner<ContractConfiguration>) {
+    if (config.signer) {
       const signer = config.signer;
       const contract = this.createContract(config);
       return new ANTWritable({ signer, contract });

--- a/src/common/ar-io.ts
+++ b/src/common/ar-io.ts
@@ -31,6 +31,7 @@ import {
   Gateway,
   JoinNetworkParams,
   Observations,
+  OptionalSigner,
   RegistrationType,
   TransactionId,
   UpdateGatewaySettingsParams,
@@ -98,19 +99,12 @@ export class ArIO {
    * ```
    */
   static init(
-    config: ContractConfiguration &
-      WithSigner &
-      ({ contract: WarpContract<ArIOState> } | { contractTxId: string }),
+    config: WithSigner<
+      { contract: WarpContract<ArIOState> } | { contractTxId: string }
+    >,
   ): ArIOWritable;
-  static init(
-    config?: ContractConfiguration &
-      ({ contract?: RemoteContract<ArIOState> } | { contractTxId: string }),
-  ): ArIOReadable;
-  static init(
-    config: ContractConfiguration & {
-      signer?: ContractSigner;
-    } = {},
-  ) {
+  static init(config?: ContractConfiguration): ArIOReadable;
+  static init(config?: OptionalSigner<ContractConfiguration>) {
     if (config?.signer) {
       const signer = config.signer;
       const contract = this.createContract(config);

--- a/src/common/ar-io.ts
+++ b/src/common/ar-io.ts
@@ -539,7 +539,7 @@ export class ArIOWritable extends ArIOReadable implements ArIOWriteContract {
       }
     | { contractTxId?: string }
   >) {
-    if (!config) {
+    if (Object.keys(config).length === 0) {
       super({
         contract: new WarpContract<ArIOState>({
           contractTxId: ARNS_TESTNET_REGISTRY_TX,

--- a/src/common/arweave.ts
+++ b/src/common/arweave.ts
@@ -14,13 +14,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-export const ARWEAVE_TX_REGEX = new RegExp('^[a-zA-Z0-9_-]{43}$');
-// sortkey: padded blockheight to 12, JS timestamp, hash of transactionID + block hash. Timestamp only applicable to L2 and normally is all zeros.
-export const SORT_KEY_REGEX = new RegExp(
-  '^[0-9]{12},[0-9]{13},[a-fA-F0-9]{64}$',
-);
-export const ARNS_TESTNET_REGISTRY_TX =
-  process.env.ARNS_REGISTRY_TX ?? 'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
+import Arweave from 'arweave';
 
-export const ARNS_DEVNET_REGISTRY_TX =
-  '_NctcA2sRy1-J4OmIQZbYFPM17piNcbdBPH2ncX2RL8';
+export const defaultArweave = Arweave.init({
+  host: 'arweave.net',
+  port: 443,
+  protocol: 'https',
+});

--- a/src/common/contracts/warp-contract.ts
+++ b/src/common/contracts/warp-contract.ts
@@ -56,7 +56,7 @@ export class WarpContract<T>
 
   constructor({
     contractTxId,
-    cacheUrl,
+    cacheUrl = 'https://api.arns.app',
     warp = defaultWarp,
     logger = new DefaultLogger({
       level: 'info',

--- a/src/common/contracts/warp-contract.ts
+++ b/src/common/contracts/warp-contract.ts
@@ -24,12 +24,12 @@ import {
   Warp,
 } from 'warp-contracts';
 
-import { defaultWarp } from '../../constants.js';
 import {
   BaseContract,
   ContractSigner,
   EvaluationParameters,
   Logger,
+  OptionalSigner,
   ReadContract,
   WriteContract,
   WriteInteractionResult,
@@ -39,6 +39,7 @@ import { sha256B64Url, toB64Url } from '../../utils/base64.js';
 import { getContractManifest } from '../../utils/smartweave.js';
 import { FailedRequestError, WriteInteractionError } from '../error.js';
 import { DefaultLogger } from '../logger.js';
+import { defaultWarp } from '../warp.js';
 
 LoggerFactory.INST.setOptions({
   logLevel: 'fatal',
@@ -99,8 +100,6 @@ export class WarpContract<T>
       },
       type: 'arweave',
     });
-    //this.contract = this.contract.connect(warpSigner);
-    //this.signer = warpSigner;
     return warpSigner;
   }
 
@@ -122,11 +121,7 @@ export class WarpContract<T>
     return evaluationResult.cachedValue.state as T;
   }
 
-  async ensureContractInit({
-    signer,
-  }: {
-    signer?: ContractSigner;
-  } = {}): Promise<void> {
+  async ensureContractInit({ signer }: OptionalSigner = {}): Promise<void> {
     this.logger.debug(`Checking contract initialized`, {
       contractTxId: this.contractTxId,
     });
@@ -190,9 +185,7 @@ export class WarpContract<T>
     inputs,
     signer,
     // TODO: support dryWrite
-  }: EvaluationParameters<WriteParameters<Input>> & {
-    signer: ContractSigner;
-  }): Promise<WriteInteractionResult> {
+  }: WriteParameters<Input>): Promise<WriteInteractionResult> {
     try {
       this.logger.debug(`Write interaction: ${functionName}`, {
         contractTxId: this.contractTxId,

--- a/src/common/warp.ts
+++ b/src/common/warp.ts
@@ -14,13 +14,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-export const ARWEAVE_TX_REGEX = new RegExp('^[a-zA-Z0-9_-]{43}$');
-// sortkey: padded blockheight to 12, JS timestamp, hash of transactionID + block hash. Timestamp only applicable to L2 and normally is all zeros.
-export const SORT_KEY_REGEX = new RegExp(
-  '^[0-9]{12},[0-9]{13},[a-fA-F0-9]{64}$',
-);
-export const ARNS_TESTNET_REGISTRY_TX =
-  process.env.ARNS_REGISTRY_TX ?? 'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
+import { WarpFactory, defaultCacheOptions } from 'warp-contracts';
 
-export const ARNS_DEVNET_REGISTRY_TX =
-  '_NctcA2sRy1-J4OmIQZbYFPM17piNcbdBPH2ncX2RL8';
+import { defaultArweave } from './arweave.js';
+
+export const defaultWarp = WarpFactory.forMainnet(
+  {
+    ...defaultCacheOptions,
+    inMemory: true,
+  },
+  true,
+  defaultArweave,
+);

--- a/src/utils/smartweave.ts
+++ b/src/utils/smartweave.ts
@@ -17,9 +17,9 @@
 import Arweave from 'arweave';
 import { EvaluationManifest } from 'warp-contracts';
 
-import { ContractConfiguration, SortKey } from '../common.js';
 import { RemoteContract, WarpContract } from '../common/index.js';
 import { SORT_KEY_REGEX } from '../constants.js';
+import { SortKey } from '../types.js';
 import { tagsToObject, validateArweaveId } from './arweave.js';
 
 export function isSortKey(sortKey: string): sortKey is SortKey {
@@ -73,18 +73,20 @@ export async function getContractManifest({
   return contractManifest;
 }
 
-export function isContractConfiguration<T>(
-  config: ContractConfiguration,
-): config is {
+export function isContractConfiguration<T>(config: unknown): config is {
   contract: WarpContract<T> | RemoteContract<T>;
 } {
-  return 'contract' in config;
+  return typeof config === 'object' && config !== null && 'contract' in config;
 }
 
 export function isContractTxIdConfiguration(
-  config: ContractConfiguration,
+  config: unknown,
 ): config is { contractTxId: string } {
   return (
-    'contractTxId' in config && validateArweaveId(config.contractTxId) === true
+    typeof config === 'object' &&
+    config !== null &&
+    'contractTxId' in config &&
+    typeof config.contractTxId === 'string' &&
+    validateArweaveId(config.contractTxId) === true
   );
 }

--- a/tests/integration/ant.test.ts
+++ b/tests/integration/ant.test.ts
@@ -1,18 +1,14 @@
-import { ArweaveSigner } from 'arbundles';
-
 import { ANT, ANTReadable } from '../../src/common/ant';
 import { RemoteContract } from '../../src/common/contracts/remote-contract';
 import { WarpContract } from '../../src/common/contracts/warp-contract';
 import { DefaultLogger } from '../../src/common/logger';
 import { ANTState } from '../../src/contract-state';
 import {
-  arweave,
   evaluateToBlockHeight,
   evaluateToSortKey,
+  localCacheUrl,
+  warp,
 } from '../constants';
-
-const contractTxId = 'UC2zwawQoTnh0TNd9mYLQS4wObBBeaOU5LPQTNETqA4';
-const localCacheUrl = `https://api.arns.app`;
 
 const testCases = [
   [{ sortKey: evaluateToSortKey.toString() }],
@@ -21,12 +17,20 @@ const testCases = [
 ] as const;
 
 describe('ANT contract apis', () => {
-  const ant = ANT.init({
-    contract: new RemoteContract<ANTState>({
-      cacheUrl: localCacheUrl,
-      contractTxId,
-      logger: new DefaultLogger({ level: 'none' }),
-    }),
+  let ant: ANTReadable;
+  let contractTxId: string;
+  let ownerAddress: string;
+
+  beforeAll(() => {
+    contractTxId = process.env.DEPLOYED_ANT_CONTRACT_TX_ID!;
+    ownerAddress = process.env.PRIMARY_WALLET_ADDRESS!;
+    ant = ANT.init({
+      contract: new RemoteContract<ANTState>({
+        cacheUrl: localCacheUrl,
+        contractTxId,
+        logger: new DefaultLogger({ level: 'none' }),
+      }),
+    });
   });
 
   it('should connect and return a valid instance', async () => {
@@ -81,48 +85,46 @@ describe('ANT contract apis', () => {
   it.each(testCases)(
     `should get name with evaluation options: ${JSON.stringify('%s')}`,
     async (evalTo) => {
-      const state = await ant.getName({ evaluationOptions: { evalTo } });
-      expect(state).toBeDefined();
+      const name = await ant.getName({ evaluationOptions: { evalTo } });
+      expect(name).toBeDefined();
     },
   );
 
   it.each(testCases)(
     `should get ticker with evaluation options: ${JSON.stringify('%s')}`,
     async (evalTo) => {
-      const state = await ant.getTicker({ evaluationOptions: { evalTo } });
-      expect(state).toBeDefined();
+      const ticker = await ant.getTicker({ evaluationOptions: { evalTo } });
+      expect(ticker).toBeDefined();
     },
   );
 
   it.each(testCases)(
     `should get balances with evaluation options: ${JSON.stringify('%s')}`,
     async (evalTo) => {
-      const state = await ant.getBalances({ evaluationOptions: { evalTo } });
-      expect(state).toBeDefined();
+      const balances = await ant.getBalances({ evaluationOptions: { evalTo } });
+      expect(balances).toBeDefined();
     },
   );
 
   it.each(testCases)(
     `should get balance with evaluation options: ${JSON.stringify('%s')}`,
     async (evalTo) => {
-      const state = await ant.getBalance({
-        address: 'TRVCopHzzO1VSwRUUS8umkiO2MpAL53XtVGlLaJuI94',
+      const balance = await ant.getBalance({
+        address: ownerAddress,
         evaluationOptions: { evalTo },
       });
-      expect(state).toBeDefined();
+      expect(balance).toBeDefined();
     },
   );
 
   it('should get state with warp contract', async () => {
-    const jwk = await arweave.wallets.generate();
-    const signer = new ArweaveSigner(jwk);
-    ANT.init({
+    const ant = ANT.init({
       contract: new WarpContract<ANTState>({
         cacheUrl: localCacheUrl,
         contractTxId,
         logger: new DefaultLogger({ level: 'none' }),
+        warp,
       }),
-      signer,
     });
     const state = await ant.getState();
     expect(state).toBeDefined();

--- a/tests/integration/ar-io.test.ts
+++ b/tests/integration/ar-io.test.ts
@@ -28,6 +28,18 @@ describe('ArIO Factory', () => {
     signer = new ArweaveSigner(JSON.parse(process.env.PRIMARY_WALLET_JWK!));
   });
 
+  it('should return a readable without any configuration provided', () => {
+    const readable = ArIO.init();
+    expect(readable).toBeDefined();
+    expect(readable).toBeInstanceOf(ArIOReadable);
+  });
+
+  it('should return a writable without any configuration provided', () => {
+    const writable = ArIO.init({ signer });
+    expect(writable).toBeDefined();
+    expect(writable).toBeInstanceOf(ArIOWritable);
+  });
+
   it('should return a valid instance of ArIOWritable with contract config', async () => {
     const writeClient = ArIO.init({
       signer,

--- a/tests/unit/utils-smartweave.test.ts
+++ b/tests/unit/utils-smartweave.test.ts
@@ -1,5 +1,6 @@
 import { RemoteContract, WarpContract } from '../../src/common/index.js';
 import { ARNS_DEVNET_REGISTRY_TX } from '../../src/constants.js';
+import { ArIOState } from '../../src/contract-state.js';
 import {
   isContractConfiguration,
   isContractTxIdConfiguration,
@@ -7,7 +8,7 @@ import {
 
 describe('smartweave', () => {
   const contractConfig = {
-    contract: new WarpContract({
+    contract: new WarpContract<ArIOState>({
       contractTxId: ARNS_DEVNET_REGISTRY_TX,
     }),
   };

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -2,6 +2,9 @@
   "extends": "./tsconfig.json",
   "include": ["src/web", "src/common", "src/utils"],
   "compilerOptions": {
-    "outDir": "./lib/web"
+    "outDir": "./lib/web",
+    "paths": {
+      "arweave": ["./node_modules/arweave/node/index.js"]
+    }
   }
 }


### PR DESCRIPTION
If you don't specify anything - the `ArIO.init()` will throw `Invalid configuration error` as `{}` is provided by default. This PR aims to cleanup types and leverage generics where useful. Additionally separates out warp and arweave into separate files - we may need to move these to web and node implementations to avoid some build errors in the browser.