### PR TITLE
chore(wayfinder): cleanup gateways provier interfaces

### DIFF
--- a/src/common/wayfinder/index.ts
+++ b/src/common/wayfinder/index.ts
@@ -18,7 +18,7 @@ export * from './wayfinder.js';
 // routers
 export * from './routers/random.js';
 export * from './routers/priority.js';
-export * from './routers/fixed.js';
+export * from './routers/static.js';
 
 // gateways providers
 export * from './gateways.js';

--- a/src/common/wayfinder/routers/priority.test.ts
+++ b/src/common/wayfinder/routers/priority.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { AoGatewayWithAddress } from '../../../types/io.js';
+import { AoARIORead, AoGatewayWithAddress } from '../../../types/io.js';
 import { PriorityGatewayRouter } from './priority.js';
 
 describe('PriorityRouter', () => {
@@ -131,14 +131,14 @@ describe('PriorityRouter', () => {
     },
   ];
 
-  const mockGatewaysProvider = {
-    getGateways: async () => mockGateways,
-  };
+  const mockArIOClient = {
+    getGateways: async () => ({ items: mockGateways }),
+  } as unknown as AoARIORead;
 
   it('should prioritize gateway with highest success rate when using successRate weight', async () => {
     const router = new PriorityGatewayRouter({
-      gatewaysProvider: mockGatewaysProvider,
-      sortBy: 'totalDelegatedStake',
+      ario: mockArIOClient,
+      sortBy: 'operatorStake',
       sortOrder: 'desc',
       limit: 1,
     });
@@ -149,7 +149,7 @@ describe('PriorityRouter', () => {
 
   it('should prioritize gateway with lowest latency when using latency weight', async () => {
     const router = new PriorityGatewayRouter({
-      gatewaysProvider: mockGatewaysProvider,
+      ario: mockArIOClient,
       sortBy: 'operatorStake',
       sortOrder: 'desc',
       limit: 1,

--- a/src/common/wayfinder/routers/random.test.ts
+++ b/src/common/wayfinder/routers/random.test.ts
@@ -1,93 +1,13 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { AoGatewayWithAddress } from '../../../types/io.js';
 import { RandomGatewayRouter } from './random.js';
 
 describe('RandomRouter', () => {
-  const mockGateways: AoGatewayWithAddress[] = [
-    {
-      settings: {
-        fqdn: 'gateway1.net',
-        port: 443,
-        protocol: 'https',
-        allowDelegatedStaking: false,
-        delegateRewardShareRatio: 0.5,
-        allowedDelegates: [],
-        minDelegatedStake: 0,
-        autoStake: false,
-        properties: '',
-        label: '',
-        note: '',
-      },
-      gatewayAddress: 'addr1',
-      observerAddress: 'addr1',
-      totalDelegatedStake: 1000,
-      startTimestamp: 0,
-      endTimestamp: 0,
-      operatorStake: 100,
-      status: 'joined',
-      weights: {
-        normalizedCompositeWeight: 0.5,
-        stakeWeight: 0.5,
-        tenureWeight: 0.5,
-        gatewayPerformanceRatio: 0.5,
-        observerPerformanceRatio: 0.5,
-        compositeWeight: 0.5,
-        gatewayRewardRatioWeight: 0.5,
-        observerRewardRatioWeight: 0.5,
-      },
-      stats: {
-        passedConsecutiveEpochs: 10,
-        failedConsecutiveEpochs: 5,
-        totalEpochCount: 15,
-        passedEpochCount: 10,
-        failedEpochCount: 5,
-        observedEpochCount: 15,
-        prescribedEpochCount: 20,
-      },
-    },
-    {
-      settings: {
-        fqdn: 'gateway2.net',
-        port: 443,
-        protocol: 'https',
-        allowDelegatedStaking: false,
-        delegateRewardShareRatio: 0.5,
-        allowedDelegates: [],
-        minDelegatedStake: 0,
-        autoStake: false,
-        properties: '',
-        label: '',
-        note: '',
-      },
-      gatewayAddress: 'addr2',
-      observerAddress: 'addr2',
-      totalDelegatedStake: 0,
-      startTimestamp: 0,
-      endTimestamp: 0,
-      operatorStake: 0,
-      status: 'leaving',
-      weights: {
-        normalizedCompositeWeight: 0.5,
-        stakeWeight: 0.5,
-        tenureWeight: 0.5,
-        gatewayPerformanceRatio: 0.5,
-        observerPerformanceRatio: 0.5,
-        compositeWeight: 0.5,
-        gatewayRewardRatioWeight: 0.5,
-        observerRewardRatioWeight: 0.5,
-      },
-      stats: {
-        passedConsecutiveEpochs: 10,
-        failedConsecutiveEpochs: 5,
-        totalEpochCount: 15,
-        passedEpochCount: 10,
-        failedEpochCount: 5,
-        observedEpochCount: 15,
-        prescribedEpochCount: 20,
-      },
-    },
+  const mockGateways: URL[] = [
+    new URL('https://gateway1.net'),
+    new URL('https://gateway2.net'),
+    new URL('https://gateway3.net'),
   ];
 
   const mockGatewaysProvider = {
@@ -99,10 +19,10 @@ describe('RandomRouter', () => {
       gatewaysProvider: mockGatewaysProvider,
     });
 
-    // Run multiple times to ensure we only get joined gateways
+    // random gateway should be one of the mock gateways
     for (let i = 0; i < 10; i++) {
       const result = await router.getTargetGateway();
-      assert.deepStrictEqual(result, new URL('https://gateway1.net'));
+      assert.ok(mockGateways.includes(result));
     }
   });
 });

--- a/src/common/wayfinder/routers/random.ts
+++ b/src/common/wayfinder/routers/random.ts
@@ -35,15 +35,13 @@ export class RandomGatewayRouter implements WayfinderRouter {
   async getTargetGateway(): Promise<URL> {
     const allGateways = await this.gatewaysProvider.getGateways();
     const gateways = allGateways.filter(
-      (g) => g.status === 'joined' && !this.blocklist.includes(g.settings.fqdn),
+      (g) => !this.blocklist.includes(g.hostname),
     );
 
     const targetGateway = gateways[randomInt(0, gateways.length)];
     if (targetGateway === undefined) {
       throw new Error('No target gateway found');
     }
-    return new URL(
-      `${targetGateway.settings.protocol}://${targetGateway.settings.fqdn}:${targetGateway.settings.port}`,
-    );
+    return targetGateway;
   }
 }

--- a/src/common/wayfinder/routers/static.test.ts
+++ b/src/common/wayfinder/routers/static.test.ts
@@ -1,12 +1,12 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { FixedGatewayRouter } from './fixed.js';
+import { StaticGatewayRouter } from './static.js';
 
-describe('FixedRouter', () => {
+describe('StaticGatewayRouter', () => {
   it('should return the provided gateway', async () => {
-    const router = new FixedGatewayRouter({
-      gateway: new URL('http://test-gateway.net'),
+    const router = new StaticGatewayRouter({
+      gateway: 'http://test-gateway.net',
     });
     const result = await router.getTargetGateway();
 

--- a/src/common/wayfinder/routers/static.ts
+++ b/src/common/wayfinder/routers/static.ts
@@ -15,12 +15,12 @@
  */
 import { WayfinderRouter } from '../../../types/wayfinder.js';
 
-export class FixedGatewayRouter implements WayfinderRouter {
-  public readonly name = 'fixed';
+export class StaticGatewayRouter implements WayfinderRouter {
+  public readonly name = 'static';
   private gateway: URL;
 
-  constructor({ gateway }: { gateway: URL }) {
-    this.gateway = gateway;
+  constructor({ gateway }: { gateway: string }) {
+    this.gateway = new URL(gateway);
   }
 
   async getTargetGateway(): Promise<URL> {

--- a/src/common/wayfinder/wayfinder.ts
+++ b/src/common/wayfinder/wayfinder.ts
@@ -16,7 +16,7 @@
 import { WayfinderRouter } from '../../types/wayfinder.js';
 import { ARIO } from '../io.js';
 import { Logger } from '../logger.js';
-import { ARIOGatewaysProvider } from './gateways.js';
+import { NetworkGatewaysProvider } from './gateways.js';
 import { RandomGatewayRouter } from './routers/random.js';
 
 // local types for wayfinder
@@ -26,7 +26,7 @@ type WayfinderHttpClient<T extends HttpClientFunction> = T;
 
 // known regexes for wayfinder urls
 export const arnsRegex = /^[a-z0-9_-]{1,51}$/;
-export const txIdRegex = /^[a-z0-9]{43}$/;
+export const txIdRegex = /^[A-Za-z0-9_-]{43}$/;
 
 /**
  * Core function to resolve a wayfinder url against a target gateway
@@ -241,7 +241,7 @@ export class Wayfinder<T extends HttpClientFunction> {
     // TODO: consider changing router to routingStrategy or strategy
     router = new RandomGatewayRouter({
       // optionally use a cache gateways provider to reduce the number of requests to the contract
-      gatewaysProvider: new ARIOGatewaysProvider({ ario: ARIO.mainnet() }),
+      gatewaysProvider: new NetworkGatewaysProvider({ ario: ARIO.mainnet() }),
     }),
     httpClient,
     logger = Logger.default,


### PR DESCRIPTION
We will return just the urls, and separate gateway implementations can be created to get filterted list.