### PR TITLE
chore(token): add symbol functions to print classes as their values

### DIFF
--- a/src/token.ts
+++ b/src/token.ts
@@ -112,6 +112,10 @@ export class IOToken {
   toMIO(): mIOToken {
     return new mIOToken(Math.floor(this.value * MIO_PER_IO));
   }
+
+  toString(): string {
+    return `${this.value}`;
+  }
 }
 
 export class mIOToken extends PositiveFiniteInteger {

--- a/tests/unit/token.test.ts
+++ b/tests/unit/token.test.ts
@@ -15,6 +15,11 @@ describe('IOToken', () => {
     const mToken = token.toMIO();
     expect(mToken.valueOf()).toBe(1000000);
   });
+
+  it('should print as a string', () => {
+    const token = new IOToken(1);
+    expect(`${token}`).toBe('1');
+  });
 });
 
 describe('mIOToken', () => {
@@ -81,5 +86,10 @@ describe('mIOToken', () => {
     const token = new mIOToken(1000000);
     const result = token.toIO();
     expect(result.valueOf()).toBe(1);
+  });
+
+  it('should print as a string', () => {
+    const token = new mIOToken(1);
+    expect(`${token}`).toBe('1');
   });
 });


### PR DESCRIPTION
This makes it so you can easily print the value of the IOToken and mIOToken classes without having to use `.valueOf()` everytime. FWIW - mIOToken had this but IOToken did not. Added unit tests to show the usefulness.