### PR TITLE
feat(ant): add sorting to ANT records responses by default

### DIFF
--- a/src/types/ant.ts
+++ b/src/types/ant.ts
@@ -193,7 +193,7 @@ export interface AoANTRead {
     { undername }: { undername: string },
     opts?: AntReadOptions,
   ): Promise<AoANTRecord | undefined>;
-  getRecords(opts?: AntReadOptions): Promise<ANTRecords>;
+  getRecords(opts?: AntReadOptions): Promise<SortedANTRecords>;
   getOwner(opts?: AntReadOptions): Promise<WalletAddress>;
   getControllers(): Promise<WalletAddress[]>;
   getTicker(opts?: AntReadOptions): Promise<string>;

--- a/tests/e2e/esm/index.test.ts
+++ b/tests/e2e/esm/index.test.ts
@@ -1105,6 +1105,7 @@ describe('e2e esm tests', async () => {
         for (const record of Object.values(records)) {
           assert(typeof record.transactionId === 'string');
           assert(typeof record.ttlSeconds === 'number');
+          assert(typeof record.index === 'number');
           if (record.priority) {
             assert(typeof record.priority === 'number');
           }


### PR DESCRIPTION
This returns the additional index flag, indicating the position for each undername of an ANT.