### PR TITLE
fix(io): default the IO process to use testnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "lint:fix": "eslint src --fix",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
-    "test": "yarn test:unit && yarn test:integration",
+    "test": "yarn test:unit && yarn test:integration && yarn test:e2e",
     "test:cjs": "cd ./tests/e2e/cjs && yarn && yarn test",
     "test:esm": "cd ./tests/e2e/esm && yarn && yarn test",
     "test:web": "cd ./tests/e2e/web && yarn && yarn test",

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -16,7 +16,7 @@
  */
 import Arweave from 'arweave';
 
-import { ioDevnetProcessId } from '../constants.js';
+import { IO_TESTNET_PROCESS_ID } from '../constants.js';
 import {
   ArNSReservedNameData,
   EpochDistributionData,
@@ -93,7 +93,7 @@ export class IOReadable implements AoIORead {
   constructor(config?: ProcessConfiguration, arweave = Arweave.init({})) {
     if (!config) {
       this.process = new AOProcess({
-        processId: ioDevnetProcessId,
+        processId: IO_TESTNET_PROCESS_ID,
       });
     } else if (isProcessConfiguration(config)) {
       this.process = config.process;

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -494,7 +494,7 @@ export class IOWriteable extends IOReadable implements AoIOWrite {
     if (Object.keys(config).length === 0) {
       super({
         process: new AOProcess({
-          processId: ioDevnetProcessId,
+          processId: IO_TESTNET_PROCESS_ID,
         }),
       });
       this.signer = signer;

--- a/src/utils/graphql/processes.ts
+++ b/src/utils/graphql/processes.ts
@@ -19,7 +19,7 @@ import { pLimit } from 'plimit-lit';
 
 import { ANT } from '../../common/ant.js';
 import { IO } from '../../common/io.js';
-import { ioDevnetProcessId } from '../../constants.js';
+import { IO_TESTNET_PROCESS_ID } from '../../constants.js';
 import {
   AoANTState,
   AoArNSNameData,
@@ -31,7 +31,7 @@ import {
 export const getANTProcessesOwnedByWallet = async ({
   address,
   contract = IO.init({
-    processId: ioDevnetProcessId,
+    processId: IO_TESTNET_PROCESS_ID,
   }),
 }: {
   address: WalletAddress;
@@ -96,7 +96,7 @@ export class ArNSEventEmitter extends EventEmitter {
   private throttle;
   constructor({
     contract = IO.init({
-      processId: ioDevnetProcessId,
+      processId: IO_TESTNET_PROCESS_ID,
     }),
     timeoutMs = 60_000,
     concurrency = 30,


### PR DESCRIPTION
This will avoid issues with clients using the newest AO implementation and unintentionally using the devnet process.