### PR TITLE
fix(gql): add fallback to go to CU for epoch distribution data

### DIFF
--- a/src/common/contracts/ao-process.ts
+++ b/src/common/contracts/ao-process.ts
@@ -31,7 +31,7 @@ import { ILogger, Logger } from '../logger.js';
 
 export class AOProcess implements AOContract {
   private logger: ILogger;
-  private ao: AoClient;
+  public readonly ao: AoClient;
   public readonly processId: string;
 
   constructor({

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -82,7 +82,7 @@ import {
 import { AoSigner, mARIOToken } from '../types/token.js';
 import { createAoSigner } from '../utils/ao.js';
 import {
-  getEpochDataFromGql,
+  getEpochDataFromGqlWithCUFallback,
   paginationParamsToTags,
   pruneTags,
   removeEligibleRewardsFromEpochData,
@@ -213,10 +213,11 @@ export class ARIOReadable implements AoARIORead {
     const epochIndex = await this.computeEpochIndex(epoch);
     const currentIndex = await this.computeCurrentEpochIndex();
     if (epochIndex !== undefined && epochIndex < currentIndex) {
-      const epochData = await getEpochDataFromGql({
+      const epochData = await getEpochDataFromGqlWithCUFallback({
         arweave: this.arweave,
         epochIndex: epochIndex,
         processId: this.process.processId,
+        ao: this.process.ao,
       });
 
       return removeEligibleRewardsFromEpochData(epochData);
@@ -392,7 +393,8 @@ export class ARIOReadable implements AoARIORead {
     const epochIndex = await this.computeEpochIndex(epoch);
     const currentIndex = await this.computeCurrentEpochIndex();
     if (epochIndex !== undefined && epochIndex < currentIndex) {
-      const epochData = await getEpochDataFromGql({
+      const epochData = await getEpochDataFromGqlWithCUFallback({
+        ao: this.process.ao,
         arweave: this.arweave,
         epochIndex: epochIndex,
         processId: this.process.processId,
@@ -417,10 +419,11 @@ export class ARIOReadable implements AoARIORead {
     const epochIndex = await this.computeEpochIndex(epoch);
     const currentIndex = await this.computeCurrentEpochIndex();
     if (epochIndex !== undefined && epochIndex < currentIndex) {
-      const epochData = await getEpochDataFromGql({
+      const epochData = await getEpochDataFromGqlWithCUFallback({
         arweave: this.arweave,
         epochIndex: epochIndex,
         processId: this.process.processId,
+        ao: this.process.ao,
       });
       return epochData?.prescribedNames;
     }
@@ -444,10 +447,11 @@ export class ARIOReadable implements AoARIORead {
     const epochIndex = await this.computeEpochIndex(epoch);
     const currentIndex = await this.computeCurrentEpochIndex();
     if (epochIndex !== undefined && epochIndex < currentIndex) {
-      const epochData = await getEpochDataFromGql({
+      const epochData = await getEpochDataFromGqlWithCUFallback({
         arweave: this.arweave,
         epochIndex: epochIndex,
         processId: this.process.processId,
+        ao: this.process.ao,
       });
       return epochData?.observations;
     }
@@ -471,10 +475,11 @@ export class ARIOReadable implements AoARIORead {
     const epochIndex = await this.computeEpochIndex(epoch);
     const currentIndex = await this.computeCurrentEpochIndex();
     if (epochIndex !== undefined && epochIndex < currentIndex) {
-      const epochData = await getEpochDataFromGql({
+      const epochData = await getEpochDataFromGqlWithCUFallback({
         arweave: this.arweave,
         epochIndex: epochIndex,
         processId: this.process.processId,
+        ao: this.process.ao,
       });
       return epochData?.distributions;
     }
@@ -499,10 +504,11 @@ export class ARIOReadable implements AoARIORead {
     const epochIndex = await this.computeEpochIndex(epoch);
     const currentIndex = await this.computeCurrentEpochIndex();
     if (epochIndex !== undefined && epochIndex < currentIndex) {
-      const epochData = await getEpochDataFromGql({
+      const epochData = await getEpochDataFromGqlWithCUFallback({
         arweave: this.arweave,
         epochIndex: epochIndex,
         processId: this.process.processId,
+        ao: this.process.ao,
       });
       return sortAndPaginateEpochDataIntoEligibleDistributions(
         epochData,


### PR DESCRIPTION
If the epoch distribution message does not get cranked, we need to fallback to to the CU to with any tick messages that couldve created it and parse the results of those messages. This is a temporary patch, while we work with FWD to resolve