### PR TITLE
PE-7751 config changes

### DIFF
--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -99,6 +99,7 @@ import { AOProcess } from './contracts/ao-process.js';
 import { InvalidContractConfigurationError } from './error.js';
 import { createFaucet } from './faucet.js';
 import {
+  TurboArNSPaymentFactory,
   TurboArNSPaymentProviderAuthenticated,
   TurboArNSPaymentProviderUnauthenticated,
   isTurboArNSSigner,
@@ -224,7 +225,7 @@ export class ARIOReadable implements AoARIORead {
     } else {
       throw new InvalidContractConfigurationError();
     }
-    this.paymentProvider = new TurboArNSPaymentProviderUnauthenticated({
+    this.paymentProvider = TurboArNSPaymentFactory.init({
       paymentUrl: config?.paymentUrl,
     });
   }
@@ -956,14 +957,10 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
       super(config);
     }
     this.signer = createAoSigner(signer);
-    this.paymentProvider = isTurboArNSSigner(signer)
-      ? new TurboArNSPaymentProviderAuthenticated({
-          signer,
-          paymentUrl,
-        })
-      : new TurboArNSPaymentProviderUnauthenticated({
-          paymentUrl,
-        });
+    this.paymentProvider = TurboArNSPaymentFactory.init({
+      signer: isTurboArNSSigner(signer) ? signer : undefined,
+      paymentUrl,
+    });
   }
 
   async transfer(

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -111,23 +111,7 @@ type ARIOConfigWithSigner = WithSigner<
   OptionalPaymentUrl<OptionalArweave<ProcessConfiguration>>
 >;
 
-type WithAuthenticatedPaymentProvider<T> = T & {
-  paymentProvider: TurboArNSPaymentProviderAuthenticated;
-};
-
-type WithUnauthenticatedPaymentProvider<T> = T & {
-  paymentProvider: TurboArNSPaymentProviderUnauthenticated;
-};
-
-type ARIOConfigWithSignerAndAuthenticatedPaymentProvider =
-  WithAuthenticatedPaymentProvider<ARIOConfigWithSigner>;
-type ARIOConfigWithSignerAndUnauthenticatedPaymentProvider =
-  WithUnauthenticatedPaymentProvider<ARIOConfigWithSigner>;
-type ARIOConfig =
-  | ARIOConfigNoSigner
-  | ARIOConfigWithSigner
-  | ARIOConfigWithSignerAndAuthenticatedPaymentProvider
-  | ARIOConfigWithSignerAndUnauthenticatedPaymentProvider;
+type ARIOConfig = ARIOConfigNoSigner | ARIOConfigWithSigner;
 
 export class ARIO {
   // Overload: No arguments -> returns AoARIORead

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -1358,10 +1358,14 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
     params: AoBuyRecordParams,
     options?: WriteOptions,
   ): Promise<AoMessageResult> {
-    if (
-      this.paymentProvider instanceof TurboArNSPaymentProviderAuthenticated &&
-      params.fundFrom === 'turbo'
-    ) {
+    if (params.fundFrom === 'turbo') {
+      if (
+        !(this.paymentProvider instanceof TurboArNSPaymentProviderAuthenticated)
+      ) {
+        throw new Error(
+          'Turbo funding is not supported for this payment provider',
+        );
+      }
       return this.paymentProvider.initiateArNSPurchase({
         intent: 'Buy-Name',
         ...params,
@@ -1397,10 +1401,14 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
     params: AoArNSPurchaseParams,
     options?: WriteOptions,
   ): Promise<AoMessageResult> {
-    if (
-      this.paymentProvider instanceof TurboArNSPaymentProviderAuthenticated &&
-      params.fundFrom === 'turbo'
-    ) {
+    if (params.fundFrom === 'turbo') {
+      if (
+        !(this.paymentProvider instanceof TurboArNSPaymentProviderAuthenticated)
+      ) {
+        throw new Error(
+          'Turbo funding is not supported for this payment provider',
+        );
+      }
       return this.paymentProvider.initiateArNSPurchase({
         intent: 'Upgrade-Name',
         name: params.name,
@@ -1433,10 +1441,14 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
     params: AoExtendLeaseParams,
     options?: WriteOptions,
   ): Promise<AoMessageResult> {
-    if (
-      this.paymentProvider instanceof TurboArNSPaymentProviderAuthenticated &&
-      params.fundFrom === 'turbo'
-    ) {
+    if (params.fundFrom === 'turbo') {
+      if (
+        !(this.paymentProvider instanceof TurboArNSPaymentProviderAuthenticated)
+      ) {
+        throw new Error(
+          'Turbo funding is not supported for this payment provider',
+        );
+      }
       return this.paymentProvider.initiateArNSPurchase({
         intent: 'Extend-Lease',
         ...params,
@@ -1461,10 +1473,14 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
     params: AoIncreaseUndernameLimitParams,
     options?: WriteOptions,
   ): Promise<AoMessageResult> {
-    if (
-      this.paymentProvider instanceof TurboArNSPaymentProviderAuthenticated &&
-      params.fundFrom === 'turbo'
-    ) {
+    if (params.fundFrom === 'turbo') {
+      if (
+        !(this.paymentProvider instanceof TurboArNSPaymentProviderAuthenticated)
+      ) {
+        throw new Error(
+          'Turbo funding is not supported for this payment provider',
+        );
+      }
       return this.paymentProvider.initiateArNSPurchase({
         intent: 'Increase-Undername-Limit',
         ...params,

--- a/src/common/turbo.ts
+++ b/src/common/turbo.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {
+  ArconnectSigner,
   ArweaveSigner,
   EthereumSigner,
   InjectedEthereumSigner,
@@ -65,6 +66,15 @@ export async function signedRequestHeadersFromSigner({
     ? SignatureConfig.ARWEAVE
     : (signer as Signer).signatureType;
 
+  if (signer instanceof ArconnectSigner) {
+    signature = toB64Url(
+      Buffer.from(
+        await signer['signer'].signMessage(Uint8Array.from(Buffer.from(nonce))),
+      ),
+    );
+  }
+
+  // equivalent to window.arweaveWallet
   if (isWanderArweaveBrowserSigner(signer)) {
     signature = toB64Url(
       Buffer.from(

--- a/src/common/turbo.ts
+++ b/src/common/turbo.ts
@@ -148,6 +148,47 @@ export interface ArNSAuthenticatedPaymentProvider
   ): Promise<AoMessageResult<ArNSPurchaseReceipt>>;
 }
 
+export class TurboArNSPaymentFactory {
+  static init(): TurboArNSPaymentProviderUnauthenticated;
+  // Overload: without signer, will return unauthenticated provider
+  static init({
+    paymentUrl,
+    axios,
+    logger,
+  }: TurboUnauthenticatedConfig & {
+    signer?: TurboArNSSigner;
+  }): TurboArNSPaymentProviderUnauthenticated;
+  // Overload: with signer, will return authenticated provider
+  static init({
+    signer,
+    paymentUrl,
+    axios,
+    logger,
+  }: TurboAuthenticatedConfig): TurboArNSPaymentProviderAuthenticated;
+  static init(
+    config?:
+      | TurboAuthenticatedConfig
+      | (TurboUnauthenticatedConfig & { signer?: TurboArNSSigner }),
+  ):
+    | TurboArNSPaymentProviderAuthenticated
+    | TurboArNSPaymentProviderUnauthenticated {
+    const { signer, paymentUrl, axios, logger } = config ?? {};
+    if (signer !== undefined) {
+      return new TurboArNSPaymentProviderAuthenticated({
+        signer,
+        paymentUrl,
+        axios,
+        logger,
+      });
+    }
+    return new TurboArNSPaymentProviderUnauthenticated({
+      paymentUrl,
+      axios,
+      logger,
+    });
+  }
+}
+
 // Base class for unauthenticated operations
 export class TurboArNSPaymentProviderUnauthenticated
   implements ArNSUnauthenticatedPaymentProvider

--- a/src/common/turbo.ts
+++ b/src/common/turbo.ts
@@ -130,7 +130,7 @@ export type ArNSPurchaseReceipt = AoTokenCostParams & {
 };
 
 // Define separate provider interfaces
-export interface ArNSUnauthenticatedPaymentProvider {
+export interface ArNSPaymentProvider {
   // TODO: have this return just the number, for generic payment providers
   /** Returns the cost of the action in the Payment Provider's native currency (winc for Turbo) */
   getPrice(params: AoTokenCostParams): Promise<number>;
@@ -140,8 +140,7 @@ export interface ArNSUnauthenticatedPaymentProvider {
   }>;
 }
 
-export interface ArNSAuthenticatedPaymentProvider
-  extends ArNSUnauthenticatedPaymentProvider {
+export interface ArNSAuthenticatedPaymentProvider extends ArNSPaymentProvider {
   initiateArNSPurchase(
     params: AoTokenCostParams & { processId?: TransactionId },
     options: WriteOptions, // Note: WriteOptions might not be necessary here if unused
@@ -191,7 +190,7 @@ export class TurboArNSPaymentFactory {
 
 // Base class for unauthenticated operations
 export class TurboArNSPaymentProviderUnauthenticated
-  implements ArNSUnauthenticatedPaymentProvider
+  implements ArNSPaymentProvider
 {
   protected readonly paymentUrl: string;
   protected readonly axios: AxiosInstance;

--- a/src/common/turbo.ts
+++ b/src/common/turbo.ts
@@ -28,7 +28,6 @@ import {
   AoMessageResult,
   TransactionId,
   TurboArNSSigner,
-  WriteOptions,
 } from '../types/common.js';
 import { AoTokenCostParams } from '../types/io.js';
 import { mARIOToken } from '../types/token.js';
@@ -143,7 +142,6 @@ export interface ArNSPaymentProvider {
 export interface ArNSAuthenticatedPaymentProvider extends ArNSPaymentProvider {
   initiateArNSPurchase(
     params: AoTokenCostParams & { processId?: TransactionId },
-    options: WriteOptions, // Note: WriteOptions might not be necessary here if unused
   ): Promise<AoMessageResult<ArNSPurchaseReceipt>>;
 }
 

--- a/src/common/turbo.ts
+++ b/src/common/turbo.ts
@@ -13,7 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ArconnectSigner, SignatureConfig } from '@dha-team/arbundles';
+import {
+  ArweaveSigner,
+  EthereumSigner,
+  InjectedEthereumSigner,
+  SignatureConfig,
+  Signer,
+} from '@dha-team/arbundles';
 import { AxiosInstance, RawAxiosRequestHeaders } from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -30,14 +36,19 @@ import { createAxiosInstance } from '../utils/http-client.js';
 import { urlWithSearchParams } from '../utils/url.js';
 import { ILogger, Logger } from './logger.js';
 
-export interface TurboConfig {
+// Define separate config interfaces
+export interface TurboUnauthenticatedConfig {
   // The URL of the Turbo payment service
   paymentUrl?: string;
   // The logger to use
   logger?: ILogger;
   // The HTTP client to use
   axios?: AxiosInstance;
-  signer?: TurboArNSSigner;
+}
+
+export interface TurboAuthenticatedConfig extends TurboUnauthenticatedConfig {
+  // The signer required for authenticated operations
+  signer: TurboArNSSigner;
 }
 
 export async function signedRequestHeadersFromSigner({
@@ -47,29 +58,36 @@ export async function signedRequestHeadersFromSigner({
   signer: TurboArNSSigner;
   nonce?: string;
 }): Promise<RawAxiosRequestHeaders> {
-  let signature: string;
-  let publicKey: string;
+  let signature: string | undefined = undefined;
+  let publicKey: string | undefined = undefined;
+
+  const signatureType = isWanderArweaveBrowserSigner(signer)
+    ? SignatureConfig.ARWEAVE
+    : (signer as Signer).signatureType;
 
   if (isWanderArweaveBrowserSigner(signer)) {
-    publicKey = await signer.getActivePublicKey();
-
     signature = toB64Url(
       Buffer.from(
         await signer.signMessage(Uint8Array.from(Buffer.from(nonce))),
       ),
     );
-  } else {
-    if (signer.publicKey === undefined) {
-      await (signer as ArconnectSigner).setPublicKey?.();
-    }
-
+  } else if (
+    signer instanceof ArweaveSigner ||
+    signer instanceof EthereumSigner ||
+    signer instanceof InjectedEthereumSigner
+  ) {
     signature = toB64Url(
       Buffer.from(await signer.sign(Uint8Array.from(Buffer.from(nonce)))),
     );
 
     switch (signer.signatureType) {
       case SignatureConfig.ARWEAVE:
-        publicKey = toB64Url(signer.publicKey);
+        if (isWanderArweaveBrowserSigner(signer)) {
+          publicKey = await signer.getActivePublicKey();
+        } else if ('setPublicKey' in signer) {
+          await signer.setPublicKey();
+          publicKey = toB64Url(signer.publicKey);
+        }
         break;
       case SignatureConfig.ETHEREUM:
         publicKey = '0x' + signer.publicKey.toString('hex');
@@ -79,15 +97,18 @@ export async function signedRequestHeadersFromSigner({
       // case SignatureConfig.ED25519:
       default:
         throw new Error(
-          `Unsupported signer type for signing requests: ${signer.signatureType}`,
+          `Unsupported signer type for signing requests: ${signatureType}`,
         );
     }
+  }
+  if (publicKey === undefined || signature === undefined) {
+    throw new Error('Public key or signature not found');
   }
   return {
     'x-public-key': publicKey,
     'x-nonce': nonce,
     'x-signature': signature,
-    'x-signature-type': signer.signatureType ?? 'arweave',
+    'x-signature-type': signatureType,
   };
 }
 
@@ -98,7 +119,8 @@ export type ArNSPurchaseReceipt = AoTokenCostParams & {
   createdDate: string;
 };
 
-export interface ArNSPaymentProvider {
+// Define separate provider interfaces
+export interface ArNSUnauthenticatedPaymentProvider {
   // TODO: have this return just the number, for generic payment providers
   /** Returns the cost of the action in the Payment Provider's native currency (winc for Turbo) */
   getPrice(params: AoTokenCostParams): Promise<number>;
@@ -106,28 +128,32 @@ export interface ArNSPaymentProvider {
     winc: string;
     mARIO: mARIOToken;
   }>;
+}
+
+export interface ArNSAuthenticatedPaymentProvider
+  extends ArNSUnauthenticatedPaymentProvider {
   initiateArNSPurchase(
     params: AoTokenCostParams & { processId?: TransactionId },
-    options: WriteOptions,
+    options: WriteOptions, // Note: WriteOptions might not be necessary here if unused
   ): Promise<AoMessageResult<ArNSPurchaseReceipt>>;
 }
 
-export class TurboArNSPaymentProvider implements ArNSPaymentProvider {
-  private readonly paymentUrl: string;
-  private readonly axios: AxiosInstance;
-  private readonly logger: ILogger;
-  private readonly signer?: TurboArNSSigner;
+// Base class for unauthenticated operations
+export class TurboArNSPaymentProviderUnauthenticated
+  implements ArNSUnauthenticatedPaymentProvider
+{
+  protected readonly paymentUrl: string;
+  protected readonly axios: AxiosInstance;
+  protected readonly logger: ILogger;
 
   constructor({
     paymentUrl = 'https://payment.ardrive.io',
     axios = createAxiosInstance(),
     logger = Logger.default,
-    signer,
-  }: TurboConfig) {
+  }: TurboUnauthenticatedConfig) {
     this.paymentUrl = paymentUrl;
     this.axios = axios;
     this.logger = logger;
-    this.signer = signer;
   }
 
   public async getArNSPriceDetails({
@@ -180,6 +206,22 @@ export class TurboArNSPaymentProvider implements ArNSPaymentProvider {
     const { winc } = await this.getArNSPriceDetails(params);
     return +winc;
   }
+}
+
+// Class for authenticated operations, extending the base class
+export class TurboArNSPaymentProviderAuthenticated
+  extends TurboArNSPaymentProviderUnauthenticated
+  implements ArNSAuthenticatedPaymentProvider
+{
+  private readonly signer: TurboArNSSigner;
+
+  constructor({ signer, ...restConfig }: TurboAuthenticatedConfig) {
+    super(restConfig); // Pass unauthenticated config to base class+
+    if (!isTurboArNSSigner(signer)) {
+      throw new Error('Signer must be a TurboArNSSigner');
+    }
+    this.signer = signer;
+  }
 
   public async initiateArNSPurchase({
     intent,
@@ -190,13 +232,9 @@ export class TurboArNSPaymentProvider implements ArNSPaymentProvider {
     years,
   }: AoTokenCostParams & {
     processId?: TransactionId;
+    // options parameter removed as it wasn't used
   }): Promise<AoMessageResult<ArNSPurchaseReceipt>> {
-    if (!this.signer) {
-      throw new Error(
-        'Signer required for initiating ArNS purchase with Turbo',
-      );
-    }
-
+    // Signer check is implicitly handled by requiring it in the constructor
     const url = urlWithSearchParams({
       baseUrl: `${this.paymentUrl}/v1/arns/purchase/${intent}/${name}`,
       params: {
@@ -254,4 +292,13 @@ function isWanderArweaveBrowserSigner(signer: unknown): signer is WanderWallet {
     'signMessage' in signer &&
     'getActivePublicKey' in signer
   );
+}
+
+export function isTurboArNSSigner(signer: unknown): signer is TurboArNSSigner {
+  const isWanderWallet = isWanderArweaveBrowserSigner(signer);
+  const isSigner =
+    signer instanceof EthereumSigner ||
+    signer instanceof InjectedEthereumSigner ||
+    signer instanceof ArweaveSigner;
+  return isWanderWallet || isSigner;
 }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -13,7 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Signer } from '@dha-team/arbundles';
+import {
+  ArweaveSigner,
+  EthereumSigner,
+  InjectedEthereumSigner,
+  Signer,
+} from '@dha-team/arbundles';
 import {
   dryrun,
   message,
@@ -39,7 +44,12 @@ export type OptionalArweave<T = NonNullable<unknown>> = {
 export type OptionalPaymentUrl<T = NonNullable<unknown>> = {
   paymentUrl?: string;
 } & T;
-export type TurboArNSSigner = Signer;
+// TODO: TurboArNSSigner could be simply `Signer` but we need to implement each message signing method for signing headers.
+export type TurboArNSSigner =
+  | EthereumSigner
+  | InjectedEthereumSigner
+  | ArweaveSigner
+  | Window['arweaveWallet'];
 export type ContractSigner = Signer | Window['arweaveWallet'] | AoSigner;
 export type WithSigner<T = NonNullable<unknown>> = {
   signer: ContractSigner;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {
+  ArconnectSigner,
   ArweaveSigner,
   EthereumSigner,
   InjectedEthereumSigner,
@@ -49,6 +50,7 @@ export type TurboArNSSigner =
   | EthereumSigner
   | InjectedEthereumSigner
   | ArweaveSigner
+  | ArconnectSigner
   | Window['arweaveWallet'];
 export type ContractSigner = Signer | Window['arweaveWallet'] | AoSigner;
 export type WithSigner<T = NonNullable<unknown>> = {

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -13,7 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { ArweaveSigner, ArconnectSigner } from '@dha-team/arbundles';
+export {
+  ArweaveSigner,
+  ArconnectSigner,
+  InjectedEthereumSigner,
+  EthereumSigner,
+} from '@dha-team/arbundles';
 
 export * from '../types/index.js';
 export * from '../common/index.js';


### PR DESCRIPTION
Modifies the turbo arns class to have authenticated and unauthenticated versions, updates signer to be more restricted types based on the message signing we have implmented.

Would like to add some stronger typing on the ARIO writable class to indicate on apis with `fundFrom: "turbo"` whether or not they can be used with turbo base on the class configuration.