### PR TITLE
fix(eth signer): use a unique anchor in ans-104 headers

### DIFF
--- a/src/common/contracts/ao-process.ts
+++ b/src/common/contracts/ao-process.ts
@@ -130,6 +130,11 @@ export class AOProcess implements AOContract {
         });
 
         // TODO: do a read as a dry run to check if the process supports the action
+        const randomLetter = String.fromCharCode(
+          65 + Math.floor(Math.random() * 26),
+        );
+        // anchor is a random string produce non-deterministic messages IDs
+        const anchor = Date.now().toString().padEnd(32, randomLetter);
 
         const messageId = await this.ao.message({
           process: this.processId,
@@ -137,11 +142,13 @@ export class AOProcess implements AOContract {
           tags: [...tags, { name: 'AR-IO-SDK', value: version }],
           data,
           signer,
+          anchor,
         });
 
         this.logger.debug(`Sent message to process`, {
           messageId,
           processId: this.processId,
+          anchor,
         });
 
         // check the result of the send interaction

--- a/src/common/contracts/ao-process.ts
+++ b/src/common/contracts/ao-process.ts
@@ -16,6 +16,7 @@
 import { connect } from '@permaweb/aoconnect';
 
 import { AOContract, AoClient, AoSigner } from '../../types/index.js';
+import { getRandomText } from '../../utils/base64.js';
 import { safeDecode } from '../../utils/json.js';
 import { version } from '../../version.js';
 import { WriteInteractionError } from '../error.js';
@@ -130,11 +131,8 @@ export class AOProcess implements AOContract {
         });
 
         // TODO: do a read as a dry run to check if the process supports the action
-        const randomLetter = String.fromCharCode(
-          65 + Math.floor(Math.random() * 26),
-        );
-        // anchor is a random string produce non-deterministic messages IDs
-        const anchor = Date.now().toString().padEnd(32, randomLetter);
+        // anchor is a random text produce non-deterministic messages IDs when deterministic signers are provided (ETH)
+        const anchor = getRandomText(32);
 
         const messageId = await this.ao.message({
           process: this.processId,

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createHash, getRandomValues } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 
 // safely encodes and decodes base64url strings to and from buffers
 const BASE64_CHAR_62 = '+';
@@ -54,10 +54,11 @@ export function sha256B64Url(input: Buffer): string {
   return toB64Url(createHash('sha256').update(Uint8Array.from(input)).digest());
 }
 
-export function getRandomText(length = 32) {
-  const array = new Uint8Array(length);
-  getRandomValues(array);
-  return Array.from(array, (byte) => byte.toString(16).padStart(2, '0'))
+export function getRandomText(length = 32): string {
+  // Generate a buffer of random bytes
+  const buffer = randomBytes(length);
+  // Convert bytes to hexadecimal string
+  return Array.from(buffer, (byte) => byte.toString(16).padStart(2, '0'))
     .join('')
     .slice(0, length);
 }

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createHash } from 'crypto';
+import { createHash, getRandomValues } from 'crypto';
 
 // safely encodes and decodes base64url strings to and from buffers
 const BASE64_CHAR_62 = '+';
@@ -52,4 +52,12 @@ export function toB64Url(buffer: Buffer): string {
 
 export function sha256B64Url(input: Buffer): string {
   return toB64Url(createHash('sha256').update(Uint8Array.from(input)).digest());
+}
+
+export function getRandomText(length = 32) {
+  const array = new Uint8Array(length);
+  getRandomValues(array);
+  return Array.from(array, (byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, length);
 }

--- a/tests/unit/b64.test.ts
+++ b/tests/unit/b64.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { fromB64Url, toB64Url } from '../../src/utils/base64.js';
+import { fromB64Url, getRandomText, toB64Url } from '../../src/utils/base64.js';
 
 describe('b64utils', () => {
   it('should convert various strings to base64url and back', () => {
@@ -64,5 +64,21 @@ describe('b64utils', () => {
         `Failed for edge case: ${testCase}`,
       );
     }
+  });
+
+  it('should generate random text', () => {
+    const randomText = getRandomText();
+    assert.strictEqual(randomText.length, 32);
+    const randomText2 = getRandomText();
+    assert.strictEqual(randomText2.length, 32);
+
+    assert.notStrictEqual(randomText, randomText2);
+
+    const smallRandomText = getRandomText(16);
+    assert.strictEqual(smallRandomText.length, 16);
+    const smallRandomText2 = getRandomText();
+    assert.strictEqual(smallRandomText2.length, 16);
+
+    assert.notStrictEqual(smallRandomText, smallRandomText2);
   });
 });

--- a/tests/unit/b64.test.ts
+++ b/tests/unit/b64.test.ts
@@ -68,15 +68,15 @@ describe('b64utils', () => {
 
   it('should generate random text', () => {
     const randomText = getRandomText();
-    assert.strictEqual(randomText.length, 32);
     const randomText2 = getRandomText();
+    assert.strictEqual(randomText.length, 32);
     assert.strictEqual(randomText2.length, 32);
 
     assert.notStrictEqual(randomText, randomText2);
 
     const smallRandomText = getRandomText(16);
+    const smallRandomText2 = getRandomText(16);
     assert.strictEqual(smallRandomText.length, 16);
-    const smallRandomText2 = getRandomText();
     assert.strictEqual(smallRandomText2.length, 16);
 
     assert.notStrictEqual(smallRandomText, smallRandomText2);


### PR DESCRIPTION
this will produce non-deterministic IDs for all signer types that dont provide salt

PE-7158