### PR TITLE
fix(epochs): getPrescribedObservers and getPrescribedNames should get…

### DIFF
--- a/src/cli/commands/readCommands.ts
+++ b/src/cli/commands/readCommands.ts
@@ -171,9 +171,9 @@ export async function getEpoch(o: EpochCLIOptions) {
 export async function getPrescribedObservers(o: EpochCLIOptions) {
   const epoch = epochInputFromOptions(o);
   const result = await readARIOFromOptions(o).getPrescribedObservers(epoch);
-  return result?.length
-    ? result
-    : { message: `No prescribed observers found for epoch ${epoch}` };
+  return (
+    result ?? { message: `No prescribed observers found for epoch ${epoch}` }
+  );
 }
 
 export async function getPrescribedNames(o: EpochCLIOptions) {
@@ -181,9 +181,7 @@ export async function getPrescribedNames(o: EpochCLIOptions) {
   const result = await readARIOFromOptions(o).getPrescribedNames(
     epochInputFromOptions(o),
   );
-  return result?.length
-    ? result
-    : { message: `No prescribed names found for epoch ${epoch}` };
+  return result ?? { message: `No prescribed names found for epoch ${epoch}` };
 }
 
 export async function getTokenCost(o: GetTokenCostCLIOptions) {

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -375,7 +375,18 @@ export class ARIOReadable implements AoARIORead {
 
   async getPrescribedObservers(
     epoch?: EpochInput,
-  ): Promise<AoWeightedObserver[]> {
+  ): Promise<AoWeightedObserver[] | undefined> {
+    const epochIndex = await this.computeEpochIndex(epoch);
+    const currentIndex = await this.computeCurrentEpochIndex();
+    if (epochIndex !== undefined && +epochIndex < currentIndex) {
+      const epochData = await getEpochDataFromGql({
+        arweave: this.arweave,
+        epochIndex: +epochIndex,
+        processId: this.process.processId,
+      });
+      return epochData?.prescribedObservers;
+    }
+
     const allTags = [
       { name: 'Action', value: 'Epoch-Prescribed-Observers' },
       { name: 'Epoch-Index', value: await this.computeEpochIndex(epoch) },
@@ -386,7 +397,17 @@ export class ARIOReadable implements AoARIORead {
     });
   }
 
-  async getPrescribedNames(epoch?: EpochInput): Promise<string[]> {
+  async getPrescribedNames(epoch?: EpochInput): Promise<string[] | undefined> {
+    const epochIndex = await this.computeEpochIndex(epoch);
+    const currentIndex = await this.computeCurrentEpochIndex();
+    if (epochIndex !== undefined && +epochIndex < currentIndex) {
+      const epochData = await getEpochDataFromGql({
+        arweave: this.arweave,
+        epochIndex: +epochIndex,
+        processId: this.process.processId,
+      });
+      return epochData?.prescribedNames;
+    }
     const allTags = [
       { name: 'Action', value: 'Epoch-Prescribed-Names' },
       { name: 'Epoch-Index', value: await this.computeEpochIndex(epoch) },

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -588,8 +588,10 @@ export interface AoARIORead {
   }): Promise<AoReturnedName | undefined>;
   getEpoch(epoch?: EpochInput): Promise<AoEpochData | undefined>;
   getCurrentEpoch(): Promise<AoEpochData>;
-  getPrescribedObservers(epoch?: EpochInput): Promise<AoWeightedObserver[]>;
-  getPrescribedNames(epoch?: EpochInput): Promise<string[]>;
+  getPrescribedObservers(
+    epoch?: EpochInput,
+  ): Promise<AoWeightedObserver[] | undefined>;
+  getPrescribedNames(epoch?: EpochInput): Promise<string[] | undefined>;
   getObservations(
     epoch?: EpochInput,
   ): Promise<AoEpochObservationData | undefined>;


### PR DESCRIPTION
… data from GQL/arweave vs. the contract