### PR TITLE
fix(types): add `totalEligibleGateways` to `AoEpochDistributionData` …

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ Returns the current rewards distribution information.
 
 ```typescript
 const io = IO.init();
-const distributions = await io.getDistributions();
+const distributions = await io.getDistributions({ epochIndex: 0 });
 ```
 
 <details>
@@ -637,11 +637,22 @@ const distributions = await io.getDistributions();
 
 ```json
 {
+  "totalEligibleGateways": 1,
   "totalEligibleRewards": 100000000,
+  "totalEligibleObserverReward": 100000000,
+  "totalEligibleGatewayReward": 100000000,
   "totalDistributedRewards": 100000000,
   "distributedTimestamp": 1720720621424,
   "rewards": {
-    "IPdwa3Mb_9pDD8c2IaJx6aad51Ss-_TfStVwBuhtXMs": 100000000
+    "eligible": {
+      "IPdwa3Mb_9pDD8c2IaJx6aad51Ss-_TfStVwBuhtXMs": {
+        "operatorReward": 100000000,
+        "delegateRewards": {}
+      }
+    },
+    "distributed": {
+      "IPdwa3Mb_9pDD8c2IaJx6aad51Ss-_TfStVwBuhtXMs": 100000000
+    }
   }
 }
 ```
@@ -693,11 +704,22 @@ const epoch = await io.getEpoch({ epochIndex: 0 });
     }
   ],
   "distributions": {
-    "distributedTimestamp": 1752256702026,
+    "totalEligibleGateways": 1,
     "totalEligibleRewards": 100000000,
-    "totoalDistributedRewards": 100000000,
+    "totalEligibleObserverReward": 100000000,
+    "totalEligibleGatewayReward": 100000000,
+    "totalDistributedRewards": 100000000,
+    "distributedTimestamp": 1720720621424,
     "rewards": {
-      "IPdwa3Mb_9pDD8c2IaJx6aad51Ss-_TfStVwBuhtXMs": 100000000
+      "eligible": {
+        "IPdwa3Mb_9pDD8c2IaJx6aad51Ss-_TfStVwBuhtXMs": {
+          "operatorReward": 100000000,
+          "delegateRewards": {}
+        }
+      },
+      "distributed": {
+        "IPdwa3Mb_9pDD8c2IaJx6aad51Ss-_TfStVwBuhtXMs": 100000000
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ const demandFactor = await io.getDemandFactor();
 
 #### `getObservations({ epochIndex })`
 
-Returns the epoch-indexed observation list.
+Returns the epoch-indexed observation list. If no epoch index is provided, the current epoch is used.
 
 ```typescript
 const io = IO.init();
@@ -625,7 +625,7 @@ const observations = await io.getObservations();
 
 #### `getDistributions({ epochIndex })`
 
-Returns the current rewards distribution information.
+Returns the current rewards distribution information. If no epoch index is provided, the current epoch is used.
 
 ```typescript
 const io = IO.init();
@@ -661,7 +661,7 @@ const distributions = await io.getDistributions({ epochIndex: 0 });
 
 #### `getEpoch({ epochIndex })`
 
-Returns the epoch data for the specified block height.
+Returns the epoch data for the specified block height. If no epoch index is provided, the current epoch is used.
 
 ```typescript
 const io = IO.init();

--- a/src/io.ts
+++ b/src/io.ts
@@ -114,6 +114,7 @@ export type AoEpochDistributionRewards = {
 
 export type AoEpochDistributionData = {
   rewards: AoEpochDistributionRewards;
+  totalEligibleGateways: number;
   totalEligibleRewards: number;
   totalEligibleObserverReward: number;
   totalEligibleGatewayReward: number;

--- a/tests/e2e/cjs/index.test.js
+++ b/tests/e2e/cjs/index.test.js
@@ -121,8 +121,13 @@ describe('IO', async () => {
     assert.ok(arns);
   });
 
-  it('should be able to get the current epoch', async () => {
+  it('should be able to get the current epoch using getCurrentEpoch', async () => {
     const epoch = await io.getCurrentEpoch();
+    assert.ok(epoch);
+  });
+
+  it('should be able to get the current epoch using getEpoch', async () => {
+    const epoch = await io.getEpoch({ epochIndex: 0 });
     assert.ok(epoch);
   });
 

--- a/tests/e2e/esm/index.test.js
+++ b/tests/e2e/esm/index.test.js
@@ -334,6 +334,31 @@ describe('IO', async () => {
     }
   });
 
+  it('should be able to get current epoch distributions', async () => {
+    const distributions = await io.getDistributions();
+    assert.ok(distributions);
+  });
+
+  it('should be able to get epoch distributions at a specific epoch', async () => {
+    const distributions = await io.getDistributions({ epochIndex: 0 });
+    assert.ok(distributions);
+  });
+
+  it('should be able to get current epoch observations', async () => {
+    const observations = await io.getObservations();
+    assert.ok(observations);
+  });
+
+  it('should be able to get epoch observations at a specific epoch', async () => {
+    const observations = await io.getObservations({ epochIndex: 0 });
+    assert.ok(observations);
+  });
+
+  it('should be able to get current demand factor', async () => {
+    const demandFactor = await io.getDemandFactor();
+    assert.ok(demandFactor);
+  });
+
   it('should be able to create IOWriteable with valid signers', async () => {
     for (const signer of signers) {
       const io = IO.init({ signer });


### PR DESCRIPTION
…type

Useful for traversing epoch data and understanding how many gateways were active when the epoch was created

Related: https://github.com/ar-io/ar-io-network-process/pull/99