### PR TITLE
feat(primary names): add processID to read APIs PE-7307

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -66,6 +66,7 @@ export type AoPrimaryNameRequest = {
 
 export type AoPrimaryName = {
   owner: WalletAddress;
+  processId: ProcessId;
   name: string;
   startTimestamp: Timestamp;
 };

--- a/tests/e2e/esm/index.test.ts
+++ b/tests/e2e/esm/index.test.ts
@@ -720,6 +720,7 @@ describe('e2e esm tests', async () => {
         owner: 'HwFceQaMQnOBgKDpnFqCqgwKwEU5LBme1oXRuQOWSRA',
         name: 'arns',
         startTimestamp: 1719356032297,
+        processId: 'HwFceQaMQnOBgKDpnFqCqgwKwEU5LBme1oXRuQOWSRA',
       });
     });
 
@@ -732,6 +733,7 @@ describe('e2e esm tests', async () => {
         owner: 'HwFceQaMQnOBgKDpnFqCqgwKwEU5LBme1oXRuQOWSRA',
         name: 'arns',
         startTimestamp: 1719356032297,
+        processId: 'HwFceQaMQnOBgKDpnFqCqgwKwEU5LBme1oXRuQOWSRA',
       });
     });
 


### PR DESCRIPTION
```sh
~/ar-io/ar-io-sdk PE-7307-forw..primary-name                                                              19s 11:39:33 AM
> node lib/esm/cli/cli.js get-primary-name --name arns --dev
{
  "owner": "HwFceQaMQnOBgKDpnFqCqgwKwEU5LBme1oXRuQOWSRA",
  "startTimestamp": 1719356032297,
  "processId": "HwFceQaMQnOBgKDpnFqCqgwKwEU5LBme1oXRuQOWSRA",
  "name": "arns"
}
```