### PR TITLE
fix(mIO): allow mIO as an input to write APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ This is the home of [ar.io] SDK. This SDK provides functionality for interacting
   - [Web](#web)
   - [Node](#node)
   - [Typescript](#typescript)
+- [IOToken & mIOToken](#iotoken--miotoken)
+  - [Converting IO to mIO](#converting-io-to-mio)
 - [ArIO Contract](#ario-contract)
+
   - [APIs](#apis)
     - [`init({ signer })`](#init-signer-)
     - [`getState({ evaluationOptions })`](#getstate-evaluationoptions-)
@@ -39,6 +42,7 @@ This is the home of [ar.io] SDK. This SDK provides functionality for interacting
     - [`saveObservations({ reportTxId, failedGateways })`](#saveobservations-reporttxid-failedgateways-)
     - [`transfer({ target, qty, denomination })`](#transfer-target-qty-denomination-)
   - [Custom Contracts](#custom-contracts)
+
 - [Arweave Name Tokens (ANT's)](#arweave-name-tokens-ants)
   - [APIs](#apis-1)
     - [`init({ signer })`](#init-signer-)
@@ -188,6 +192,26 @@ const gateways = await arIO.getGateways();
 
 The SDK provides TypeScript types. When you import the SDK in a TypeScript project types are exported from `./lib/types/[node/web]/index.d.ts` and should be automatically recognized by package managers, offering benefits such as type-checking and autocompletion.
 
+## IOToken & mIOToken
+
+The ArIO contract stores all values as mIO (milli-IO) to avoid floating-point arithmetic issues. The SDK provides an `IOToken` and `mIOToken` classes to handle the conversion between IO and mIO. Each provide methods to convert between the two denominations, along with rounding logic for precision.
+
+**All contract interactions expect values in mIO. If numbers are provided as inputs, they are automatically converted to mIO.**
+
+### Converting IO to mIO
+
+```typescript
+import { IOToken, mIOToken } from '@ar.io/sdk';
+
+const ioValue = 1;
+const mIOValue = new IOToken(ioValue).toMIO();
+console.log(mIOValue); // 1000000 (mIO)
+
+const mIOValue = 1_000_000;
+const ioValue = new mIOToken(mIOValue).toIO();
+console.log(ioValue); // 1 (IO)
+```
+
 ## ArIO Contract
 
 ### APIs
@@ -323,8 +347,6 @@ const arIO = ArIO.init();
 const balance = await arIO.getBalance({
   address: 'INSERT_WALLET_ADDRESS',
 });
-// convert to IO token using helper class
-const balanceIO = new mIO(balance).toIO();
 ```
 
 <details>
@@ -773,10 +795,10 @@ Joins a gateway to the ar.io network via its associated wallet. Requires `signer
 
 ```typescript
 const joinNetworkParams = {
-  qty: new IOToken(10_000).toMIO().valueOf(), // minimum operator stake allowed
+  qty: new IOToken(10_000).toMIO(), // minimum operator stake allowed
   autoStake: true, // auto-stake operator rewards to the gateway
   allowDelegatedStaking: true, // allows delegated staking
-  minDelegatedStake: new IOToken(100).toMIO().valueOf(), // minimum delegated stake allowed (in IO)
+  minDelegatedStake: new IOToken(100).toMIO(), // minimum delegated stake allowed
   delegateRewardShareRatio: 10, // percentage of rewards to share with delegates (e.g. 10%)
   label: 'john smith', // min 1, max 64 characters
   note: 'The example gateway', // max 256 characters
@@ -798,7 +820,7 @@ Writes new gateway settings to the callers gateway configuration. Requires `sign
 
 ```typescript
 const updateGatewaySettingsParams = {
-  minDelegatedStake: new IOToken(100).toMIO().valueOf(),
+  minDelegatedStake: new IOToken(100).toMIO(),
 };
 
 const signer = new ArweaveSigner(jwk);
@@ -816,7 +838,7 @@ Increases the callers stake on the target gateway. Requires `signer` to be provi
 ```typescript
 const params = {
   target: 't4Xr0_J4Iurt7caNST02cMotaz2FIbWQ4Kbj616RHl3',
-  qty: new IOToken(100).toMIO().valueOf(),
+  qty: new IOToken(100).toMIO(),
 };
 
 const signer = new ArweaveSigner(jwk);
@@ -832,7 +854,7 @@ Decreases the callers stake on the target gateway. Requires `signer` to be provi
 ```typescript
 const params = {
   target: 't4Xr0_J4Iurt7caNST02cMotaz2FIbWQ4Kbj616RHl3',
-  qty: new IOToken(100).toMIO().valueOf(),
+  qty: new IOToken(100).toMIO(),
 };
 
 const signer = new ArweaveSigner(jwk);
@@ -847,7 +869,7 @@ Increases the callers operator stake. Must be executed with a wallet registered 
 
 ```typescript
 const params = {
-  qty: new IOToken(100).toMIO().valueOf(),
+  qty: new IOToken(100).toMIO(),
 };
 
 const signer = new ArweaveSigner(jwk);
@@ -862,7 +884,7 @@ Decreases the callers operator stake. Must be executed with a wallet registered 
 
 ```typescript
 const params = {
-  qty: new IOToken(100).toMIO().valueOf(),
+  qty: new IOToken(100).toMIO(),
 };
 
 const signer = new ArweaveSigner(jwk);
@@ -896,7 +918,7 @@ Transfers `IO` or `mIO` depending on the `denomination` selected, defaulting as 
 const authenticatedArIO = ArIO.init({ signer });
 const { id: txId } = await authenticatedArIO.transfer({
   target: '-5dV7nk7waR8v4STuwPnTck1zFVkQqJh5K9q9Zik4Y5',
-  qty: new IOToken(1000).toMIO().valueOf(),
+  qty: new IOToken(1000).toMIO(),
   denomination: 'IO',
 });
 ```

--- a/README.md
+++ b/README.md
@@ -773,10 +773,10 @@ Joins a gateway to the ar.io network via its associated wallet. Requires `signer
 
 ```typescript
 const joinNetworkParams = {
-  qty: new IOToken(10_000).valueOf(), // minimum operator stake allowed
+  qty: new IOToken(10_000).toMIO().valueOf(), // minimum operator stake allowed
   autoStake: true, // auto-stake operator rewards to the gateway
   allowDelegatedStaking: true, // allows delegated staking
-  minDelegatedStake: new IOToken(100).valueOf(), // minimum delegated stake allowed (in IO)
+  minDelegatedStake: new IOToken(100).toMIO().valueOf(), // minimum delegated stake allowed (in IO)
   delegateRewardShareRatio: 10, // percentage of rewards to share with delegates (e.g. 10%)
   label: 'john smith', // min 1, max 64 characters
   note: 'The example gateway', // max 256 characters
@@ -798,7 +798,7 @@ Writes new gateway settings to the callers gateway configuration. Requires `sign
 
 ```typescript
 const updateGatewaySettingsParams = {
-  minDelegatedStake: new IOToken(100).valueOf(),
+  minDelegatedStake: new IOToken(100).toMIO().valueOf(),
 };
 
 const signer = new ArweaveSigner(jwk);
@@ -816,7 +816,7 @@ Increases the callers stake on the target gateway. Requires `signer` to be provi
 ```typescript
 const params = {
   target: 't4Xr0_J4Iurt7caNST02cMotaz2FIbWQ4Kbj616RHl3',
-  qty: new IOToken(100).valueOf(),
+  qty: new IOToken(100).toMIO().valueOf(),
 };
 
 const signer = new ArweaveSigner(jwk);
@@ -832,7 +832,7 @@ Decreases the callers stake on the target gateway. Requires `signer` to be provi
 ```typescript
 const params = {
   target: 't4Xr0_J4Iurt7caNST02cMotaz2FIbWQ4Kbj616RHl3',
-  qty: new IOToken(100).valueOf(),
+  qty: new IOToken(100).toMIO().valueOf(),
 };
 
 const signer = new ArweaveSigner(jwk);
@@ -847,7 +847,7 @@ Increases the callers operator stake. Must be executed with a wallet registered 
 
 ```typescript
 const params = {
-  qty: new IOToken(100).valueOf(),
+  qty: new IOToken(100).toMIO().valueOf(),
 };
 
 const signer = new ArweaveSigner(jwk);
@@ -862,7 +862,7 @@ Decreases the callers operator stake. Must be executed with a wallet registered 
 
 ```typescript
 const params = {
-  qty: new IOToken(100).valueOf(),
+  qty: new IOToken(100).toMIO().valueOf(),
 };
 
 const signer = new ArweaveSigner(jwk);
@@ -896,7 +896,7 @@ Transfers `IO` or `mIO` depending on the `denomination` selected, defaulting as 
 const authenticatedArIO = ArIO.init({ signer });
 const { id: txId } = await authenticatedArIO.transfer({
   target: '-5dV7nk7waR8v4STuwPnTck1zFVkQqJh5K9q9Zik4Y5',
-  qty: new IOToken(1000).valueOf(),
+  qty: new IOToken(1000).toMIO().valueOf(),
   denomination: 'IO',
 });
 ```

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ const arIO = ArIO.init();
 const gateways = await arIO.getGateways();
 ```
 
-##### CJS
+#### CJS
 
 ```javascript
 import { ArIO } from '@ar.io/sdk';
@@ -194,9 +194,9 @@ The SDK provides TypeScript types. When you import the SDK in a TypeScript proje
 
 ## IOToken & mIOToken
 
-The ArIO contract stores all values as mIO (milli-IO) to avoid floating-point arithmetic issues. The SDK provides an `IOToken` and `mIOToken` classes to handle the conversion between IO and mIO. Each provide methods to convert between the two denominations, along with rounding logic for precision.
+The ArIO contract stores all values as mIO (milli-IO) to avoid floating-point arithmetic issues. The SDK provides an `IOToken` and `mIOToken` classes to handle the conversion between IO and mIO, along with rounding logic for precision.
 
-**All contract interactions expect values in mIO. If numbers are provided as inputs, they are automatically converted to mIO.**
+**All contract interactions expect values in mIO. If numbers are provided as inputs, they are assumed to be in raw mIO values.**
 
 ### Converting IO to mIO
 
@@ -937,7 +937,7 @@ const { id: txId } = await authenticatedArIO.increaseUndernameLimit({
 
 #### `extendLease({ domain, years })`
 
-Extends the lease of a registered ArNS domain, with an extension of 1-5 years depending on grace period status. Permenantly registered domains cannot be extended.
+Extends the lease of a registered ArNS domain, with an extension of 1-5 years depending on grace period status. Permanently registered domains cannot be extended.
 
 ```typescript
 const authenticatedArIO = ArIO.init({ signer });

--- a/src/common.ts
+++ b/src/common.ts
@@ -36,6 +36,7 @@ import {
   RegistrationType,
   WeightedObserver,
 } from './contract-state.js';
+import { mIOToken } from './token.js';
 
 export type BlockHeight = number;
 export type SortKey = string;
@@ -203,18 +204,18 @@ export interface ArIOWriteContract {
     observerWallet,
   }: UpdateGatewaySettingsParams): Promise<WriteInteractionResult>;
   increaseOperatorStake(params: {
-    qty: number;
+    qty: number | mIOToken;
   }): Promise<WriteInteractionResult>;
   decreaseOperatorStake(params: {
-    qty: number;
+    qty: number | mIOToken;
   }): Promise<WriteInteractionResult>;
   increaseDelegateStake(params: {
     target: WalletAddress;
-    qty: number;
+    qty: number | mIOToken;
   }): Promise<WriteInteractionResult>;
   decreaseDelegateStake(params: {
     target: WalletAddress;
-    qty: number;
+    qty: number | mIOToken;
   }): Promise<WriteInteractionResult>;
   saveObservations(params: {
     reportTxId: TransactionId;
@@ -232,9 +233,20 @@ export interface ArIOWriteContract {
 
 export type WriteInteractionResult = Transaction | DataItem;
 
-export type JoinNetworkParams = GatewayConnectionSettings &
-  GatewayStakingSettings &
-  GatewayMetadata & { qty: number; observerWallet?: WalletAddress };
+// Helper type to overwrite properties of A with B
+type Overwrite<T, U> = {
+  [K in keyof T]: K extends keyof U ? U[K] : T[K];
+};
+
+export type JoinNetworkParams = Overwrite<
+  GatewayConnectionSettings & GatewayStakingSettings & GatewayMetadata,
+  {
+    minDelegatedStake: number | mIOToken; // TODO: this is for backwards compatibility
+  }
+> & {
+  qty: number | mIOToken; // TODO: this is for backwards compatibility
+  observerWallet?: WalletAddress;
+};
 
 // Original type definition refined with proper field-specific types
 export type UpdateGatewaySettingsParamsBase = {
@@ -242,7 +254,7 @@ export type UpdateGatewaySettingsParamsBase = {
   delegateRewardShareRatio?: number;
   fqdn?: string;
   label?: string;
-  minDelegatedStake?: number;
+  minDelegatedStake?: number | mIOToken; // TODO: this is for backwards compatibility - eventually we'll drop number
   note?: string;
   port?: number;
   properties?: string;

--- a/src/common/ar-io.ts
+++ b/src/common/ar-io.ts
@@ -29,6 +29,7 @@ import {
   EvaluationOptions,
   EvaluationParameters,
   Gateway,
+  IOToken,
   JoinNetworkParams,
   Observations,
   OptionalSigner,
@@ -39,6 +40,7 @@ import {
   WeightedObserver,
   WithSigner,
   WriteInteractionResult,
+  mIOToken,
 } from '../types.js';
 import {
   isContractConfiguration,
@@ -563,7 +565,7 @@ export class ArIOWritable extends ArIOReadable implements ArIOWriteContract {
 
   /**
    * @param target @type {string} The address of the account you want to transfer IO tokens to.
-   * @param qty @type {number} The amount of IO or mIO to transfer.
+   * @param qty @type {number | mIOToken} The amount of IO or mIO to transfer.
    * @param denomination @type {DENOMINATIONS} The denomination of the amount to transfer (io or mio).
    * @returns {Promise<WriteInteractionResult>} The result of the interaction.
    * @example
@@ -578,9 +580,10 @@ export class ArIOWritable extends ArIOReadable implements ArIOWriteContract {
    * IO transfer
    * ```ts
    * arIO.transfer({
-   * target: "fGht8v4STuwPnTck1zFVkQqJh5K9q9Zik4Y5-5dV7nk",
-   * qty: 1,
-   * denomination: DENOMINATIONS.IO
+        target: "fGht8v4STuwPnTck1zFVkQqJh5K9q9Zik4Y5-5dV7nk",
+        qty: new IOToken(100).toMIO(),
+        denomination: DENOMINATIONS.IO
+   });
    * ```
    */
   async transfer({
@@ -589,9 +592,15 @@ export class ArIOWritable extends ArIOReadable implements ArIOWriteContract {
     denomination = DENOMINATIONS.IO,
   }: {
     target: string;
-    qty: number;
+    qty: number | mIOToken;
+    // @deprecated - the contract will no longer support denominations
     denomination?: DENOMINATIONS;
   }): Promise<WriteInteractionResult> {
+    let convertedQty = qty;
+    // the contract will no longer support denominations
+    if (denomination === DENOMINATIONS.IO && typeof qty === 'number') {
+      convertedQty = new IOToken(qty).toMIO();
+    }
     return this.contract.writeInteraction<{
       target: WalletAddress;
       qty: number;
@@ -600,7 +609,7 @@ export class ArIOWritable extends ArIOReadable implements ArIOWriteContract {
       functionName: AR_IO_CONTRACT_FUNCTIONS.TRANSFER,
       inputs: {
         target,
-        qty,
+        qty: convertedQty.valueOf(), // convert to number if mIO is provided
         denomination,
       },
       signer: this.signer,
@@ -614,23 +623,19 @@ export class ArIOWritable extends ArIOReadable implements ArIOWriteContract {
    * Join the network with the your configuration.
    * ```ts
    *   const jointNetworkParams = {
-    // initial operator stake 
-    qty: 4000,
-    // delegated staking settings 
-    allowDelegatedStaking: true,
-    minDelegatedStake: 100,
-    delegateRewardShareRatio: 1,
-    autoStake: true,
-    // gateway metadata info
-    label: 'john smith', // min 1, max 64 characters
-    note: 'The example gateway', // max 256 characters
-    properties: 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44', // Arweave transaction ID containing additional properties of the Gateway.
-    observerWallet: '0VE0wIhDy90WiQoV3U2PeY44FH1aVetOoulPGqgYukj', // wallet address of the observer
-    // gateway info
-    fqdn: 'example.com',
-    port: 443,
-    protocol: 'https',
-  };
+          qty: new IOToken(10000).toMIO(),              // initial operator stake 
+          allowDelegatedStaking: true,                  // delegated staking settings 
+          minDelegatedStake: new IOToken(100).toMIO(),  // min delegated stake                  
+          delegateRewardShareRatio: 1,                  // delegate reward share ratio
+          autoStake: true,                              // auto stake operator tokens 
+          label: 'john smith',                          // min 1, max 64 characters
+          note: 'The example gateway',                  // max 256 characters
+          properties: 'FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44',     // Arweave transaction ID containing additional properties of the Gateway.
+          observerWallet: '0VE0wIhDy90WiQoV3U2PeY44FH1aVetOoulPGqgYukj', // wallet address of the observer
+          fqdn: 'example.com',                     // fully qualified domain name
+          port: 443,                               // port number
+          protocol: 'https',                       // protocol
+        };
     * arIO.joinNetwork(jointNetworkParams);
    * ```
    */
@@ -651,12 +656,12 @@ export class ArIOWritable extends ArIOReadable implements ArIOWriteContract {
     return this.contract.writeInteraction<JoinNetworkParams>({
       functionName: AR_IO_CONTRACT_FUNCTIONS.JOIN_NETWORK,
       inputs: {
-        qty,
+        qty: qty.valueOf(), // convert to number if mIO is provided
         allowDelegatedStaking,
         delegateRewardShareRatio,
         fqdn,
         label,
-        minDelegatedStake,
+        minDelegatedStake: minDelegatedStake.valueOf(), // convert to number if mIO is provided
         note,
         port,
         properties,
@@ -674,7 +679,7 @@ export class ArIOWritable extends ArIOReadable implements ArIOWriteContract {
    * @example
    * Update a setting of the gateway.
    * ```ts
-   * arIO.updateGatewaySettings({ autoStake: true });
+   * arIO.updateGatewaySettings({ autoStake: true, minDelegatedStake: new IOToken(100).toMIO()});
    * ```
    */
   async updateGatewaySettings({
@@ -697,7 +702,7 @@ export class ArIOWritable extends ArIOReadable implements ArIOWriteContract {
         delegateRewardShareRatio,
         fqdn,
         label,
-        minDelegatedStake,
+        minDelegatedStake: minDelegatedStake?.valueOf(), // convert to number if mIO is provided
         note,
         port,
         properties,
@@ -711,7 +716,7 @@ export class ArIOWritable extends ArIOReadable implements ArIOWriteContract {
 
   /**
    * @param target @type {string} The gateway you wish to delegate stake to.
-   * @param qty @type {number} The amount of stake to delegate.
+   * @param qty @type {number | mIOToken} The amount of stake to delegate represented in mIO.
    * @returns {Promise<WriteInteractionResult>} The result of the interaction.
    * @example
    * Delegate stake to a gateway.
@@ -721,51 +726,59 @@ export class ArIOWritable extends ArIOReadable implements ArIOWriteContract {
    */
   async increaseDelegateStake(params: {
     target: string;
-    qty: number;
+    qty: number | mIOToken;
   }): Promise<WriteInteractionResult> {
     return this.contract.writeInteraction<{ target: string; qty: number }>({
       functionName: AR_IO_CONTRACT_FUNCTIONS.DELEGATE_STAKE,
-      inputs: params,
+      inputs: {
+        target: params.target,
+        qty: params.qty.valueOf(), // convert to number if mIO is provided
+      },
       signer: this.signer,
     });
   }
 
   /**
    * @param target @type {string} The gateway you wish to decrease stake at.
-   * @param qty @type {number} The amount of stake to decrease.
+   * @param qty @type {number | mIOToken} The amount of stake to decrease represented in mIO.
    * @returns {Promise<WriteInteractionResult>} The result of the interaction.
    * @example
    * Decrease your delegated staked tokens at a gateway.
    * ```ts
-   * arIO.decreaseDelegateStake({ target: "FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44", qty: 1000 });
+   * arIO.decreaseDelegateStake({ target: "FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44", qty: new IOToken(1000).toMIO() });
    * ```
    */
   async decreaseDelegateStake(params: {
     target: string;
-    qty: number;
+    qty: number | mIOToken;
   }): Promise<WriteInteractionResult> {
     return this.contract.writeInteraction<{ target: string; qty: number }>({
       functionName: AR_IO_CONTRACT_FUNCTIONS.DECREASE_DELEGATE_STAKE,
-      inputs: params,
+      inputs: {
+        target: params.target,
+        qty: params.qty.valueOf(), // convert to number if mIO is provided
+      },
       signer: this.signer,
     });
   }
 
   /**
-   * @param qty @type {number} The amount of stake to increase by.
+   * @param qty @type {number | mIOToken} The amount of stake to increase by represented in mIO.
    * @returns {Promise<WriteInteractionResult>} The result of the interaction.
    * @example
-   * Increase your staked tokens as an operater
-   * ```ts
-   * arIO.increaseOperatorStake({ qty: 1000 });
+   * Increase your staked tokens as an operator
+   * ```new IOToken(1000).toMIO()
+   * arIO.increaseOperatorStake({ qty: new IOToken(1000).toMIO() });
    * ```
    */
   async increaseOperatorStake(params: {
-    qty: number;
+    qty: number | mIOToken;
   }): Promise<WriteInteractionResult> {
     return this.contract.writeInteraction<{ qty: number }>({
       functionName: AR_IO_CONTRACT_FUNCTIONS.INCREASE_OPERATOR_STAKE,
-      inputs: params,
+      inputs: {
+        qty: params.qty.valueOf(), // convert to number if mIO is provided
+      },
       signer: this.signer,
     });
   }
@@ -780,11 +793,13 @@ export class ArIOWritable extends ArIOReadable implements ArIOWriteContract {
    * ```
    */
   async decreaseOperatorStake(params: {
-    qty: number;
+    qty: number | mIOToken;
   }): Promise<WriteInteractionResult> {
     const res = this.contract.writeInteraction<{ qty: number }>({
       functionName: AR_IO_CONTRACT_FUNCTIONS.DECREASE_OPERATOR_STAKE,
-      inputs: params,
+      inputs: {
+        qty: params.qty.valueOf(), // convert to number if mIO is provided
+      },
       signer: this.signer,
     });
     return res;

--- a/src/common/ar-io.ts
+++ b/src/common/ar-io.ts
@@ -593,7 +593,7 @@ export class ArIOWritable extends ArIOReadable implements ArIOWriteContract {
   }: {
     target: string;
     qty: number | mIOToken;
-    // @deprecated - the contract will no longer support denominations
+    // @deprecated - the contract will no longer support denominations - all values will be in mIO
     denomination?: DENOMINATIONS;
   }): Promise<WriteInteractionResult> {
     let convertedQty = qty;
@@ -610,7 +610,6 @@ export class ArIOWritable extends ArIOReadable implements ArIOWriteContract {
       inputs: {
         target,
         qty: convertedQty.valueOf(), // convert to number if mIO is provided
-        denomination,
       },
       signer: this.signer,
     });

--- a/tests/integration/ar-io-writable.test.ts
+++ b/tests/integration/ar-io-writable.test.ts
@@ -5,6 +5,7 @@ import { ArIO, ArIOWritable } from '../../src/common/ar-io.js';
 import { WarpContract } from '../../src/common/index.js';
 import { DefaultLogger } from '../../src/common/logger.js';
 import { ArIOState } from '../../src/contract-state.js';
+import { IOToken } from '../../src/token.js';
 import { arweave, gatewayAddress, localCacheUrl, warp } from '../constants.js';
 
 describe('ArIOWriteable', () => {
@@ -32,13 +33,13 @@ describe('ArIOWriteable', () => {
       label: 'example',
       protocol: 'https',
       port: 443,
-      qty: 20000,
+      qty: new IOToken(20000).toMIO(),
       properties: ''.padEnd(43, 'a'),
       note: 'a note',
       observerWallet: ''.padEnd(43, 'b'),
       allowDelegatedStaking: true,
       delegateRewardShareRatio: 10,
-      minDelegatedStake: 100,
+      minDelegatedStake: new IOToken(100).toMIO(),
       autoStake: true,
     });
     expect(tx.id).toBeDefined();
@@ -49,7 +50,7 @@ describe('ArIOWriteable', () => {
   it('should successfully increase delegate stake', async () => {
     const tx = await arIO.increaseDelegateStake({
       target: gatewayAddress,
-      qty: 101,
+      qty: new IOToken(100).toMIO(),
     });
     expect(tx.id).toBeDefined();
     const verified = await arweave.transactions.verify(tx as Transaction);
@@ -59,7 +60,7 @@ describe('ArIOWriteable', () => {
   it('should successfully decrease delegate stake', async () => {
     const tx = await arIO.decreaseDelegateStake({
       target: gatewayAddress,
-      qty: 101,
+      qty: new IOToken(100).toMIO(),
     });
     expect(tx.id).toBeDefined();
     const verified = await arweave.transactions.verify(tx as Transaction);
@@ -68,10 +69,9 @@ describe('ArIOWriteable', () => {
 
   it('should successfully transfer tokens to another address', async () => {
     const target = ''.padEnd(43, 'f');
-    const qty = 101;
     const tx = await arIO.transfer({
       target,
-      qty,
+      qty: new IOToken(10).toMIO(),
     });
     expect(tx.id).toBeDefined();
     const verified = await arweave.transactions.verify(tx as Transaction);

--- a/tests/integration/ar-io-writable.test.ts
+++ b/tests/integration/ar-io-writable.test.ts
@@ -4,18 +4,20 @@ import Transaction from 'arweave/node/lib/transaction.js';
 import { ArIO, ArIOWritable } from '../../src/common/ar-io.js';
 import { WarpContract } from '../../src/common/index.js';
 import { DefaultLogger } from '../../src/common/logger.js';
-import { ArIOState } from '../../src/contract-state.js';
-import { IOToken } from '../../src/token.js';
+import { ArIOState, ArNSLeaseData } from '../../src/contract-state.js';
+import { IOToken, mIOToken } from '../../src/token.js';
 import { arweave, gatewayAddress, localCacheUrl, warp } from '../constants.js';
 
 describe('ArIOWriteable', () => {
   let signer: ArweaveSigner;
+  let interactingAddress = '';
   let contractTxId: string;
   let arIO: ArIOWritable;
 
   beforeAll(() => {
     contractTxId = process.env.DEPLOYED_REGISTRY_CONTRACT_TX_ID!;
     signer = new ArweaveSigner(JSON.parse(process.env.PRIMARY_WALLET_JWK!));
+    interactingAddress = process.env.PRIMARY_WALLET_ADDRESS!;
     arIO = ArIO.init({
       signer,
       contract: new WarpContract<ArIOState>({
@@ -55,6 +57,12 @@ describe('ArIOWriteable', () => {
     expect(tx.id).toBeDefined();
     const verified = await arweave.transactions.verify(tx as Transaction);
     expect(verified).toBe(true);
+    const gateway = await arIO.getGateway({ address: gatewayAddress });
+    expect(gateway?.delegates[interactingAddress]).toEqual({
+      start: expect.any(Number),
+      delegatedStake: new IOToken(100).toMIO().valueOf(),
+      vaults: {},
+    });
   });
 
   it('should successfully decrease delegate stake', async () => {
@@ -65,9 +73,24 @@ describe('ArIOWriteable', () => {
     expect(tx.id).toBeDefined();
     const verified = await arweave.transactions.verify(tx as Transaction);
     expect(verified).toBe(true);
+    const gateway = await arIO.getGateway({ address: gatewayAddress });
+    expect(gateway?.delegates[interactingAddress]).toEqual({
+      delegatedStake: 0,
+      start: expect.any(Number),
+      vaults: {
+        [tx.id as string]: {
+          start: expect.any(Number),
+          end: expect.any(Number),
+          balance: new IOToken(100).toMIO().valueOf(),
+        },
+      },
+    });
   });
 
   it('should successfully transfer tokens to another address', async () => {
+    const balanceBefore = await arIO.getBalance({
+      address: interactingAddress,
+    });
     const target = ''.padEnd(43, 'f');
     const tx = await arIO.transfer({
       target,
@@ -76,11 +99,23 @@ describe('ArIOWriteable', () => {
     expect(tx.id).toBeDefined();
     const verified = await arweave.transactions.verify(tx as Transaction);
     expect(verified).toBe(true);
+    const targetBalance = await arIO.getBalance({ address: target });
+    expect(targetBalance).toEqual(new IOToken(10).toMIO().valueOf());
+    const balanceAfter = await arIO.getBalance({
+      address: interactingAddress,
+    });
+    const expectedAfter = new mIOToken(balanceBefore)
+      .minus(new IOToken(10).toMIO())
+      .valueOf();
+    expect(balanceAfter).toEqual(expectedAfter);
   });
 
   it('should successfully extend a domain', async () => {
     const domain = 'test-extend';
     const years = 2;
+    const recordBefore = (await arIO.getArNSRecord({
+      domain: 'test-extend',
+    })) as ArNSLeaseData;
     const tx = await arIO.extendLease({
       domain,
       years,
@@ -88,6 +123,10 @@ describe('ArIOWriteable', () => {
     expect(tx.id).toBeDefined();
     const verified = await arweave.transactions.verify(tx as Transaction);
     expect(verified).toBe(true);
+    const record = (await arIO.getArNSRecord({ domain })) as ArNSLeaseData;
+    expect(record?.endTimestamp).toBe(
+      recordBefore.endTimestamp + years * 31536000,
+    );
   });
 
   it('should successfully increase the undername support on a domain', async () => {
@@ -100,5 +139,7 @@ describe('ArIOWriteable', () => {
     expect(tx.id).toBeDefined();
     const verified = await arweave.transactions.verify(tx as Transaction);
     expect(verified).toBe(true);
+    const record = await arIO.getArNSRecord({ domain });
+    expect(record?.undernames).toBe(11);
   });
 });

--- a/tests/integration/arlocal/ar-io-contract/index.js
+++ b/tests/integration/arlocal/ar-io-contract/index.js
@@ -514,7 +514,8 @@ function isActiveReservedName({ caller, reservedName, currentBlockTimestamp }) {
   }
   const isCallerTarget = caller !== void 0 && target === caller;
   const isActiveReservation =
-    endTimestamp && endTimestamp > currentBlockTimestamp.valueOf();
+    endTimestamp === void 0 ||
+    (endTimestamp !== void 0 && endTimestamp > currentBlockTimestamp.valueOf());
   if (!isCallerTarget && isActiveReservation) {
     return true;
   }
@@ -688,7 +689,7 @@ function calculateExistingAuctionBidForCaller({
 }) {
   if (submittedBid && submittedBid.isLessThan(requiredMinimumBid)) {
     throw new ContractError(
-      `The bid (${submittedBid.toIO().valueOf()} IO) is less than the current required minimum bid of ${requiredMinimumBid.toIO().valueOf()} IO.`,
+      `The bid (${submittedBid.valueOf()} mIO) is less than the current required minimum bid of ${requiredMinimumBid.valueOf()} mIO.`,
     );
   }
   if (caller === auction.initiator) {
@@ -5374,7 +5375,7 @@ var AuctionBid = class {
       contractTxId = RESERVED_ATOMIC_TX_ID,
     } = input;
     this.name = name.trim().toLowerCase();
-    this.qty = qty ? new IOToken(qty).toMIO() : void 0;
+    this.qty = qty ? new mIOToken(qty) : void 0;
     this.type = type;
     this.contractTxId =
       contractTxId === RESERVED_ATOMIC_TX_ID
@@ -6106,7 +6107,7 @@ var CreateVault = class {
       );
     }
     const { qty, lockLength } = input;
-    this.qty = new IOToken(qty).toMIO();
+    this.qty = new mIOToken(qty);
     this.lockLength = new BlockHeight(lockLength);
   }
 };
@@ -6263,7 +6264,7 @@ var DecreaseOperatorStake = class {
       );
     }
     const { qty } = input;
-    this.qty = new IOToken(qty).toMIO();
+    this.qty = new mIOToken(qty);
   }
 };
 var decreaseOperatorStake = async (state, { caller, input }) => {
@@ -6281,7 +6282,7 @@ var decreaseOperatorStake = async (state, { caller, input }) => {
   const maxWithdraw = existingStake.minus(MIN_OPERATOR_STAKE);
   if (qty.isGreaterThan(maxWithdraw)) {
     throw new ContractError(
-      `Resulting stake is not enough maintain the minimum operator stake of ${MIN_OPERATOR_STAKE.toIO().valueOf()} IO`,
+      `Resulting stake is not enough maintain the minimum operator stake of ${MIN_OPERATOR_STAKE.valueOf()} mIO`,
     );
   }
   const interactionHeight = new BlockHeight(+SmartWeave.block.height);
@@ -6315,7 +6316,7 @@ var DelegateStake = class {
     }
     const { target, qty } = input;
     this.target = target;
-    this.qty = new IOToken(qty).toMIO();
+    this.qty = new mIOToken(qty);
   }
 };
 var delegateStake = async (state, { caller, input }) => {
@@ -6385,7 +6386,7 @@ var increaseOperatorStake = async (state, { caller, input }) => {
   if (isNaN(input.qty) || input.qty <= 0) {
     throw new ContractError(INVALID_INPUT_MESSAGE);
   }
-  const qty = new IOToken(input.qty).toMIO();
+  const qty = new mIOToken(input.qty);
   if (!(caller in gateways)) {
     throw new ContractError(INVALID_GATEWAY_EXISTS_MESSAGE);
   }
@@ -6414,7 +6415,7 @@ var IncreaseVault = class {
     }
     const { id, qty } = input;
     this.id = id;
-    this.qty = new IOToken(qty).toMIO();
+    this.qty = new mIOToken(qty);
   }
 };
 var increaseVault = async (state, { caller, input }) => {
@@ -6464,7 +6465,7 @@ var JoinNetwork = class {
       delegateRewardShareRatio = 0,
       minDelegatedStake = MIN_DELEGATED_STAKE,
     } = input;
-    this.qty = new IOToken(qty).toMIO();
+    this.qty = new mIOToken(qty);
     this.label = label;
     this.port = port;
     this.protocol = protocol;
@@ -7485,10 +7486,9 @@ var TransferToken = class {
         getInvalidAjvMessage(validateTransferToken, input, 'transferToken'),
       );
     }
-    const { target, qty, denomination = 'mIO' } = input;
+    const { target, qty } = input;
     this.target = target;
-    this.qty =
-      denomination === 'mIO' ? new mIOToken(qty) : new IOToken(qty).toMIO();
+    this.qty = new mIOToken(qty);
   }
 };
 var transferTokens = async (state, { caller, input }) => {
@@ -7539,7 +7539,7 @@ var GatewaySettings = class {
         delegateRewardShareRatio,
       }),
       ...(minDelegatedStake !== void 0 && {
-        minDelegatedStake: new IOToken(minDelegatedStake).toMIO(),
+        minDelegatedStake: new mIOToken(minDelegatedStake),
       }),
     };
     this.observerWallet = observerWallet;
@@ -7630,7 +7630,7 @@ var TransferTokensLocked = class {
     }
     const { target, qty, lockLength } = input;
     this.target = target;
-    this.qty = new IOToken(qty).toMIO();
+    this.qty = new mIOToken(qty);
     this.lockLength = new BlockHeight(lockLength);
   }
 };

--- a/tests/integration/jest.setup.ts
+++ b/tests/integration/jest.setup.ts
@@ -22,7 +22,7 @@ async function jestGlobalSetup() {
 
   // deploy example any contract
   const [arIOContractDeploy, antContractDeploy] = await Promise.all([
-    deployArIOContract({ jwk: wallet, address, warp }),
+    deployArIOContract({ jwk: wallet, address, warp, arweave }),
     deployANTContract({ jwk: wallet, address, warp }),
   ]);
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -51,13 +51,14 @@ export async function deployArIOContract({
   jwk,
   address,
   warp,
+  arweave,
 }: {
   jwk: JWKInterface;
   address: string;
   warp: Warp;
+  arweave: Arweave;
 }): Promise<ContractDeploy> {
-  const currentBlockTimestamp = (await warp.arweave.blocks.getCurrent())
-    .timestamp;
+  const currentBlockTimestamp = (await arweave.blocks.getCurrent()).timestamp;
   const src = fs.readFileSync(
     path.join(__dirname, '/integration/arlocal/ar-io-contract/index.js'),
     'utf8',


### PR DESCRIPTION
Allows `mIOToken` class to be provided as an input parameter to write interaction APIs.