### PR TITLE
feat(arns): add ArNSNameResovler interface and API 

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -91,24 +91,24 @@ Options:
   -h, --help                              display help for command
 
 Commands:
+  # ARIO Network
+
+  # Getters
   info [options]                          Get network info
   token-supply [options]                  Get the total token supply
+  balance [options]                       Get the balance of an address
   get-registration-fees [options]         Get registration fees
   get-demand-factor [options]             Get demand factor
   get-demand-factor-settings [options]    Get current settings for demand factor
   get-epoch-settings [options]            Get current settings for epochs
   get-gateway [options]                   Get the gateway of an address
-  list-gateways [options]                 List the gateways of the network
-  list-all-delegates [options]            List all paginated delegates from all gateways
   get-gateway-delegates [options]         Get the delegates of a gateway
+  get-gateway-vaults [options]            Get the vaults of a gateway
   get-delegations [options]               Get all stake delegated to gateways from this address
   get-allowed-delegates [options]         Get the allow list of a gateway delegate
   get-arns-record [options]               Get an ArNS record by name
-  list-arns-records [options]             List all ArNS records
   get-arns-reserved-name [options]        Get a reserved ArNS name
-  list-arns-reserved-names [options]      Get all reserved ArNS names
   get-arns-returned-name [options]        Get an ArNS returned name by name
-  list-arns-returned-names [options]      Get all ArNS recently returned names
   get-epoch [options]                     Get epoch data
   get-current-epoch [options]             Get current epoch data
   get-prescribed-observers [options]      Get prescribed observers for an epoch
@@ -118,17 +118,28 @@ Commands:
   get-eligible-rewards [options]          Get eligible distributions for an epoch
   get-token-cost [options]                Get token cost for an intended action
   get-cost-details [options]              Get expanded cost details for an intended action
-  list-vaults [options]                   Get all wallet vaults
-  get-primary-name-request [options]      Get primary name request
-  list-primary-name-requests [options]    Get primary name requests
   get-primary-name [options]              Get primary name
-  list-primary-names [options]            Get primary names
-  balance [options]                       Get the balance of an address
-  list-balances [options]                 List all balances
+  get-primary-name-request [options]      Get primary name request
   get-redelegation-fee [options]          Get redelegation fee
   get-vault [options]                     Get the vault of provided address and vault ID
-  get-gateway-vaults [options]            Get the vaults of a gateway
+
+
+  # ArNS Resolution
+  resolve-arns-name [options]             Resolve an ArNS name
+
+  # Paginated handlers
+  list-gateways [options]                 List the gateways of the network
+  list-all-delegates [options]            List all paginated delegates from all gateways
+  list-arns-records [options]             List all ArNS records
+  list-arns-reserved-names [options]      Get all reserved ArNS names
+  list-arns-returned-names [options]      Get all ArNS recently returned names
+  list-vaults [options]                   Get all wallet vaults
+  list-primary-name-requests [options]    Get primary name requests
+  list-primary-names [options]            Get primary names
+  list-balances [options]                 List all balances
   list-all-gateway-vaults [options]       List vaults from all gateways
+
+  # Actions
   transfer [options]                      Transfer ARIO to another address
   vaulted-transfer [options]              Transfer ARIO to another address into a locked vault
   revoke-vault [options]                  Revoke a vaulted transfer as the controller
@@ -151,33 +162,48 @@ Commands:
   extend-lease [options]                  Extend the lease of a record
   increase-undername-limit [options]      Increase the limit of a name
   request-primary-name [options]          Request a primary name
-  spawn-ant [options]                     Spawn an ANT process
+
+  # ANTS
+
+  # Getters
   get-ant-state [options]                 Get the state of an ANT process
   get-ant-info [options]                  Get the info of an ANT process
   get-ant-record [options]                Get a record of an ANT process
-  list-ant-records [options]              Get the records of an ANT process
   get-ant-owner [options]                 Get the owner of an ANT process
-  list-ant-controllers [options]          List the controllers of an ANT process
   get-ant-name [options]                  Get the name of an ANT process
   get-ant-ticker [options]                Get the ticker of an ANT process
   get-ant-balance [options]               Get the balance of an ANT process
+
+  # Spawn
+  spawn-ant [options]                     Spawn an ANT process
+
+  # ANT Paginated Handlers
+
+  list-ant-records [options]              Get the records of an ANT process
+  list-ant-controllers [options]          List the controllers of an ANT process
   list-ant-balances [options]             Get the balances of an ANT process
+
+  # Actions
   transfer-ant-ownership [options]        Transfer ownership of an ANT process
   add-ant-controller [options]            Add a controller to an ANT process
   remove-ant-controller [options]         Remove a controller from an ANT process
+  remove-ant-record [options]             Remove a record from an ANT process
   set-ant-record [options]                Set a record of an ANT process. Deprecated: use set-ant-base-name and set-ant-undername
   set-ant-base-name [options]             Set the base name of an ANT process
   set-ant-undername [options]             Set an undername of an ANT process
-  remove-ant-record [options]             Remove a record from an ANT process
   set-ant-ticker [options]                Set the ticker of an ANT process
   set-ant-name [options]                  Set the name of an ANT process
   set-ant-description [options]           Set the description of an ANT process
   set-ant-keywords [options]              Set the keywords of an ANT process
   set-ant-logo [options]                  Set the logo of an ANT process
+
+  # ARIO Actions (messages are forwarded to the provided ario-process-id)
   release-name [options]                  Release the name of an ANT process
   reassign-name [options]                 Reassign the name of an ANT process to another ANT process
   approve-primary-name-request [options]  Approve a primary name request
   remove-primary-names [options]          Remove primary names
+
+  # Utilities
   write-action [options]                  Send a write action to an AO Process
   read-action [options]                   Send a dry-run read action to an AO Process
   help [command]                          display help for command

--- a/CLI.md
+++ b/CLI.md
@@ -123,7 +123,6 @@ Commands:
   get-redelegation-fee [options]          Get redelegation fee
   get-vault [options]                     Get the vault of provided address and vault ID
 
-
   # ArNS Resolution
   resolve-arns-name [options]             Resolve an ArNS name
 
@@ -178,7 +177,6 @@ Commands:
   spawn-ant [options]                     Spawn an ANT process
 
   # ANT Paginated Handlers
-
   list-ant-records [options]              Get the records of an ANT process
   list-ant-controllers [options]          List the controllers of an ANT process
   list-ant-balances [options]             Get the balances of an ANT process

--- a/README.md
+++ b/README.md
@@ -1179,6 +1179,58 @@ const delegates = await ario.getAllDelegates({
 
 ### Arweave Name System (ArNS)
 
+#### `resolveArNSName({ name })`
+
+Resolves an ArNS name to the underlying data id stored on the names corresponding ANT id.
+
+##### Resolving a base name
+
+```typescript
+const ario = ARIO.mainnet();
+const record = await ario.resolveArNSName({ name: 'ardrive' });
+```
+
+<details>
+  <summary>Output</summary>
+
+```json
+{
+  "processId": "bh9l1cy0aksiL_x9M359faGzM_yjralacHIUo8_nQXM",
+  "txId": "kvhEUsIY5bXe0Wu2-YUFz20O078uYFzmQIO-7brv8qw",
+  "type": "lease",
+  "recordIndex": 0,
+  "undernameLimit": 100,
+  "owner": "t4Xr0_J4Iurt7caNST02cMotaz2FIbWQ4Kbj616RHl3",
+  "name": "ardrive"
+}
+```
+
+</details>
+
+##### Resolving an undername
+
+```typescript
+const ario = ARIO.mainnet();
+const record = await ario.resolveArNSName({ name: 'logo_ardrive' });
+```
+
+<details>
+  <summary>Output</summary>
+
+```json
+{
+  "processId": "bh9l1cy0aksiL_x9M359faGzM_yjralacHIUo8_nQXM",
+  "txId": "kvhEUsIY5bXe0Wu2-YUFz20O078uYFzmQIO-7brv8qw",
+  "type": "lease",
+  "recordIndex": 1,
+  "undernameLimit": 100,
+  "owner": "t4Xr0_J4Iurt7caNST02cMotaz2FIbWQ4Kbj616RHl3",
+  "name": "ardrive"
+}
+```
+
+</details>
+
 #### `buyRecord({ name, type, years, processId })`
 
 Purchases a new ArNS record with the specified name, type, and duration.

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -141,6 +141,7 @@ applyOptions(
   globalOptions,
 );
 
+// # Getters
 makeCommand({
   name: 'info',
   description: 'Get network info',
@@ -151,6 +152,22 @@ makeCommand({
   name: 'token-supply',
   description: 'Get the total token supply',
   action: (options) => readARIOFromOptions(options).getTokenSupply(),
+});
+
+makeCommand<AddressCLIOptions>({
+  name: 'balance',
+  description: 'Get the balance of an address',
+  options: [optionMap.address],
+  action: (options) =>
+    readARIOFromOptions(options)
+      .getBalance({ address: requiredAddressFromOptions(options) })
+      .then((result) => ({
+        address: requiredAddressFromOptions(options),
+        mARIOBalance: result,
+        message: `Provided address current has a balance of ${formatARIOWithCommas(
+          new mARIOToken(result).toARIO(),
+        )} ARIO`,
+      })),
 });
 
 makeCommand({
@@ -185,24 +202,17 @@ makeCommand({
 });
 
 makeCommand({
-  name: 'list-gateways',
-  description: 'List the gateways of the network',
-  options: paginationOptions,
-  action: listGateways,
-});
-
-makeCommand({
-  name: 'list-all-delegates',
-  description: 'List all paginated delegates from all gateways',
-  options: paginationOptions,
-  action: listAllDelegatesCLICommand,
-});
-
-makeCommand({
   name: 'get-gateway-delegates',
   description: 'Get the delegates of a gateway',
   options: paginationAddressOptions,
   action: getGatewayDelegates,
+});
+
+makeCommand({
+  name: 'get-gateway-vaults',
+  description: 'Get the vaults of a gateway',
+  options: paginationAddressOptions,
+  action: getGatewayVaults,
 });
 
 makeCommand({
@@ -227,13 +237,6 @@ makeCommand({
 });
 
 makeCommand({
-  name: 'list-arns-records',
-  description: 'List all ArNS records',
-  options: paginationOptions,
-  action: listArNSRecords,
-});
-
-makeCommand({
   name: 'get-arns-reserved-name',
   description: 'Get a reserved ArNS name',
   options: [optionMap.name],
@@ -241,24 +244,10 @@ makeCommand({
 });
 
 makeCommand({
-  name: 'list-arns-reserved-names',
-  description: 'Get all reserved ArNS names',
-  options: paginationOptions,
-  action: listArNSReservedNames,
-});
-
-makeCommand({
   name: 'get-arns-returned-name',
   description: 'Get an ArNS returned name by name',
   options: [optionMap.name],
   action: getArNSReturnedName,
-});
-
-makeCommand({
-  name: 'list-arns-returned-names',
-  description: 'Get all ArNS recently returned names',
-  options: paginationOptions,
-  action: listArNSReturnedNames,
 });
 
 makeCommand({
@@ -342,19 +331,12 @@ makeCommand({
   action: getCostDetails,
 });
 
-makeCommand<PaginationCLIOptions>({
-  name: 'list-vaults',
-  description: 'Get all wallet vaults',
-  options: paginationOptions,
-  action: (o) =>
-    readARIOFromOptions(o)
-      .getVaults(paginationParamsFromOptions(o))
-      .then((result) =>
-        result.items.length ? result : { message: 'No vaults found' },
-      ),
+makeCommand<AddressAndNameCLIOptions>({
+  name: 'get-primary-name',
+  description: 'Get primary name',
+  options: [optionMap.address, optionMap.name],
+  action: getPrimaryName,
 });
-
-// TODO: Could assert valid arweave (or ETH) addresses at CLI level when coming from options (no need from wallet)
 
 makeCommand<InitiatorCLIOptions>({
   name: 'get-primary-name-request',
@@ -370,65 +352,6 @@ makeCommand<InitiatorCLIOptions>({
           result ?? {
             message: `No primary name request found`,
           },
-      ),
-});
-
-makeCommand<PaginationCLIOptions>({
-  name: 'list-primary-name-requests',
-  description: 'Get primary name requests',
-  options: paginationOptions,
-  action: (o) =>
-    readARIOFromOptions(o)
-      .getPrimaryNameRequests(paginationParamsFromOptions(o))
-      .then((result) =>
-        result.items.length ? result : { message: 'No requests found' },
-      ),
-});
-
-makeCommand<AddressAndNameCLIOptions>({
-  name: 'get-primary-name',
-  description: 'Get primary name',
-  options: [optionMap.address, optionMap.name],
-  action: getPrimaryName,
-});
-
-makeCommand<PaginationCLIOptions>({
-  name: 'list-primary-names',
-  description: 'Get primary names',
-  options: paginationOptions,
-  action: (o) =>
-    readARIOFromOptions(o)
-      .getPrimaryNames(paginationParamsFromOptions(o))
-      .then((result) =>
-        result.items.length ? result : { message: 'No names found' },
-      ),
-});
-
-makeCommand<AddressCLIOptions>({
-  name: 'balance',
-  description: 'Get the balance of an address',
-  options: [optionMap.address],
-  action: (options) =>
-    readARIOFromOptions(options)
-      .getBalance({ address: requiredAddressFromOptions(options) })
-      .then((result) => ({
-        address: requiredAddressFromOptions(options),
-        mARIOBalance: result,
-        message: `Provided address current has a balance of ${formatARIOWithCommas(
-          new mARIOToken(result).toARIO(),
-        )} ARIO`,
-      })),
-});
-
-makeCommand({
-  name: 'list-balances',
-  description: 'List all balances',
-  options: paginationOptions,
-  action: (o) =>
-    readARIOFromOptions(o)
-      .getBalances(paginationParamsFromOptions(o))
-      .then((result) =>
-        result.items.length ? result : { message: 'No balances found' },
       ),
 });
 
@@ -449,11 +372,96 @@ makeCommand({
   action: getVault,
 });
 
+// # ArNS Resolution
 makeCommand({
-  name: 'get-gateway-vaults',
-  description: 'Get the vaults of a gateway',
-  options: paginationAddressOptions,
-  action: getGatewayVaults,
+  name: 'resolve-arns-name',
+  description: 'Resolve an ArNS name',
+  options: [optionMap.name],
+  action: resolveArNSName,
+});
+
+// # Paginated handlers
+makeCommand({
+  name: 'list-gateways',
+  description: 'List the gateways of the network',
+  options: paginationOptions,
+  action: listGateways,
+});
+
+makeCommand({
+  name: 'list-all-delegates',
+  description: 'List all paginated delegates from all gateways',
+  options: paginationOptions,
+  action: listAllDelegatesCLICommand,
+});
+
+makeCommand({
+  name: 'list-arns-records',
+  description: 'List all ArNS records',
+  options: paginationOptions,
+  action: listArNSRecords,
+});
+
+makeCommand({
+  name: 'list-arns-reserved-names',
+  description: 'Get all reserved ArNS names',
+  options: paginationOptions,
+  action: listArNSReservedNames,
+});
+
+makeCommand({
+  name: 'list-arns-returned-names',
+  description: 'Get all ArNS recently returned names',
+  options: paginationOptions,
+  action: listArNSReturnedNames,
+});
+
+makeCommand<PaginationCLIOptions>({
+  name: 'list-vaults',
+  description: 'Get all wallet vaults',
+  options: paginationOptions,
+  action: (o) =>
+    readARIOFromOptions(o)
+      .getVaults(paginationParamsFromOptions(o))
+      .then((result) =>
+        result.items.length ? result : { message: 'No vaults found' },
+      ),
+});
+
+makeCommand<PaginationCLIOptions>({
+  name: 'list-primary-name-requests',
+  description: 'Get primary name requests',
+  options: paginationOptions,
+  action: (o) =>
+    readARIOFromOptions(o)
+      .getPrimaryNameRequests(paginationParamsFromOptions(o))
+      .then((result) =>
+        result.items.length ? result : { message: 'No requests found' },
+      ),
+});
+
+makeCommand<PaginationCLIOptions>({
+  name: 'list-primary-names',
+  description: 'Get primary names',
+  options: paginationOptions,
+  action: (o) =>
+    readARIOFromOptions(o)
+      .getPrimaryNames(paginationParamsFromOptions(o))
+      .then((result) =>
+        result.items.length ? result : { message: 'No names found' },
+      ),
+});
+
+makeCommand({
+  name: 'list-balances',
+  description: 'List all balances',
+  options: paginationOptions,
+  action: (o) =>
+    readARIOFromOptions(o)
+      .getBalances(paginationParamsFromOptions(o))
+      .then((result) =>
+        result.items.length ? result : { message: 'No balances found' },
+      ),
 });
 
 makeCommand({
@@ -463,13 +471,7 @@ makeCommand({
   action: getAllGatewayVaults,
 });
 
-makeCommand({
-  name: 'resolve-arns-name',
-  description: 'Resolve an ArNS name',
-  options: [optionMap.name],
-  action: resolveArNSName,
-});
-
+// # Actions
 makeCommand({
   name: 'transfer',
   description: 'Transfer ARIO to another address',
@@ -628,28 +630,9 @@ makeCommand({
   action: requestPrimaryNameCLICommand,
 });
 
-// ANTS
+// # ANTS
 
-makeCommand<ANTStateCLIOptions>({
-  name: 'spawn-ant',
-  description: 'Spawn an ANT process',
-  options: antStateOptions,
-  action: async (options) => {
-    const state = getANTStateFromOptions(options);
-    const antProcessId = await spawnANT({
-      state,
-      signer: requiredAoSignerFromOptions(options),
-      logger: getLoggerFromOptions(options),
-    });
-
-    return {
-      processId: antProcessId,
-      state,
-      message: `Spawned ANT process with process ID ${antProcessId}`,
-    };
-  },
-});
-
+// # Getters
 makeCommand<ProcessIdCLIOptions>({
   name: 'get-ant-state',
   description: 'Get the state of an ANT process',
@@ -686,29 +669,11 @@ makeCommand<
 });
 
 makeCommand<ProcessIdCLIOptions>({
-  name: 'list-ant-records',
-  description: 'Get the records of an ANT process',
-  options: [optionMap.processId],
-  action: async (options) => {
-    return readANTFromOptions(options).getRecords();
-  },
-});
-
-makeCommand<ProcessIdCLIOptions>({
   name: 'get-ant-owner',
   description: 'Get the owner of an ANT process',
   options: [optionMap.processId],
   action: async (options) => {
     return readANTFromOptions(options).getOwner();
-  },
-});
-
-makeCommand<ProcessIdCLIOptions>({
-  name: 'list-ant-controllers',
-  description: 'List the controllers of an ANT process',
-  options: [optionMap.processId],
-  action: async (options) => {
-    return readANTFromOptions(options).getControllers();
   },
 });
 
@@ -741,6 +706,46 @@ makeCommand<ProcessIdCLIOptions & { address?: string }>({
   },
 });
 
+// # Spawn
+makeCommand<ANTStateCLIOptions>({
+  name: 'spawn-ant',
+  description: 'Spawn an ANT process',
+  options: antStateOptions,
+  action: async (options) => {
+    const state = getANTStateFromOptions(options);
+    const antProcessId = await spawnANT({
+      state,
+      signer: requiredAoSignerFromOptions(options),
+      logger: getLoggerFromOptions(options),
+    });
+
+    return {
+      processId: antProcessId,
+      state,
+      message: `Spawned ANT process with process ID ${antProcessId}`,
+    };
+  },
+});
+
+// # ANT Paginated Handlers
+makeCommand<ProcessIdCLIOptions>({
+  name: 'list-ant-records',
+  description: 'Get the records of an ANT process',
+  options: [optionMap.processId],
+  action: async (options) => {
+    return readANTFromOptions(options).getRecords();
+  },
+});
+
+makeCommand<ProcessIdCLIOptions>({
+  name: 'list-ant-controllers',
+  description: 'List the controllers of an ANT process',
+  options: [optionMap.processId],
+  action: async (options) => {
+    return readANTFromOptions(options).getControllers();
+  },
+});
+
 makeCommand<ProcessIdCLIOptions>({
   name: 'list-ant-balances',
   description: 'Get the balances of an ANT process',
@@ -750,11 +755,8 @@ makeCommand<ProcessIdCLIOptions>({
   },
 });
 
-makeCommand<
-  ProcessIdWriteActionCLIOptions & {
-    target?: string;
-  }
->({
+// # Actions
+makeCommand<ProcessIdWriteActionCLIOptions & { target?: string }>({
   name: 'transfer-ant-ownership',
   description: 'Transfer ownership of an ANT process',
   options: [optionMap.processId, optionMap.target, ...writeActionOptions],
@@ -806,6 +808,27 @@ makeCommand<ProcessIdCLIOptions & { controller?: string }>({
   },
 });
 
+makeCommand<ProcessIdWriteActionCLIOptions & { undername?: string }>({
+  name: 'remove-ant-record',
+  description: 'Remove a record from an ANT process',
+  options: [optionMap.processId, optionMap.undername, ...writeActionOptions],
+  action: async (options) => {
+    const undername = requiredStringFromOptions(options, 'undername');
+
+    await assertConfirmationPrompt(
+      `Are you sure you want to remove the record with undername ${undername}?`,
+      options,
+    );
+
+    return writeANTFromOptions(options).removeRecord(
+      {
+        undername,
+      },
+      customTagsFromOptions(options),
+    );
+  },
+});
+
 makeCommand({
   name: 'set-ant-record',
   description:
@@ -826,27 +849,6 @@ makeCommand({
   description: 'Set an undername of an ANT process',
   options: setAntUndernameOptions,
   action: setAntRecordCLICommand,
-});
-
-makeCommand<ProcessIdWriteActionCLIOptions & { undername?: string }>({
-  name: 'remove-ant-record',
-  description: 'Remove a record from an ANT process',
-  options: [optionMap.processId, optionMap.undername, ...writeActionOptions],
-  action: async (options) => {
-    const undername = requiredStringFromOptions(options, 'undername');
-
-    await assertConfirmationPrompt(
-      `Are you sure you want to remove the record with undername ${undername}?`,
-      options,
-    );
-
-    return writeANTFromOptions(options).removeRecord(
-      {
-        undername,
-      },
-      customTagsFromOptions(options),
-    );
-  },
 });
 
 makeCommand<ProcessIdWriteActionCLIOptions & { ticker?: string }>({
@@ -952,7 +954,6 @@ makeCommand<ProcessIdWriteActionCLIOptions & { transactionId?: string }>({
     );
     return writeANTFromOptions(options).setLogo(
       {
-        // TODO: Could take a logo file, upload it to Arweave, get transaction ID
         txId,
       },
       customTagsFromOptions(options),
@@ -960,6 +961,7 @@ makeCommand<ProcessIdWriteActionCLIOptions & { transactionId?: string }>({
   },
 });
 
+// # ARIO Actions
 makeCommand<
   ProcessIdWriteActionCLIOptions & {
     name?: string;
@@ -1079,6 +1081,7 @@ makeCommand<
   },
 });
 
+// # Utilities
 makeCommand({
   name: 'write-action',
   description: 'Send a write action to an AO Process',

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -67,6 +67,7 @@ import {
   listArNSReservedNames,
   listArNSReturnedNames,
   listGateways,
+  resolveArNSName,
 } from './commands/readCommands.js';
 import {
   createVaultCLICommand,
@@ -463,6 +464,13 @@ makeCommand({
 });
 
 makeCommand({
+  name: 'resolve-arns-name',
+  description: 'Resolve an ArNS name',
+  options: [optionMap.name],
+  action: resolveArNSName,
+});
+
+makeCommand({
   name: 'transfer',
   description: 'Transfer ARIO to another address',
   options: transferOptions,
@@ -619,6 +627,8 @@ makeCommand({
   options: arnsPurchaseOptions,
   action: requestPrimaryNameCLICommand,
 });
+
+// ANTS
 
 makeCommand<ANTStateCLIOptions>({
   name: 'spawn-ant',

--- a/src/cli/commands/readCommands.ts
+++ b/src/cli/commands/readCommands.ts
@@ -282,3 +282,9 @@ export async function getVault(o: AddressAndVaultIdCLIOptions) {
         },
     );
 }
+
+export async function resolveArNSName(o: NameCLIOptions) {
+  const name = requiredStringFromOptions(o, 'name');
+  const result = await readARIOFromOptions(o).resolveArNSName({ name });
+  return result ?? { message: `No record found for name ${name}` };
+}

--- a/src/common/ant.ts
+++ b/src/common/ant.ts
@@ -150,14 +150,12 @@ export class AoANTReadable implements AoANTRead {
     { undername }: { undername: string },
     { strict }: AntReadOptions = { strict: this.strict },
   ): Promise<AoANTRecord> {
-    const tags = [
-      { name: 'Sub-Domain', value: undername },
-      { name: 'Action', value: 'Record' },
-    ];
-
-    const record = await this.process.read<AoANTRecord>({
-      tags,
-    });
+    const records = await this.getRecords();
+    // TODO: use sortedANTRecords to get priority on all records, even if ANT does not have a priority set
+    const record = records[undername];
+    if (record === undefined) {
+      throw new Error(`Record for ${undername} not found on ANT.`);
+    }
     if (strict) parseSchemaResult(AntRecordSchema.passthrough(), record);
 
     return record;

--- a/src/common/ant.ts
+++ b/src/common/ant.ts
@@ -150,12 +150,13 @@ export class AoANTReadable implements AoANTRead {
     { undername }: { undername: string },
     { strict }: AntReadOptions = { strict: this.strict },
   ): Promise<AoANTRecord> {
-    const records = await this.getRecords();
     // TODO: use sortedANTRecords to get priority on all records, even if ANT does not have a priority set
-    const record = records[undername];
-    if (record === undefined) {
-      throw new Error(`Record for ${undername} not found on ANT.`);
-    }
+    const record = await this.process.read<AoANTRecord>({
+      tags: [
+        { name: 'Action', value: 'Record' },
+        { name: 'Sub-Domain', value: undername },
+      ],
+    });
     if (strict) parseSchemaResult(AntRecordSchema.passthrough(), record);
 
     return record;

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -948,7 +948,8 @@ export class ARIOReadable implements AoARIORead, ArNSNameResolver {
     if (baseName === undefined) {
       throw new Error('Invalid name');
     }
-    const undername = name.replace(`_${baseName}`, '') || '@';
+    const undername =
+      name === baseName ? '@' : name.replace(`_${baseName}`, '');
     const nameData = await this.getArNSRecord({ name: baseName });
     const ant = ANT.init({
       process: new AOProcess({

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -69,6 +69,7 @@ import {
   AoVaultedTransferParams,
   AoWalletVault,
   AoWeightedObserver,
+  ArNSNameResolver,
   CostDetailsResult,
   DemandFactorSettings,
   EpochInput,
@@ -203,7 +204,7 @@ export class ARIO {
   }
 }
 
-export class ARIOReadable implements AoARIORead {
+export class ARIOReadable implements AoARIORead, ArNSNameResolver {
   public readonly process: AOProcess;
   protected epochSettings: AoEpochSettings | undefined;
   protected arweave: Arweave;

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -978,6 +978,7 @@ export class ARIOReadable implements AoARIORead, ArNSNameResolver {
       txId: antRecord.transactionId,
       ttlSeconds: antRecord.ttlSeconds,
       priority: antRecord.priority,
+      // NOTE: we may want return the actual index of the record based on sorting in case ANT tries to set duplicate priority values to get around undername limits
       processId: nameData.processId,
       undernameLimit: nameData.undernameLimit,
       type: nameData.type,

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -33,7 +33,6 @@ import {
   AoArNSReservedNameDataWithName,
   AoBalanceWithAddress,
   AoBuyRecordParams,
-  AoClient,
   AoCreateVaultParams,
   AoDelegation,
   AoEligibleDistribution,
@@ -940,7 +939,7 @@ export class ARIOReadable implements AoARIORead {
 
   async resolveArNSName({ name }: { name: string }): Promise<{
     name: string;
-    owner: string;
+    owner: string | undefined; // could be unowned
     txId: string;
     processId: string;
     ttlSeconds: number;
@@ -962,7 +961,15 @@ export class ARIOReadable implements AoARIORead {
       ant.getRecord({ undername }),
     ]);
     if (antRecord === undefined) {
-      throw new Error('Under name not found');
+      throw new Error(`Record for ${undername} not found on ANT.`);
+    }
+    if (
+      antRecord.ttlSeconds === undefined ||
+      antRecord.transactionId === undefined
+    ) {
+      throw new Error(
+        `Invalid record on ANT. Must have ttlSeconds and transactionId. Record: ${JSON.stringify(antRecord)}`,
+      );
     }
     return {
       name: name,

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -976,10 +976,11 @@ export class ARIOReadable implements AoARIORead, ArNSNameResolver {
       name: name,
       owner: owner,
       txId: antRecord.transactionId,
-      processId: nameData.processId,
       ttlSeconds: antRecord.ttlSeconds,
-      index: antRecord.priority,
-      limit: nameData.undernameLimit,
+      recordIndex: antRecord.priority,
+      processId: nameData.processId,
+      undernameLimit: nameData.undernameLimit,
+      type: nameData.type,
     };
   }
 }

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -977,7 +977,7 @@ export class ARIOReadable implements AoARIORead, ArNSNameResolver {
       owner: owner,
       txId: antRecord.transactionId,
       ttlSeconds: antRecord.ttlSeconds,
-      recordIndex: antRecord.priority,
+      priority: antRecord.priority,
       processId: nameData.processId,
       undernameLimit: nameData.undernameLimit,
       type: nameData.type,

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -69,6 +69,7 @@ import {
   AoVaultedTransferParams,
   AoWalletVault,
   AoWeightedObserver,
+  ArNSNameResolutionData,
   ArNSNameResolver,
   CostDetailsResult,
   DemandFactorSettings,
@@ -938,13 +939,11 @@ export class ARIOReadable implements AoARIORead, ArNSNameResolver {
     });
   }
 
-  async resolveArNSName({ name }: { name: string }): Promise<{
+  async resolveArNSName({
+    name,
+  }: {
     name: string;
-    owner: string | undefined; // could be unowned
-    txId: string;
-    processId: string;
-    ttlSeconds: number;
-  }> {
+  }): Promise<ArNSNameResolutionData> {
     const baseName = name.split('_').pop();
     if (baseName === undefined) {
       throw new Error('Invalid name');
@@ -978,6 +977,8 @@ export class ARIOReadable implements AoARIORead, ArNSNameResolver {
       txId: antRecord.transactionId,
       processId: nameData.processId,
       ttlSeconds: antRecord.ttlSeconds,
+      index: antRecord.priority,
+      limit: nameData.undernameLimit,
     };
   }
 }

--- a/src/types/ant.ts
+++ b/src/types/ant.ts
@@ -266,7 +266,7 @@ export interface AoANTWrite extends AoANTRead {
 export type AoANTSetBaseNameRecordParams = {
   transactionId: string;
   ttlSeconds: number;
-  priority?: number;
+  priority?: number; // TODO: the SDK should always provide a priority, even if the ANT does not have a priority set
 };
 
 export type AoANTSetUndernameRecordParams = AoANTSetBaseNameRecordParams & {

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -570,10 +570,11 @@ export type ArNSNameResolutionData = {
   name: string;
   owner?: string; // could be unowned
   txId: string;
+  type: 'lease' | 'permabuy';
   processId: string;
   ttlSeconds: number;
-  index?: number; // TODO: the SDK should always provide a priority index, even if the ANT does not have a priority set
-  limit: number;
+  recordIndex?: number; // TODO: the SDK should always provide a priority index, even if the ANT does not have a priority set
+  undernameLimit: number;
 };
 
 export interface ArNSNameResolver {

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -573,7 +573,7 @@ export type ArNSNameResolutionData = {
   type: 'lease' | 'permabuy';
   processId: string;
   ttlSeconds: number;
-  recordIndex?: number; // TODO: the SDK should always provide a priority index, even if the ANT does not have a priority set
+  priority?: number; // TODO: the SDK should always provide a priority index, even if the ANT does not have a priority set
   undernameLimit: number;
 };
 

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -565,7 +565,20 @@ export type DemandFactorSettings = {
 
 // Interfaces
 
-export interface AoARIORead {
+// simple interface to allow multiple implementations of ArNSNameResolver
+export type ArNSNameResolutionData = {
+  name: string;
+  owner: string | undefined; // could be unowned
+  txId: string;
+  processId: string;
+  ttlSeconds: number;
+};
+
+export interface ArNSNameResolver {
+  resolveArNSName({ name }: { name: string }): Promise<ArNSNameResolutionData>;
+}
+
+export interface AoARIORead extends ArNSNameResolver {
   process: AOProcess;
   getInfo(): Promise<{
     Ticker: string;

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -568,10 +568,12 @@ export type DemandFactorSettings = {
 // simple interface to allow multiple implementations of ArNSNameResolver
 export type ArNSNameResolutionData = {
   name: string;
-  owner: string | undefined; // could be unowned
+  owner?: string; // could be unowned
   txId: string;
   processId: string;
   ttlSeconds: number;
+  index?: number; // TODO: the SDK should always provide a priority index, even if the ANT does not have a priority set
+  limit: number;
 };
 
 export interface ArNSNameResolver {

--- a/tests/e2e/esm/index.test.ts
+++ b/tests/e2e/esm/index.test.ts
@@ -1171,7 +1171,7 @@ describe('e2e esm tests', async () => {
       assert.equal(typeof arnsName.name, 'string');
       assert.equal(typeof arnsName.processId, 'string');
       assert.equal(typeof arnsName.ttlSeconds, 'number');
-      assert.equal(typeof arnsName.transactionId, 'string');
+      assert.equal(typeof arnsName.txId, 'string');
     });
 
     it('should be able to resolve an undername', async () => {
@@ -1183,7 +1183,7 @@ describe('e2e esm tests', async () => {
       assert.equal(typeof undername.name, 'string');
       assert.equal(typeof undername.processId, 'string');
       assert.equal(typeof undername.ttlSeconds, 'number');
-      assert.equal(typeof undername.transactionId, 'string');
+      assert.equal(typeof undername.txId, 'string');
     });
 
     describe('faucet', async () => {

--- a/tests/e2e/esm/index.test.ts
+++ b/tests/e2e/esm/index.test.ts
@@ -1173,7 +1173,6 @@ describe('e2e esm tests', async () => {
       assert.equal(typeof arnsName.ttlSeconds, 'number');
       assert.equal(typeof arnsName.txId, 'string');
       assert.equal(typeof arnsName.type, 'string');
-      assert.equal(typeof arnsName.recordIndex, 'number');
       assert.equal(typeof arnsName.undernameLimit, 'number');
     });
 
@@ -1188,7 +1187,6 @@ describe('e2e esm tests', async () => {
       assert.equal(typeof undername.ttlSeconds, 'number');
       assert.equal(typeof undername.txId, 'string');
       assert.equal(typeof undername.type, 'string');
-      assert.equal(typeof undername.recordIndex, 'number');
       assert.equal(typeof undername.undernameLimit, 'number');
     });
 

--- a/tests/e2e/esm/index.test.ts
+++ b/tests/e2e/esm/index.test.ts
@@ -1162,6 +1162,30 @@ describe('e2e esm tests', async () => {
       );
     });
 
+    it('should be able to resolve an arns name', async () => {
+      const arnsName = await ario.resolveArNSName({
+        name: 'ardrive',
+      });
+      assert.ok(arnsName);
+      assert.equal(typeof arnsName.owner, 'string');
+      assert.equal(typeof arnsName.name, 'string');
+      assert.equal(typeof arnsName.processId, 'string');
+      assert.equal(typeof arnsName.ttlSeconds, 'number');
+      assert.equal(typeof arnsName.transactionId, 'string');
+    });
+
+    it('should be able to resolve an undername', async () => {
+      const undername = await ario.resolveArNSName({
+        name: 'logo_ardrive',
+      });
+      assert.ok(undername);
+      assert.equal(typeof undername.owner, 'string');
+      assert.equal(typeof undername.name, 'string');
+      assert.equal(typeof undername.processId, 'string');
+      assert.equal(typeof undername.ttlSeconds, 'number');
+      assert.equal(typeof undername.transactionId, 'string');
+    });
+
     describe('faucet', async () => {
       let testnet: ARIOWithFaucet<AoARIORead>;
 

--- a/tests/e2e/esm/index.test.ts
+++ b/tests/e2e/esm/index.test.ts
@@ -1172,6 +1172,9 @@ describe('e2e esm tests', async () => {
       assert.equal(typeof arnsName.processId, 'string');
       assert.equal(typeof arnsName.ttlSeconds, 'number');
       assert.equal(typeof arnsName.txId, 'string');
+      assert.equal(typeof arnsName.type, 'string');
+      assert.equal(typeof arnsName.recordIndex, 'number');
+      assert.equal(typeof arnsName.undernameLimit, 'number');
     });
 
     it('should be able to resolve an undername', async () => {
@@ -1184,6 +1187,9 @@ describe('e2e esm tests', async () => {
       assert.equal(typeof undername.processId, 'string');
       assert.equal(typeof undername.ttlSeconds, 'number');
       assert.equal(typeof undername.txId, 'string');
+      assert.equal(typeof undername.type, 'string');
+      assert.equal(typeof undername.recordIndex, 'number');
+      assert.equal(typeof undername.undernameLimit, 'number');
     });
 
     describe('faucet', async () => {


### PR DESCRIPTION
This interface can be impemented in various ways. For now just adds resolution API directly via CUs on ARIO class. Wayfinder can also implement it, using router strategies to resolve arns names against ar-io resolver endpoints.

CLI:
```bash
❯ node lib/esm/cli/cli.js resolve-arns-name --name dtf
{
  "name": "dtf",
  "owner": "ZjmB2vEUlHlJ7-rgJkYP09N5IzLPhJyStVrK5u9dDEo",
  "txId": "Zkoo3vgTq-f0wBlM-cOYhVy3dxVMajr7l-dEBFRYos4",
  "ttlSeconds": 3600,
  "recordIndex": 0,
  "processId": "Rfm9Ob2M-7FRKdi4azJVU4JLpUa6bjM1Ud3KpwkepOE",
  "undernameLimit": 10,
  "type": "permabuy"
}
```