### PR TITLE
feat(arns): add `ArNSResolver` class that enables forward and reverse name resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "axios": "1.7.7",
     "axios-retry": "^4.3.0",
     "eventemitter3": "^5.0.1",
+    "node-cache": "^5.1.2",
     "plimit-lit": "^3.0.1",
     "winston": "^3.13.0",
     "zod": "^3.23.8"

--- a/src/common/contracts/ao-process.ts
+++ b/src/common/contracts/ao-process.ts
@@ -53,6 +53,7 @@ export class AOProcess implements AOContract {
       try {
         this.logger.debug(`Evaluating read interaction on contract`, {
           tags,
+          processId: this.processId,
         });
         // map tags to inputs
         const result = await this.ao.dryrun({
@@ -86,8 +87,9 @@ export class AOProcess implements AOContract {
       } catch (e) {
         attempts++;
         this.logger.debug(`Read attempt ${attempts} failed`, {
-          error: e,
+          error: e.message,
           tags,
+          processId: this.processId,
         });
         lastError = e;
         // exponential backoff

--- a/tests/e2e/esm/index.test.js
+++ b/tests/e2e/esm/index.test.js
@@ -4,9 +4,12 @@ import {
   AOProcess,
   AoANTRegistryWriteable,
   AoANTWriteable,
+  ArNSResolver,
   ArweaveSigner,
   IO,
   IOWriteable,
+  IO_TESTNET_PROCESS_ID,
+  Logger,
   createAoSigner,
   ioDevnetProcessId,
 } from '@ar.io/sdk';
@@ -34,14 +37,14 @@ const signers = [
 
 const io = IO.init({
   process: new AOProcess({
-    processId: ioDevnetProcessId,
+    processId: IO_TESTNET_PROCESS_ID,
     ao: connect({
       CU_URL: 'http://localhost:6363',
     }),
   }),
 });
 
-describe('IO', async () => {
+describe('e2e tests', () => {
   let compose;
   before(async () => {
     compose = await new DockerComposeEnvironment(
@@ -102,40 +105,11 @@ describe('IO', async () => {
       assert(['lease', 'permabuy'].includes(record.type));
       assert(typeof record.undernameLimit === 'number');
     });
-  });
 
-  it('should be able to return a specific page of arns records', async () => {
-    const records = await io.getArNSRecords({
-      cursor: 'ardrive',
-      limit: 5,
-      sortOrder: 'desc',
-      sortBy: 'name',
+    it('should be able to get the total token supply', async () => {
+      const tokenSupply = await io.getTokenSupply();
+      assert.ok(tokenSupply);
     });
-    assert.ok(records);
-    assert(records.limit === 5);
-    assert(records.sortOrder === 'desc');
-    assert(records.sortBy === 'name');
-    assert(typeof records.totalItems === 'number');
-    assert(typeof records.sortBy === 'string');
-    assert(typeof records.sortOrder === 'string');
-    assert(typeof records.limit === 'number');
-    assert(typeof records.hasMore === 'boolean');
-    if (records.nextCursor) {
-      assert(typeof records.nextCursor === 'string');
-    }
-    assert(Array.isArray(records.items));
-    records.items.forEach((record) => {
-      assert(typeof record.processId === 'string');
-      assert(typeof record.name === 'string');
-      assert(typeof record.startTimestamp === 'number');
-      assert(['lease', 'permabuy'].includes(record.type));
-      assert(typeof record.undernameLimit === 'number');
-    });
-  });
-  it('should be able to get a single arns record', async () => {
-    const arns = await io.getArNSRecord({ name: 'ardrive' });
-    assert.ok(arns);
-  });
 
   it('should be able to get the current epoch', async () => {
     const epoch = await io.getCurrentEpoch();
@@ -390,77 +364,372 @@ describe('ANTRegistry', async () => {
       const registry = ANTRegistry.init({
         signer,
       });
-      assert(registry instanceof AoANTRegistryWriteable);
-    }
-  });
-});
-
-describe('ANT', async () => {
-  const processId = 'aWI_dq1JH7facsulLuas1X3l5dkKuWtixcZDYMw9mpg';
-  const ant = ANT.init({
-    processId,
-  });
-
-  it('should be able to create ANTWriteable with valid signers', async () => {
-    for (const signer of signers) {
-      const writeable = ANT.init({
-        processId,
-        signer,
-      });
-
-      assert(writeable instanceof AoANTWriteable);
-    }
-  });
-
-  it('should be able to get ANT info', async () => {
-    const info = await ant.getInfo({ processId });
-    assert.ok(info);
-  });
-
-  it('should be able to get the ANT records', async () => {
-    const records = await ant.getRecords({ processId });
-    assert.ok(records);
-  });
-
-  it('should be able to get a @ record from the ANT', async () => {
-    const record = await ant.getRecord({ undername: '@' });
-    assert.ok(record);
-  });
-
-  it('should be able to get the ANT owner', async () => {
-    const owner = await ant.getOwner();
-    assert.ok(owner);
-  });
-
-  it('should be able to get the ANT name', async () => {
-    const name = await ant.getName();
-    assert.ok(name);
-  });
-
-  it('should be able to get the ANT ticker', async () => {
-    const ticker = await ant.getTicker();
-    assert.ok(ticker);
-  });
-
-  it('should be able to get the ANT controllers', async () => {
-    const controllers = await ant.getControllers();
-    assert.ok(controllers);
-  });
-
-  it('should be able to get the ANT state', async () => {
-    const state = await ant.getState();
-    assert.ok(state);
-  });
-
-  it('should be able to get the ANT balance for an address', async () => {
-    const balance = await ant.getBalance({
-      address: '"7waR8v4STuwPnTck1zFVkQqJh5K9q9Zik4Y5-5dV7nk',
     });
-    assert.notEqual(balance, undefined);
+
+    it('should be able to return a specific page of arns records', async () => {
+      const records = await io.getArNSRecords({
+        cursor: 'ardrive',
+        limit: 5,
+        sortOrder: 'desc',
+        sortBy: 'name',
+      });
+      assert.ok(records);
+      assert(records.limit === 5);
+      assert(records.sortOrder === 'desc');
+      assert(records.sortBy === 'name');
+      assert(typeof records.totalItems === 'number');
+      assert(typeof records.sortBy === 'string');
+      assert(typeof records.sortOrder === 'string');
+      assert(typeof records.limit === 'number');
+      assert(typeof records.hasMore === 'boolean');
+      if (records.nextCursor) {
+        assert(typeof records.nextCursor === 'string');
+      }
+      assert(Array.isArray(records.items));
+      records.items.forEach((record) => {
+        assert(typeof record.processId === 'string');
+        assert(typeof record.name === 'string');
+        assert(typeof record.startTimestamp === 'number');
+        assert(['lease', 'permabuy'].includes(record.type));
+        assert(typeof record.undernameLimit === 'number');
+      });
+    });
+    it('should be able to get a single arns record', async () => {
+      const arns = await io.getArNSRecord({ name: 'ardrive' });
+      assert.ok(arns);
+    });
+
+    it('should be able to get the current epoch', async () => {
+      const epoch = await io.getCurrentEpoch();
+      assert.ok(epoch);
+    });
+
+    it('should be able to get epoch-settings', async () => {
+      const epochSettings = await io.getEpochSettings();
+      assert.ok(epochSettings);
+    });
+
+    it('should be able to get reserved names', async () => {
+      const reservedNames = await io.getArNSReservedNames();
+      assert.ok(reservedNames);
+    });
+
+    it('should be able to get a single reserved name', async () => {
+      const reservedNames = await io.getArNSReservedNames({ name: 'www ' });
+      assert.ok(reservedNames);
+    });
+
+    it('should be able to get first page of gateways', async () => {
+      const gateways = await io.getGateways();
+      assert.ok(gateways);
+      assert(gateways.limit === 100);
+      assert(gateways.sortOrder === 'desc');
+      assert(gateways.sortBy === 'startTimestamp');
+      assert(typeof gateways.totalItems === 'number');
+      assert(typeof gateways.sortBy === 'string');
+      assert(typeof gateways.sortOrder === 'string');
+      assert(typeof gateways.limit === 'number');
+      assert(typeof gateways.hasMore === 'boolean');
+      if (gateways.nextCursor) {
+        assert(typeof gateways.nextCursor === 'string');
+      }
+      assert(Array.isArray(gateways.items));
+      gateways.items.forEach((gateway) => {
+        assert(typeof gateway.gatewayAddress === 'string');
+        assert(typeof gateway.observerAddress === 'string');
+        assert(typeof gateway.startTimestamp === 'number');
+        assert(typeof gateway.operatorStake === 'number');
+        assert(typeof gateway.totalDelegatedStake === 'number');
+        assert(typeof gateway.settings === 'object');
+        assert(typeof gateway.weights === 'object');
+        assert(typeof gateway.weights.normalizedCompositeWeight === 'number');
+        assert(typeof gateway.weights.compositeWeight === 'number');
+        assert(typeof gateway.weights.stakeWeight === 'number');
+        assert(typeof gateway.weights.tenureWeight === 'number');
+        assert(typeof gateway.weights.observerRewardRatioWeight === 'number');
+        assert(typeof gateway.weights.gatewayRewardRatioWeight === 'number');
+      });
+    });
+
+    it('should be able to get a specific page of gateways', async () => {
+      const gateways = await io.getGateways({
+        cursor: 1000000,
+        limit: 1,
+        sortBy: 'operatorStake',
+        sortOrder: 'desc',
+      });
+      assert.ok(gateways);
+      assert(gateways.limit === 1);
+      assert(gateways.sortOrder === 'desc');
+      assert(gateways.sortBy === 'operatorStake');
+      assert(typeof gateways.totalItems === 'number');
+      assert(typeof gateways.sortBy === 'string');
+      assert(typeof gateways.sortOrder === 'string');
+      assert(typeof gateways.limit === 'number');
+      assert(typeof gateways.hasMore === 'boolean');
+      if (gateways.nextCursor) {
+        assert(typeof gateways.nextCursor === 'string');
+      }
+      assert(Array.isArray(gateways.items));
+      gateways.items.forEach((gateway) => {
+        assert(typeof gateway.gatewayAddress === 'string');
+        assert(typeof gateway.observerAddress === 'string');
+        assert(typeof gateway.startTimestamp === 'number');
+        assert(typeof gateway.operatorStake === 'number');
+        assert(typeof gateway.totalDelegatedStake === 'number');
+        assert(typeof gateway.settings === 'object');
+        assert(typeof gateway.weights === 'object');
+        assert(typeof gateway.weights.normalizedCompositeWeight === 'number');
+        assert(typeof gateway.weights.compositeWeight === 'number');
+        assert(typeof gateway.weights.stakeWeight === 'number');
+        assert(typeof gateway.weights.tenureWeight === 'number');
+        assert(typeof gateway.weights.observerRewardRatioWeight === 'number');
+        assert(typeof gateway.weights.gatewayRewardRatioWeight === 'number');
+      });
+    });
+
+    it('should be able to get a single gateway', async () => {
+      const gateways = await io.getGateway({
+        address: 'QGWqtJdLLgm2ehFWiiPzMaoFLD50CnGuzZIPEdoDRGQ',
+      });
+      assert.ok(gateways);
+    });
+
+    it('should be able to get balances, defaulting to first page', async () => {
+      const balances = await io.getBalances();
+      assert.ok(balances);
+      assert(balances.limit === 100);
+      assert(balances.sortOrder === 'desc');
+      assert(balances.sortBy === 'balance');
+      assert(typeof balances.totalItems === 'number');
+      assert(typeof balances.sortBy === 'string');
+      assert(typeof balances.sortOrder === 'string');
+      assert(typeof balances.limit === 'number');
+      assert(typeof balances.hasMore === 'boolean');
+      if (balances.nextCursor) {
+        assert(typeof gateways.nextCursor === 'string');
+      }
+      assert(Array.isArray(balances.items));
+      balances.items.forEach((wallet) => {
+        assert(typeof wallet.address === 'string');
+        assert(typeof wallet.balance === 'number');
+      });
+    });
+
+    it('should be able to get balances of a specific to first page', async () => {
+      const balances = await io.getBalances({
+        cursor: 1000000,
+        limit: 1,
+        sortBy: 'address',
+        sortOrder: 'asc',
+      });
+      assert.ok(balances);
+      assert(balances.limit === 1);
+      assert(balances.sortOrder === 'asc');
+      assert(balances.sortBy === 'address');
+      assert(typeof balances.totalItems === 'number');
+      assert(typeof balances.sortBy === 'string');
+      assert(typeof balances.sortOrder === 'string');
+      assert(typeof balances.limit === 'number');
+      assert(typeof balances.hasMore === 'boolean');
+      if (balances.nextCursor) {
+        assert(typeof balances.nextCursor === 'string');
+      }
+      assert(Array.isArray(balances.items));
+      balances.items.forEach((wallet) => {
+        assert(typeof wallet.address === 'string');
+        assert(typeof wallet.balance === 'number');
+      });
+    });
+
+    it('should be able to get a single balance', async () => {
+      const balances = await io.getBalance({
+        address: 'QGWqtJdLLgm2ehFWiiPzMaoFLD50CnGuzZIPEdoDRGQ',
+      });
+      assert.ok(balances);
+    });
+
+    it('should be able to get prescribed names', async () => {
+      const prescribedNames = await io.getPrescribedNames();
+      assert.ok(prescribedNames);
+    });
+
+    it('should return the prescribed observers for a given epoch', async () => {
+      const observers = await io.getPrescribedObservers();
+      assert.ok(observers);
+      for (const observer of observers) {
+        assert(typeof observer.gatewayAddress === 'string');
+        assert(typeof observer.observerAddress === 'string');
+        assert(typeof observer.stake === 'number');
+        assert(typeof observer.startTimestamp === 'number');
+        assert(typeof observer.stakeWeight === 'number');
+        assert(typeof observer.tenureWeight === 'number');
+        assert(typeof observer.gatewayRewardRatioWeight === 'number');
+        assert(typeof observer.observerRewardRatioWeight === 'number');
+        assert(typeof observer.compositeWeight === 'number');
+      }
+    });
+
+    it('should be able to get token cost for leasing a name', async () => {
+      const tokenCost = await io.getTokenCost({
+        intent: 'Buy-Record',
+        name: 'new-name',
+        years: 1,
+      });
+      assert.ok(tokenCost);
+    });
+
+    it('should be able to get token cost for buying a name name', async () => {
+      const tokenCost = await io.getTokenCost({
+        intent: 'Buy-Record',
+        name: 'new-name',
+        type: 'permabuy',
+      });
+      assert.ok(tokenCost);
+    });
+
+    it('should be able to get registration fees', async () => {
+      const registrationFees = await io.getRegistrationFees();
+      assert(registrationFees);
+      assert.equal(Object.keys(registrationFees).length, 51);
+      for (const nameLength of Object.keys(registrationFees)) {
+        // assert lease is length of 5
+        assert(registrationFees[nameLength]['lease']['1'] > 0);
+        assert(registrationFees[nameLength]['lease']['2'] > 0);
+        assert(registrationFees[nameLength]['lease']['3'] > 0);
+        assert(registrationFees[nameLength]['lease']['4'] > 0);
+        assert(registrationFees[nameLength]['lease']['5'] > 0);
+        assert(registrationFees[nameLength]['permabuy'] > 0);
+      }
+    });
+
+    it('should be able to create IOWriteable with valid signers', async () => {
+      for (const signer of signers) {
+        const io = IO.init({ signer });
+
+        assert(io instanceof IOWriteable);
+      }
+    });
   });
 
-  it('should be able to get the ANT balances', async () => {
-    const balances = await ant.getBalances();
-    assert.ok(balances);
+  describe('ANTRegistry', async () => {
+    const registry = ANTRegistry.init();
+    const address = '7waR8v4STuwPnTck1zFVkQqJh5K9q9Zik4Y5-5dV7nk';
+
+    it('should retrieve ids from registry', async () => {
+      const affiliatedAnts = await registry.accessControlList({ address });
+      assert(Array.isArray(affiliatedAnts.Owned));
+      assert(Array.isArray(affiliatedAnts.Controlled));
+    });
+
+    it('should be able to create AoANTRegistryWriteable with valid signers', async () => {
+      for (const signer of signers) {
+        const registry = ANTRegistry.init({
+          signer,
+        });
+        assert(registry instanceof AoANTRegistryWriteable);
+      }
+    });
+  });
+
+  describe('ANT', async () => {
+    const processId = 'aWI_dq1JH7facsulLuas1X3l5dkKuWtixcZDYMw9mpg';
+    const ant = ANT.init({
+      processId,
+    });
+
+    it('should be able to create ANTWriteable with valid signers', async () => {
+      for (const signer of signers) {
+        const writeable = ANT.init({
+          processId,
+          signer,
+        });
+
+        assert(writeable instanceof AoANTWriteable);
+      }
+    });
+
+    it('should be able to get ANT info', async () => {
+      const info = await ant.getInfo({ processId });
+      assert.ok(info);
+    });
+
+    it('should be able to get the ANT records', async () => {
+      const records = await ant.getRecords({ processId });
+      assert.ok(records);
+    });
+
+    it('should be able to get a @ record from the ANT', async () => {
+      const record = await ant.getRecord({ undername: '@' });
+      assert.ok(record);
+    });
+
+    it('should be able to get the ANT owner', async () => {
+      const owner = await ant.getOwner();
+      assert.ok(owner);
+    });
+
+    it('should be able to get the ANT name', async () => {
+      const name = await ant.getName();
+      assert.ok(name);
+    });
+
+    it('should be able to get the ANT ticker', async () => {
+      const ticker = await ant.getTicker();
+      assert.ok(ticker);
+    });
+
+    it('should be able to get the ANT controllers', async () => {
+      const controllers = await ant.getControllers();
+      assert.ok(controllers);
+    });
+
+    it('should be able to get the ANT state', async () => {
+      const state = await ant.getState();
+      assert.ok(state);
+    });
+
+    it('should be able to get the ANT balance for an address', async () => {
+      const balance = await ant.getBalance({
+        address: '"7waR8v4STuwPnTck1zFVkQqJh5K9q9Zik4Y5-5dV7nk',
+      });
+      assert.notEqual(balance, undefined);
+    });
+
+    it('should be able to get the ANT balances', async () => {
+      const balances = await ant.getBalances();
+      assert.ok(balances);
+    });
+  });
+
+  describe('ArNSResolver', async () => {
+    const resolver = new ArNSResolver({
+      io,
+    });
+
+    it('should return the resolution data for a given name', async () => {
+      const name = 'ardrive';
+      const record = await io.getArNSRecord({ name });
+      const resolvedName = await resolver.resolveArNSName({
+        name: name,
+      });
+      assert.ok(resolvedName);
+      assert.ok(resolvedName.processId === record.processId);
+      assert.ok(resolvedName.name === name);
+      assert.ok(resolvedName.transactionId);
+    });
+
+    it('should return the list of names associated with to a transaction id', async () => {
+      const name = 'ardrive';
+      const resolvedName = await resolver.resolveArNSName({
+        name: name,
+      });
+      const associatedNames = await resolver.lookupAssociatedArNSNames({
+        txId: resolvedName.transactionId,
+      });
+      assert.ok(associatedNames);
+      assert.ok(associatedNames.length > 0);
+      assert.ok(associatedNames.includes(name));
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2890,6 +2890,11 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -6263,6 +6268,13 @@ node-addon-api@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
   integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
+
+node-cache@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
+  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
+  dependencies:
+    clone "2.x"
 
 node-emoji@^1.11.0:
   version "1.11.0"


### PR DESCRIPTION
This includes a node-cache dep, we can just use an in-memory map and introduce other deps via plugins to avoid bolting this in the SDK even if clients do not need it