### PR TITLE
fix(utils): manally convert from b64 to b64url to avoid web polyfill i…

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -2,7 +2,7 @@ export default {
   preset: 'ts-jest',
   clearMocks: true,
   moduleFileExtensions: ['ts', 'js', 'mjs'],
-  testMatch: ['**/src/**/*.test.ts'],
+  testMatch: ['**/tests/unit/**.test.ts'],
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.ts'],
   testEnvironment: 'node',

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -34,15 +34,15 @@ function base64urlToBase64(str: string): string {
     .replaceAll(BASE64URL_CHAR_63, BASE64_CHAR_63);
 }
 
-function base64urlFromBase64(str) {
+function base64urlFromBase64(str: string) {
   return str
     .replaceAll(BASE64_CHAR_62, BASE64URL_CHAR_62)
     .replaceAll(BASE64_CHAR_63, BASE64URL_CHAR_63)
     .replaceAll(BASE64_PADDING, '');
 }
 
-export function fromB64Url(input: string): Buffer {
-  const b64Str = base64urlToBase64(input);
+export function fromB64Url(str: string): Buffer {
+  const b64Str = base64urlToBase64(str);
   return Buffer.from(b64Str, 'base64');
 }
 

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -16,12 +16,39 @@
  */
 import { createHash } from 'crypto';
 
+// safely encodes and decodes base64url strings to and from buffers
+const BASE64_CHAR_62 = '+';
+const BASE64_CHAR_63 = '/';
+const BASE64URL_CHAR_62 = '-';
+const BASE64URL_CHAR_63 = '_';
+const BASE64_PADDING = '=';
+
+function base64urlToBase64(str: string): string {
+  const padLength = str.length % 4;
+  if (padLength) {
+    str += BASE64_PADDING.repeat(4 - padLength);
+  }
+
+  return str
+    .replaceAll(BASE64URL_CHAR_62, BASE64_CHAR_62)
+    .replaceAll(BASE64URL_CHAR_63, BASE64_CHAR_63);
+}
+
+function base64urlFromBase64(str) {
+  return str
+    .replaceAll(BASE64_CHAR_62, BASE64URL_CHAR_62)
+    .replaceAll(BASE64_CHAR_63, BASE64URL_CHAR_63)
+    .replaceAll(BASE64_PADDING, '');
+}
+
 export function fromB64Url(input: string): Buffer {
-  return Buffer.from(input, 'base64');
+  const b64Str = base64urlToBase64(input);
+  return Buffer.from(b64Str, 'base64');
 }
 
 export function toB64Url(buffer: Buffer): string {
-  return buffer.toString('base64url');
+  const b64Str = buffer.toString('base64');
+  return base64urlFromBase64(b64Str);
 }
 
 export function sha256B64Url(input: Buffer): string {

--- a/tests/unit/b64.test.ts
+++ b/tests/unit/b64.test.ts
@@ -1,0 +1,15 @@
+import { fromB64Url, toB64Url } from '../../src/utils/base64';
+
+describe('b64utils', () => {
+  it('should properly convert a buffer to base64url string', async () => {
+    const input = Buffer.from('hello+_world_+', 'base64');
+    const expected = input.toString('base64url');
+    expect(toB64Url(input)).toEqual(expected);
+  });
+
+  it('should properly convert a base64 string to a buffer', async () => {
+    const b64url = Buffer.from('hello+_world_+').toString('base64url');
+    const expected = Buffer.from(b64url, 'base64url');
+    expect(fromB64Url(b64url)).toEqual(expected);
+  });
+});

--- a/tests/unit/b64.test.ts
+++ b/tests/unit/b64.test.ts
@@ -1,14 +1,33 @@
 import { fromB64Url, toB64Url } from '../../src/utils/base64';
 
 describe('b64utils', () => {
-  it('should properly convert a buffer to base64url string', async () => {
-    const input = Buffer.from('hello+_world_+', 'base64');
-    const expected = input.toString('base64url');
-    expect(toB64Url(input)).toEqual(expected);
-  });
+  it.each([
+    'hello+_world_+',
+    'hello/_world/_',
+    '', // empty string
+    'hello', // single character
+    'hello123456', // alphanumeric string
+    '123456', // numeric string
+    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/', // all base64 characters
+    'aGVsbG8=',
+  ])(
+    'should properly convert a buffer to base64url string',
+    async (str: string) => {
+      const input = Buffer.from(str, 'base64');
+      const expected = input.toString('base64url');
+      expect(toB64Url(input)).toEqual(expected);
+    },
+  );
 
-  it('should properly convert a base64 string to a buffer', async () => {
-    const b64url = Buffer.from('hello+_world_+').toString('base64url');
+  it.each([
+    'aGVsbG8', // missing padding character
+    'YQ==', // single character
+    'aGVsbG8gMTIzNDU2', // alphanumeric string
+    'MTIzNDU2', // numeric string
+    'YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXotLUVy', // all base64url characters
+    '', // empty string
+  ])('should properly convert a base64 string to a buffer', async (str) => {
+    const b64url = Buffer.from(str).toString('base64url');
     const expected = Buffer.from(b64url, 'base64url');
     expect(fromB64Url(b64url)).toEqual(expected);
   });


### PR DESCRIPTION
…ssues

Somewhat related to polyfill issues not handling `base64url` correctly - https://github.com/feross/buffer/pull/314/files