### PR TITLE
fix(types): update gateway settings type to only support `observerAdd…

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -74,10 +74,7 @@ export type JoinNetworkParams = Overwrite<
   {
     minDelegatedStake: number | mIOToken; // TODO: this is for backwards compatibility
   }
-> & {
-  qty: number | mIOToken; // TODO: this is for backwards compatibility
-  observerWallet?: WalletAddress;
-};
+>;
 
 // Original type definition refined with proper field-specific types
 export type UpdateGatewaySettingsParamsBase = {
@@ -91,7 +88,7 @@ export type UpdateGatewaySettingsParamsBase = {
   properties?: string;
   protocol?: AllowedProtocols;
   autoStake?: boolean;
-  observerWallet?: WalletAddress;
+  observerAddress?: WalletAddress;
 };
 
 // Utility type to require at least one of the fields

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -740,9 +740,7 @@ export class IOWriteable extends IOReadable implements AoIOWrite {
       protocol,
       autoStake,
       observerAddress,
-    }: Omit<UpdateGatewaySettingsParams, 'observerWallet'> & {
-      observerAddress: string;
-    },
+    }: UpdateGatewaySettingsParams,
     options?: WriteOptions,
   ): Promise<AoMessageResult> {
     const { tags = [] } = options || {};

--- a/src/io.ts
+++ b/src/io.ts
@@ -219,9 +219,7 @@ export interface AoIOWrite extends AoIORead {
       protocol,
       autoStake,
       observerAddress,
-    }: Omit<UpdateGatewaySettingsParams, 'observerWallet'> & {
-      observerAddress?: WalletAddress;
-    },
+    }: UpdateGatewaySettingsParams,
     options?: WriteOptions,
   ): Promise<AoMessageResult>;
   increaseOperatorStake(


### PR DESCRIPTION
…ress`

We left in `observerWallet` for backwards compatibility with smartweave contract, but should have updated in the v2.0.0 release to only support `observerAddress`.