### PR TITLE
fix(types): update AoGateway type to include weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,15 @@ const gateways = await io.getGateways();
         "totalEpochsPrescribedCount": 31
       },
       "status": "joined",
-      "vaults": {}
+      "vaults": {},
+      "weights": {
+        "compositeWeight": 0.97688888893556,
+        "gatewayRewardRatioWeight": 1,
+        "tenureWeight": 0.19444444444444,
+        "observerRewardRatioWeight": 1,
+        "normalizedCompositeWeight": 0.19247316211083,
+        "stakeWeight": 5.02400000024
+      }
     }
   ],
   "hasMore": true,
@@ -368,7 +376,15 @@ const gateway = await io.getGateway({
     "totalEpochsPrescribedCount": 31
   },
   "status": "joined",
-  "vaults": {}
+  "vaults": {},
+  "weights": {
+    "compositeWeight": 0.97688888893556,
+    "gatewayRewardRatioWeight": 1,
+    "tenureWeight": 0.19444444444444,
+    "observerRewardRatioWeight": 1,
+    "normalizedCompositeWeight": 0.19247316211083,
+    "stakeWeight": 5.02400000024
+  }
 }
 ```
 
@@ -416,7 +432,15 @@ Available `sortBy` options are any of the keys on the gateway object, e.g. `oper
         "totalEpochsPrescribedCount": 31
       },
       "status": "joined",
-      "vaults": {}
+      "vaults": {},
+      "weights": {
+        "compositeWeight": 0.97688888893556,
+        "gatewayRewardRatioWeight": 1,
+        "tenureWeight": 0.19444444444444,
+        "observerRewardRatioWeight": 1,
+        "normalizedCompositeWeight": 0.19247316211083,
+        "stakeWeight": 5.02400000024
+      }
     }
   ],
   "hasMore": true,

--- a/src/io.ts
+++ b/src/io.ts
@@ -396,6 +396,15 @@ export type AoGatewayStats = {
   prescribedEpochCount: number;
 };
 
+export type AoGatewayWeights = {
+  compositeWeight: number;
+  gatewayRewardRatioWeight: number;
+  tenureWeight: number;
+  observerRewardRatioWeight: number;
+  normalizedCompositeWeight: number;
+  stakeWeight: number;
+};
+
 export type AoGateway = {
   settings: GatewaySettings;
   stats: AoGatewayStats;
@@ -407,7 +416,7 @@ export type AoGateway = {
   observerAddress: WalletAddress;
   operatorStake: number;
   status: 'joined' | 'leaving';
-  // TODO: add weights
+  weights: AoGatewayWeights;
 };
 
 export type AoBalanceWithAddress = {

--- a/tests/e2e/cjs/index.test.js
+++ b/tests/e2e/cjs/index.test.js
@@ -87,11 +87,6 @@ describe('IO', async () => {
     assert.ok(epochSettings);
   });
 
-  it('should be able to get the current prescribed observers', async () => {
-    const observers = await io.getPrescribedObservers();
-    assert.ok(observers);
-  });
-
   it('should be able to get reserved names', async () => {
     const reservedNames = await io.getArNSReservedNames();
     assert.ok(reservedNames);
@@ -235,6 +230,22 @@ describe('IO', async () => {
   it('should be able to get prescribed names', async () => {
     const prescribedNames = await io.getPrescribedNames();
     assert.ok(prescribedNames);
+  });
+
+  it('should return the prescribed observers for a given epoch', async () => {
+    const observers = await io.getPrescribedObservers();
+    assert.ok(observers);
+    for (const observer of observers) {
+      assert(typeof observer.gatewayAddress === 'string');
+      assert(typeof observer.observerAddress === 'string');
+      assert(typeof observer.stake === 'number');
+      assert(typeof observer.startTimestamp === 'number');
+      assert(typeof observer.stakeWeight === 'number');
+      assert(typeof observer.tenureWeight === 'number');
+      assert(typeof observer.gatewayRewardRatioWeight === 'number');
+      assert(typeof observer.observerRewardRatioWeight === 'number');
+      assert(typeof observer.compositeWeight === 'number');
+    }
   });
 
   it('should be able to get token cost for leasing a name', async () => {

--- a/tests/e2e/cjs/index.test.js
+++ b/tests/e2e/cjs/index.test.js
@@ -123,6 +123,14 @@ describe('IO', async () => {
       assert(typeof gateway.startTimestamp === 'number');
       assert(typeof gateway.operatorStake === 'number');
       assert(typeof gateway.totalDelegatedStake === 'number');
+      assert(typeof gateway.settings === 'object');
+      assert(typeof gateway.weights === 'object');
+      assert(typeof gateway.weights.normalizedCompositeWeight === 'number');
+      assert(typeof gateway.weights.compositeWeight === 'number');
+      assert(typeof gateway.weights.stakeWeight === 'number');
+      assert(typeof gateway.weights.tenureWeight === 'number');
+      assert(typeof gateway.weights.observerRewardRatioWeight === 'number');
+      assert(typeof gateway.weights.gatewayRewardRatioWeight === 'number');
     });
   });
 
@@ -152,6 +160,14 @@ describe('IO', async () => {
       assert(typeof gateway.startTimestamp === 'number');
       assert(typeof gateway.operatorStake === 'number');
       assert(typeof gateway.totalDelegatedStake === 'number');
+      assert(typeof gateway.settings === 'object');
+      assert(typeof gateway.weights === 'object');
+      assert(typeof gateway.weights.normalizedCompositeWeight === 'number');
+      assert(typeof gateway.weights.compositeWeight === 'number');
+      assert(typeof gateway.weights.stakeWeight === 'number');
+      assert(typeof gateway.weights.tenureWeight === 'number');
+      assert(typeof gateway.weights.observerRewardRatioWeight === 'number');
+      assert(typeof gateway.weights.gatewayRewardRatioWeight === 'number');
     });
   });
 

--- a/tests/e2e/esm/index.test.js
+++ b/tests/e2e/esm/index.test.js
@@ -124,6 +124,14 @@ describe('IO', async () => {
       assert(typeof gateway.startTimestamp === 'number');
       assert(typeof gateway.operatorStake === 'number');
       assert(typeof gateway.totalDelegatedStake === 'number');
+      assert(typeof gateway.settings === 'object');
+      assert(typeof gateway.weights === 'object');
+      assert(typeof gateway.weights.normalizedCompositeWeight === 'number');
+      assert(typeof gateway.weights.compositeWeight === 'number');
+      assert(typeof gateway.weights.stakeWeight === 'number');
+      assert(typeof gateway.weights.tenureWeight === 'number');
+      assert(typeof gateway.weights.observerRewardRatioWeight === 'number');
+      assert(typeof gateway.weights.gatewayRewardRatioWeight === 'number');
     });
   });
 
@@ -153,6 +161,14 @@ describe('IO', async () => {
       assert(typeof gateway.startTimestamp === 'number');
       assert(typeof gateway.operatorStake === 'number');
       assert(typeof gateway.totalDelegatedStake === 'number');
+      assert(typeof gateway.settings === 'object');
+      assert(typeof gateway.weights === 'object');
+      assert(typeof gateway.weights.normalizedCompositeWeight === 'number');
+      assert(typeof gateway.weights.compositeWeight === 'number');
+      assert(typeof gateway.weights.stakeWeight === 'number');
+      assert(typeof gateway.weights.tenureWeight === 'number');
+      assert(typeof gateway.weights.observerRewardRatioWeight === 'number');
+      assert(typeof gateway.weights.gatewayRewardRatioWeight === 'number');
     });
   });
 

--- a/tests/e2e/esm/index.test.js
+++ b/tests/e2e/esm/index.test.js
@@ -88,11 +88,6 @@ describe('IO', async () => {
     assert.ok(epochSettings);
   });
 
-  it('should be able to get the current prescribed observers', async () => {
-    const observers = await io.getPrescribedObservers();
-    assert.ok(observers);
-  });
-
   it('should be able to get reserved names', async () => {
     const reservedNames = await io.getArNSReservedNames();
     assert.ok(reservedNames);
@@ -236,6 +231,22 @@ describe('IO', async () => {
   it('should be able to get prescribed names', async () => {
     const prescribedNames = await io.getPrescribedNames();
     assert.ok(prescribedNames);
+  });
+
+  it('should return the prescribed observers for a given epoch', async () => {
+    const observers = await io.getPrescribedObservers();
+    assert.ok(observers);
+    for (const observer of observers) {
+      assert(typeof observer.gatewayAddress === 'string');
+      assert(typeof observer.observerAddress === 'string');
+      assert(typeof observer.stake === 'number');
+      assert(typeof observer.startTimestamp === 'number');
+      assert(typeof observer.stakeWeight === 'number');
+      assert(typeof observer.tenureWeight === 'number');
+      assert(typeof observer.gatewayRewardRatioWeight === 'number');
+      assert(typeof observer.observerRewardRatioWeight === 'number');
+      assert(typeof observer.compositeWeight === 'number');
+    }
   });
 
   it('should be able to get token cost for leasing a name', async () => {


### PR DESCRIPTION
The PR in the IO process adds weights to gateways and updates them on every new epoch.

Reference: https://github.com/ar-io/ar-io-network-process/pull/29

Example:

```typescript
const gateway = await io.getGateway({ address: "1H7WZIWhzwTH9FIcnuMqYkTsoyv1OTfGa_amvuYwrgo" })
```

Result:
```json
{
  "vaults": [],
  "startTimestamp": 1719295200000,
  "endTimestamp": 0,
  "totalDelegatedStake": 1200000000,
  "operatorStake": 250000000012,
  "status": "joined",
  "observerAddress": "1H7WZIWhzwTH9FIcnuMqYkTsoyv1OTfGa_amvuYwrgo",
  "weights": {
    "compositeWeight": 0.97688888893556,
    "gatewayRewardRatioWeight": 1,
    "tenureWeight": 0.19444444444444,
    "observerRewardRatioWeight": 1,
    "normalizedCompositeWeight": 0.19247316211083,
    "stakeWeight": 5.02400000024
  },
  "stats": {
    "failedEpochCount": 0,
    "failedConsecutiveEpochs": 0,
    "passedEpochCount": 35,
    "totalEpochCount": 35,
    "passedConsecutiveEpochs": 35,
    "prescribedEpochCount": 35,
    "observedEpochCount": 9
  },
  "delegates": {
    "9jfM0uzGNc9Mkhjo1ixGoqM7ygSem9wx_EokiVgi0Bs": {
      "vaults": [],
      "delegatedStake": 500000000,
      "startTimestamp": 1719349542183
    },
    "N4h8M9A9hasa3tF47qQyNvcKjm4APBKuFs7vqUVm-SI": {
      "vaults": [],
      "delegatedStake": 700000000,
      "startTimestamp": 1719357538153
    }
  },
  "settings": {
    "delegateRewardShareRatio": 100,
    "protocol": "https",
    "minDelegatedStake": 500000000,
    "note": "Owned and operated by DTF.",
    "autoStake": true,
    "allowDelegatedStaking": true,
    "properties": "FH1aVetOoulPGqgYukj0VE0wIhDy90WiQoV3U2PeY44",
    "fqdn": "permagate.io",
    "port": 443,
    "label": "Permagate"
  }
}
```