### PR TITLE
fix(PE-7718): improved retry logic

### DIFF
--- a/src/common/contracts/ao-process.ts
+++ b/src/common/contracts/ao-process.ts
@@ -199,6 +199,7 @@ export class AOProcess implements AOContract {
           messageId,
           processId: this.processId,
         });
+        break;
       } catch (error: any) {
         this.logger.error('Error sending message to process', {
           error: error?.message,

--- a/src/common/contracts/ao-process.ts
+++ b/src/common/contracts/ao-process.ts
@@ -96,7 +96,7 @@ export class AOProcess implements AOContract {
           processId: this.processId,
         });
 
-        if (attempts === retries) {
+        if (attempts >= retries) {
           throw error;
         }
 
@@ -216,7 +216,7 @@ export class AOProcess implements AOContract {
           processId: this.processId,
         });
 
-        if (attempts === retries) {
+        if (attempts >= retries) {
           throw error;
         }
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -141,3 +141,17 @@ export type AoWriteAction<P, R = AoMessageResult> = (
   params: P,
   options?: WriteOptions,
 ) => Promise<R>;
+
+// the following are from @permaweb/aoconnect which does not export these types directly
+export type DryRunResult = {
+  Output: any;
+  Messages: any[];
+  Spawns: any[];
+  Error?: any;
+};
+export type MessageResult = {
+  Output: any;
+  Messages: any[];
+  Spawns: any[];
+  Error?: any;
+};


### PR DESCRIPTION
For AoProcess, only treat exceptions from ao.dryrun(), ao.message(), and ao.result() as retry-able errors. All other errors are treated as valid results from the process. 