### PR TITLE
fix(arns emitter): provide configuration for strict check

### DIFF
--- a/src/utils/processes.ts
+++ b/src/utils/processes.ts
@@ -144,7 +144,7 @@ export class ArNSEventEmitter extends EventEmitter {
           }
           const ant = ANT.init({
             processId,
-            strict: true,
+            strict: false,
           });
           const state: AoANTState | undefined = (await timeout(
             this.timeoutMs,

--- a/src/utils/processes.ts
+++ b/src/utils/processes.ts
@@ -67,6 +67,7 @@ export class ArNSEventEmitter extends EventEmitter {
   private timeoutMs: number; // timeout for each request to 3 seconds
   private throttle;
   private logger: ILogger;
+  private strict: boolean;
   constructor({
     contract = IO.init({
       processId: IO_TESTNET_PROCESS_ID,
@@ -74,17 +75,20 @@ export class ArNSEventEmitter extends EventEmitter {
     timeoutMs = 60_000,
     concurrency = 30,
     logger = Logger.default,
+    strict = true,
   }: {
     contract?: AoIORead;
     timeoutMs?: number;
     concurrency?: number;
     logger?: ILogger;
+    strict?: boolean;
   } = {}) {
     super();
     this.contract = contract;
     this.timeoutMs = timeoutMs;
     this.throttle = pLimit(concurrency);
     this.logger = logger;
+    this.strict = strict;
   }
 
   async fetchProcessesOwnedByWallet({
@@ -144,7 +148,7 @@ export class ArNSEventEmitter extends EventEmitter {
           }
           const ant = ANT.init({
             processId,
-            strict: false,
+            strict: this.strict,
           });
           const state: AoANTState | undefined = (await timeout(
             this.timeoutMs,


### PR DESCRIPTION
The ArNSEventEmitter was strict checking states on ant retrieval - this requires configuration if we want to still retrieve those ants. Added a check on the constructor to allow for invalid or out of date ants to be returned.