### PR TITLE
feat(io): fetch historical epoch data from gql

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -257,7 +257,11 @@ makeCommand({
   description: 'Get observations for an epoch',
   options: epochOptions,
   action: (o) =>
-    readARIOFromOptions(o).getObservations(epochInputFromOptions(o)),
+    readARIOFromOptions(o)
+      .getObservations(epochInputFromOptions(o))
+      .then(
+        (result) => result ?? { message: 'No observations found for epoch' },
+      ),
 });
 
 makeCommand({
@@ -265,7 +269,11 @@ makeCommand({
   description: 'Get distributions for an epoch',
   options: epochOptions,
   action: (o) =>
-    readARIOFromOptions(o).getDistributions(epochInputFromOptions(o)),
+    readARIOFromOptions(o)
+      .getDistributions(epochInputFromOptions(o))
+      .then(
+        (result) => result ?? { message: 'No distributions found for epoch' },
+      ),
 });
 
 makeCommand({

--- a/src/common/contracts/ao-process.ts
+++ b/src/common/contracts/ao-process.ts
@@ -24,8 +24,8 @@ import { ILogger, Logger } from '../logger.js';
 
 export class AOProcess implements AOContract {
   private logger: ILogger;
-  private processId: string;
   private ao: AoClient;
+  public readonly processId: string;
 
   constructor({
     processId,

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import Arweave from 'arweave';
+
 import { ARIO_TESTNET_PROCESS_ID } from '../constants.js';
 import {
   AoArNSNameDataWithName,
@@ -70,7 +72,11 @@ import {
 } from '../types/io.js';
 import { AoSigner, mARIOToken } from '../types/token.js';
 import { createAoSigner } from '../utils/ao.js';
-import { paginationParamsToTags, pruneTags } from '../utils/arweave.js';
+import {
+  getEpochDataFromGql,
+  paginationParamsToTags,
+  pruneTags,
+} from '../utils/arweave.js';
 import { AOProcess } from './contracts/ao-process.js';
 import { InvalidContractConfigurationError } from './error.js';
 
@@ -95,26 +101,40 @@ export class ARIO {
     processId: string;
   });
   static init({ processId }: { processId: string }): AoARIORead;
-  static init(
-    config?: OptionalSigner<ProcessConfiguration>,
-  ): AoARIORead | AoARIOWrite {
-    if (config && config.signer) {
+  static init({
+    arweave,
+    ...config
+  }: OptionalSigner<ProcessConfiguration> & { arweave?: Arweave } = {}):
+    | AoARIORead
+    | AoARIOWrite {
+    if (config !== undefined && config.signer) {
       const { signer, ...rest } = config;
       return new ARIOWriteable({
         ...rest,
         signer,
+        arweave,
       });
     }
-    return new ARIOReadable(config);
+    return new ARIOReadable({
+      arweave,
+      ...config,
+    });
   }
 }
 
 export class ARIOReadable implements AoARIORead {
   protected process: AOProcess;
   protected epochSettings: AoEpochSettings | undefined;
-
-  constructor(config?: ProcessConfiguration) {
-    if (!config) {
+  protected arweave: Arweave;
+  constructor({
+    arweave = Arweave.init({
+      host: 'arweave.net',
+      port: 443,
+      protocol: 'https',
+    }),
+    ...config
+  }: ProcessConfiguration & { arweave?: Arweave }) {
+    if (config === undefined) {
       this.process = new AOProcess({
         processId: ARIO_TESTNET_PROCESS_ID,
       });
@@ -127,6 +147,7 @@ export class ARIOReadable implements AoARIORead {
     } else {
       throw new InvalidContractConfigurationError();
     }
+    this.arweave = arweave;
   }
 
   async getInfo(): Promise<{
@@ -166,6 +187,16 @@ export class ARIOReadable implements AoARIORead {
     return Math.floor((timestamp - epochZeroStartTimestamp) / epochLengthMs);
   }
 
+  private async computeCurrentEpochIndex(): Promise<number> {
+    const epochSettings = await this.getEpochSettings();
+    const epochZeroStartTimestamp = epochSettings.epochZeroStartTimestamp;
+    const epochLengthMs = epochSettings.durationMs;
+    const currentTimestamp = Date.now();
+    return Math.floor(
+      (currentTimestamp - epochZeroStartTimestamp) / epochLengthMs,
+    );
+  }
+
   private async computeEpochIndex(
     params?: EpochInput,
   ): Promise<string | undefined> {
@@ -188,13 +219,24 @@ export class ARIOReadable implements AoARIORead {
     }));
   }
 
-  async getEpoch(epoch?: EpochInput): Promise<AoEpochData> {
+  async getEpoch(epoch?: EpochInput): Promise<AoEpochData | undefined> {
+    const epochIndex = await this.computeEpochIndex(epoch);
+    const currentIndex = await this.computeCurrentEpochIndex();
+    if (epochIndex !== undefined && +epochIndex < currentIndex) {
+      const epochData = await getEpochDataFromGql({
+        arweave: this.arweave,
+        epochIndex: +epochIndex,
+        processId: this.process.processId,
+      });
+      return epochData;
+    }
+    // go to the process epoch and fetch the epoch data
     const allTags = [
       { name: 'Action', value: 'Epoch' },
       { name: 'Epoch-Index', value: await this.computeEpochIndex(epoch) },
     ];
 
-    return this.process.read<AoEpochData>({
+    return this.process.read<AoEpochData | undefined>({
       tags: pruneTags(allTags),
     });
   }
@@ -374,7 +416,22 @@ export class ARIOReadable implements AoARIORead {
     });
   }
 
-  async getObservations(epoch?: EpochInput): Promise<AoEpochObservationData> {
+  // we need to find the epoch index for the epoch that is currently being distributed and fetch it from gql
+
+  async getObservations(
+    epoch?: EpochInput,
+  ): Promise<AoEpochObservationData | undefined> {
+    const epochIndex = await this.computeEpochIndex(epoch);
+    const currentIndex = await this.computeCurrentEpochIndex();
+    if (epochIndex !== undefined && +epochIndex < currentIndex) {
+      const epochData = await getEpochDataFromGql({
+        arweave: this.arweave,
+        epochIndex: +epochIndex,
+        processId: this.process.processId,
+      });
+      return epochData?.observations;
+    }
+    // go to the process epoch and fetch the observations
     const allTags = [
       { name: 'Action', value: 'Epoch-Observations' },
       { name: 'Epoch-Index', value: await this.computeEpochIndex(epoch) },
@@ -385,7 +442,20 @@ export class ARIOReadable implements AoARIORead {
     });
   }
 
-  async getDistributions(epoch?: EpochInput): Promise<AoEpochDistributionData> {
+  async getDistributions(
+    epoch?: EpochInput,
+  ): Promise<AoEpochDistributionData | undefined> {
+    const epochIndex = await this.computeEpochIndex(epoch);
+    const currentIndex = await this.computeCurrentEpochIndex();
+    if (epochIndex !== undefined && +epochIndex < currentIndex) {
+      const epochData = await getEpochDataFromGql({
+        arweave: this.arweave,
+        epochIndex: +epochIndex,
+        processId: this.process.processId,
+      });
+      return epochData?.distributions;
+    }
+    // go to the process epoch and fetch the distributions
     const allTags = [
       { name: 'Action', value: 'Epoch-Distributions' },
       { name: 'Epoch-Index', value: await this.computeEpochIndex(epoch) },
@@ -663,18 +733,20 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
   private signer: AoSigner;
   constructor({
     signer,
+    arweave,
     ...config
   }: WithSigner<
     | {
         process?: AOProcess;
       }
     | { processId?: string }
-  >) {
+  > & { arweave?: Arweave }) {
     if (Object.keys(config).length === 0) {
       super({
         process: new AOProcess({
           processId: ARIO_TESTNET_PROCESS_ID,
         }),
+        arweave: arweave,
       });
       this.signer = createAoSigner(signer);
     } else if (isProcessConfiguration(config)) {
@@ -685,6 +757,7 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
         process: new AOProcess({
           processId: config.processId,
         }),
+        arweave: arweave,
       });
       this.signer = createAoSigner(signer);
     } else {

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -527,8 +527,12 @@ export interface AoARIORead {
   getCurrentEpoch(): Promise<AoEpochData>;
   getPrescribedObservers(epoch?: EpochInput): Promise<AoWeightedObserver[]>;
   getPrescribedNames(epoch?: EpochInput): Promise<string[]>;
-  getObservations(epoch?: EpochInput): Promise<AoEpochObservationData>;
-  getDistributions(epoch?: EpochInput): Promise<AoEpochDistributionData>;
+  getObservations(
+    epoch?: EpochInput,
+  ): Promise<AoEpochObservationData | undefined>;
+  getDistributions(
+    epoch?: EpochInput,
+  ): Promise<AoEpochDistributionData | undefined>;
   getTokenCost({
     intent,
     type,

--- a/src/utils/ao.ts
+++ b/src/utils/ao.ts
@@ -29,6 +29,7 @@ import {
 import { AoANTRecord } from '../types/ant.js';
 import {
   AoClient,
+  AoEpochData,
   AoSigner,
   ContractSigner,
   WalletAddress,
@@ -296,4 +297,22 @@ export function initANTStateForAddress({
       },
     },
   };
+}
+
+/**
+ * Uses zod schema to parse the epoch data
+ */
+export function parseAoEpochData(value: unknown): AoEpochData {
+  const epochDataSchema = z.object({
+    startTimestamp: z.number(),
+    startHeight: z.number(),
+    distributions: z.any(),
+    endTimestamp: z.number(),
+    prescribedObservers: z.any(),
+    prescribedNames: z.array(z.string()),
+    observations: z.any(),
+    distributionTimestamp: z.number(),
+    epochIndex: z.number(),
+  });
+  return epochDataSchema.parse(value) as AoEpochData;
 }


### PR DESCRIPTION
The process now posts `Epoch-Distribution-Notice` messages with full distributed epoch data. We can fetch these via gql/gateway instead of persisting them in process state.

Related - https://github.com/ar-io/ar-io-network-process/pull/322