### PR TITLE
fix(io): update `getTokenSupply` to type that returns full breakdown …

### DIFF
--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -38,6 +38,7 @@ import {
   AoGatewayWithAddress,
   AoJoinNetworkParams,
   AoMessageResult,
+  AoTokenSupplyData,
   AoUpdateGatewaySettingsParams,
   AoWeightedObserver,
   ContractSigner,
@@ -131,8 +132,8 @@ export class IOReadable implements AoIORead {
     });
   }
 
-  async getTokenSupply(): Promise<number> {
-    return this.process.read<number>({
+  async getTokenSupply(): Promise<AoTokenSupplyData> {
+    return this.process.read<AoTokenSupplyData>({
       tags: [{ name: 'Action', value: 'Total-Token-Supply' }],
     });
   }

--- a/src/io.ts
+++ b/src/io.ts
@@ -166,6 +166,16 @@ export type AoEpochData = {
   distributions: AoEpochDistributionData;
 };
 
+export type AoTokenSupplyData = {
+  total: number;
+  circulating: number;
+  locked: number;
+  withdrawn: number;
+  delegated: number;
+  staked: number;
+  protocolBalance: number;
+};
+
 export type AoGatewayService = {
   fqdn: string;
   path: string;
@@ -323,7 +333,7 @@ export interface AoIORead {
     Handlers: string[];
     LastTickedEpochIndex: number;
   }>;
-  getTokenSupply(): Promise<number>;
+  getTokenSupply(): Promise<AoTokenSupplyData>;
   getEpochSettings(params?: EpochInput): Promise<AoEpochSettings>;
   getGateway({
     address,

--- a/tests/e2e/esm/index.test.js
+++ b/tests/e2e/esm/index.test.js
@@ -71,6 +71,13 @@ describe('IO', async () => {
   it('should be able to get the total token supply', async () => {
     const tokenSupply = await io.getTokenSupply();
     assert.ok(tokenSupply);
+    assert(typeof tokenSupply.total === 'number');
+    assert(typeof tokenSupply.circulating === 'number');
+    assert(typeof tokenSupply.locked === 'number');
+    assert(typeof tokenSupply.withdrawn === 'number');
+    assert(typeof tokenSupply.delegated === 'number');
+    assert(typeof tokenSupply.staked === 'number');
+    assert(typeof tokenSupply.protocolBalance === 'number');
   });
 
   it('should be able to get first set of arns records', async () => {


### PR DESCRIPTION
…of tokens

Note: This is a breaking change, but the API was known to be under development and not used by many clients, so we will keep it as a fix.

Depends on: https://github.com/ar-io/ar-io-network-process/pull/100