### PR TITLE
feat(wayfinder): support `strict` mode, which blocks returning client…

### DIFF
--- a/WAYFINDER.md
+++ b/WAYFINDER.md
@@ -319,7 +319,7 @@ sequenceDiagram
     Verification Strategy-->>-Wayfinder: Return request data with verification result
 
     alt Verification passed
-        Wayfinder->>Wayfinder: Emit 'verification-passed' event
+        Wayfinder->>Wayfinder: Emit 'verification-succeeded' event
         Wayfinder-->>Client: Return verified response
     else Verification failed
         Wayfinder->>Wayfinder: Emit 'verification-failed' event

--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -309,7 +309,7 @@ function App() {
         return prevUpdates;
       });
     });
-    wayfinder.emitter.on('verification-passed', (event) => {
+    wayfinder.emitter.on('verification-succeeded', (event) => {
       setWayfinderVerified(true);
       setWayfinderStatusUpdates((prevUpdates) => {
         prevUpdates.add(`✅ Verification passed for ${event.txId}`);

--- a/src/common/wayfinder/wayfinder.test.ts
+++ b/src/common/wayfinder/wayfinder.test.ts
@@ -308,8 +308,8 @@ describe('Wayfinder', () => {
       wayfinder.emitter.on('verification-progress', (event) => {
         events.push({ type: 'verification-progress', ...event });
       });
-      wayfinder.emitter.on('verification-passed', (event) => {
-        events.push({ type: 'verification-passed', ...event });
+      wayfinder.emitter.on('verification-succeeded', (event) => {
+        events.push({ type: 'verification-succeeded', ...event });
       });
       // request data and assert the event is emitted
       const response = await wayfinder.request(
@@ -322,8 +322,8 @@ describe('Wayfinder', () => {
       await response.text();
       assert.strictEqual(response.status, 200);
       assert.ok(
-        events.find((e) => e.type === 'verification-passed'),
-        'Should emit at least one verification-passed',
+        events.find((e) => e.type === 'verification-succeeded'),
+        'Should emit at least one verification-succeeded',
       );
     });
 
@@ -347,6 +347,7 @@ describe('Wayfinder', () => {
             verificationPassed = true;
           },
         },
+        strict: true,
       });
       const response = await wayfinder.request(
         'ar://c7wkwt6TKgcWJUfgvpJ5q5qi4DIZyJ1_TqhjXgURh0U',
@@ -362,284 +363,292 @@ describe('Wayfinder', () => {
         'Should not emit verification-failed',
       );
       assert.ok(verificationProgress, 'Should emit verification-progress');
-      assert.ok(verificationPassed, 'Should emit verification-passed');
+      assert.ok(verificationPassed, 'Should emit verification-succeeded');
     });
   });
 
   describe('tapAndVerifyRequest', () => {
     describe('Readable', () => {
-      it('should duplicate the stream, verify the first and return the second if verification passes', async () => {
-        // create a simple readable
-        const chunks = [
-          Buffer.from('foo'),
-          Buffer.from('bar'),
-          Buffer.from('baz'),
-        ];
-        const contentLength = chunks.reduce((sum, c) => sum + c.length, 0);
+      describe('strict mode enabled', () => {
+        it('should duplicate the stream, verify the first and return the second if verification passes', async () => {
+          // create a simple readable
+          const chunks = [
+            Buffer.from('foo'),
+            Buffer.from('bar'),
+            Buffer.from('baz'),
+          ];
+          const contentLength = chunks.reduce((sum, c) => sum + c.length, 0);
 
-        // a stream that will emit chunks
-        const originalStream = Readable.from(chunks);
-        let seen = Buffer.alloc(0);
-        const verifyData = async ({
-          data,
-          // @ts-expect-error
-          txId,
-        }: {
-          data: Readable;
-          txId: string;
-        }): Promise<void> => {
-          return new Promise((resolve, reject) => {
-            data.on('data', (chunk) => {
-              seen = Buffer.concat([seen, chunk]);
+          // a stream that will emit chunks
+          const originalStream = Readable.from(chunks);
+          let seen = Buffer.alloc(0);
+          const verifyData = async ({
+            data,
+            // @ts-expect-error
+            txId,
+          }: {
+            data: Readable;
+            txId: string;
+          }): Promise<void> => {
+            return new Promise((resolve, reject) => {
+              data.on('data', (chunk) => {
+                seen = Buffer.concat([seen, chunk]);
+              });
+              data.on('end', () => {
+                // Should have seen exactly the full payload
+                assert.strictEqual(seen.length, contentLength);
+                resolve();
+              });
+              data.on('error', reject);
             });
-            data.on('end', () => {
-              // Should have seen exactly the full payload
-              assert.strictEqual(seen.length, contentLength);
-              resolve();
-            });
-            data.on('error', reject);
+          };
+
+          const txId = 'test-tx-1';
+          const emitter = new EventEmitter();
+          const events: { type: string; txId: string }[] = [];
+          emitter.on('verification-progress', (e) => {
+            events.push({ type: 'verification-progress', ...e });
           });
-        };
+          emitter.on('verification-succeeded', (e) =>
+            events.push({ type: 'verification-succeeded', ...e }),
+          );
 
-        const txId = 'test-tx-1';
-        const emitter = new EventEmitter();
-        const events: { type: string; txId: string }[] = [];
-        emitter.on('verification-progress', (e) => {
-          events.push({ type: 'verification-progress', ...e });
-        });
-        emitter.on('verification-passed', (e) =>
-          events.push({ type: 'verification-passed', ...e }),
-        );
+          // tap with verification
+          const tapped = tapAndVerifyStream({
+            originalStream,
+            contentLength,
+            verifyData,
+            txId,
+            emitter,
+            strict: true,
+          });
 
-        // tap with verification
-        const tapped = tapAndVerifyStream({
-          originalStream,
-          contentLength,
-          verifyData,
-          txId,
-          emitter,
-        });
-
-        // read the stream
-        const out: Buffer[] = [];
-        for await (const chunk of tapped) {
-          out.push(chunk);
-        }
-
-        // assert the stream is the same
-        assert.strictEqual(
-          Buffer.concat(out).toString(),
-          Buffer.concat(chunks).toString(),
-          'The tapped stream should emit exactly the original data',
-        );
-
-        assert.ok(
-          events.find((e) => e.type === 'verification-progress'),
-          'Should emit at least one verification-progress',
-        );
-        assert.ok(
-          events.find(
-            (e) => e.type === 'verification-passed' && e.txId === txId,
-          ),
-          'Should emit at least one verification-passed',
-        );
-      });
-
-      it('should throw an error on the client stream if verification fails', async () => {
-        const chunks = [
-          Buffer.from('foo'),
-          Buffer.from('bar'),
-          Buffer.from('baz'),
-        ];
-        const contentLength = chunks.reduce((sum, c) => sum + c.length, 0);
-
-        // a stream that will emit chunks
-        const originalStream = Readable.from(chunks);
-        const verifyData = async ({
-          // @ts-expect-error
-          data,
-          txId,
-        }: {
-          data: Readable;
-          txId: string;
-        }): Promise<void> => {
-          throw new Error('Verification failed for txId: ' + txId);
-        };
-
-        const txId = 'test-tx-1';
-        const emitter = new EventEmitter();
-        const events: { type: string; txId: string }[] = [];
-        emitter.on('verification-progress', (e) =>
-          events.push({ type: 'verification-progress', ...e }),
-        );
-        emitter.on('verification-failed', (e) =>
-          events.push({ type: 'verification-failed', ...e }),
-        );
-
-        // tap with verification
-        const tapped = tapAndVerifyStream({
-          originalStream,
-          contentLength,
-          verifyData,
-          txId,
-          emitter,
-        });
-
-        // read the stream
-        try {
+          // read the stream
           const out: Buffer[] = [];
           for await (const chunk of tapped) {
             out.push(chunk);
           }
-        } catch (error) {
+
+          // assert the stream is the same
+          assert.strictEqual(
+            Buffer.concat(out).toString(),
+            Buffer.concat(chunks).toString(),
+            'The tapped stream should emit exactly the original data',
+          );
+
+          assert.ok(
+            events.find((e) => e.type === 'verification-progress'),
+            'Should emit at least one verification-progress',
+          );
           assert.ok(
             events.find(
-              (e) => e.type === 'verification-failed' && e.txId === txId,
+              (e) => e.type === 'verification-succeeded' && e.txId === txId,
             ),
-            'Should emit at least one verification-failed',
+            'Should emit at least one verification-succeeded',
           );
-          // stream should be closed
-          assert.ok(tapped.closed);
-        }
+        });
+
+        it('should throw an error on the client stream if verification fails', async () => {
+          const chunks = [
+            Buffer.from('foo'),
+            Buffer.from('bar'),
+            Buffer.from('baz'),
+          ];
+          const contentLength = chunks.reduce((sum, c) => sum + c.length, 0);
+
+          // a stream that will emit chunks
+          const originalStream = Readable.from(chunks);
+          const verifyData = async ({
+            // @ts-expect-error
+            data,
+            txId,
+          }: {
+            data: Readable;
+            txId: string;
+          }): Promise<void> => {
+            throw new Error('Verification failed for txId: ' + txId);
+          };
+
+          const txId = 'test-tx-1';
+          const emitter = new EventEmitter();
+          const events: { type: string; txId: string }[] = [];
+          emitter.on('verification-progress', (e) =>
+            events.push({ type: 'verification-progress', ...e }),
+          );
+          emitter.on('verification-failed', (e) =>
+            events.push({ type: 'verification-failed', ...e }),
+          );
+
+          // tap with verification (using strict mode)
+          const tapped = tapAndVerifyStream({
+            originalStream,
+            contentLength,
+            verifyData,
+            txId,
+            emitter,
+            strict: true,
+          });
+
+          // read the stream
+          try {
+            const out: Buffer[] = [];
+            for await (const chunk of tapped) {
+              out.push(chunk);
+            }
+          } catch (error) {
+            assert.ok(
+              events.find(
+                (e) => e.type === 'verification-failed' && e.txId === txId,
+              ),
+              'Should emit at least one verification-failed',
+            );
+            // stream should be closed
+            assert.ok(tapped.closed);
+          }
+        });
       });
     });
 
     describe('ReadableStream', () => {
-      it('should duplicate the ReadableStream, verify the first and return the second if verification passes', async () => {
-        // create a simple readable
-        const chunks = [
-          Buffer.from('foo'),
-          Buffer.from('bar'),
-          Buffer.from('baz'),
-        ];
-        const contentLength = chunks.reduce((sum, c) => sum + c.length, 0);
+      describe('strict mode enabled', () => {
+        it('should duplicate the ReadableStream, verify the first and return the second if verification passes', async () => {
+          // create a simple readable
+          const chunks = [
+            Buffer.from('foo'),
+            Buffer.from('bar'),
+            Buffer.from('baz'),
+          ];
+          const contentLength = chunks.reduce((sum, c) => sum + c.length, 0);
 
-        // a stream that will emit chunks
-        const originalStream = ReadableStream.from(chunks);
-        let seen = Buffer.alloc(0);
-        const verifyData = async ({
-          data,
-          // @ts-expect-error
-          txId,
-        }: {
-          data: ReadableStream;
-          txId: string;
-        }): Promise<void> => {
-          return new Promise(async (resolve, reject) => {
-            const reader = data.getReader();
-            while (true) {
-              try {
-                const { done, value } = await reader.read();
-                if (done) {
-                  resolve();
-                  break;
+          // a stream that will emit chunks
+          const originalStream = ReadableStream.from(chunks);
+          let seen = Buffer.alloc(0);
+          const verifyData = async ({
+            data,
+            // @ts-expect-error
+            txId,
+          }: {
+            data: ReadableStream;
+            txId: string;
+          }): Promise<void> => {
+            return new Promise(async (resolve, reject) => {
+              const reader = data.getReader();
+              while (true) {
+                try {
+                  const { done, value } = await reader.read();
+                  if (done) {
+                    resolve();
+                    break;
+                  }
+                  seen = Buffer.concat([seen, value]);
+                } catch (error) {
+                  reject(error);
                 }
-                seen = Buffer.concat([seen, value]);
-              } catch (error) {
-                reject(error);
               }
-            }
+            });
+          };
+
+          const txId = 'test-tx-1';
+          const emitter = new EventEmitter();
+          const events: { type: string; txId: string }[] = [];
+          emitter.on('verification-progress', (e) =>
+            events.push({ type: 'verification-progress', ...e }),
+          );
+          emitter.on('verification-succeeded', (e) =>
+            events.push({ type: 'verification-succeeded', ...e }),
+          );
+
+          // tap with verification
+          const tapped = tapAndVerifyStream({
+            originalStream,
+            contentLength,
+            verifyData,
+            txId,
+            emitter,
+            strict: true,
           });
-        };
 
-        const txId = 'test-tx-1';
-        const emitter = new EventEmitter();
-        const events: { type: string; txId: string }[] = [];
-        emitter.on('verification-progress', (e) =>
-          events.push({ type: 'verification-progress', ...e }),
-        );
-        emitter.on('verification-passed', (e) =>
-          events.push({ type: 'verification-passed', ...e }),
-        );
-
-        // tap with verification
-        const tapped = tapAndVerifyStream({
-          originalStream,
-          contentLength,
-          verifyData,
-          txId,
-          emitter,
-        });
-
-        // read the stream
-        const out: Buffer[] = [];
-        for await (const chunk of tapped) {
-          out.push(chunk);
-        }
-
-        // assert the stream is the same
-        assert.strictEqual(
-          Buffer.concat(out).toString(),
-          Buffer.concat(chunks).toString(),
-          'The tapped stream should emit exactly the original data',
-        );
-
-        assert.ok(
-          events.find((e) => e.type === 'verification-progress'),
-          'Should emit at least one verification-progress',
-        );
-        assert.ok(
-          events.find(
-            (e) => e.type === 'verification-passed' && e.txId === txId,
-          ),
-          'Should emit at least one verification-passed',
-        );
-      });
-
-      it('should throw an error on the client stream if verification fails', async () => {
-        const chunks = [
-          Buffer.from('foo'),
-          Buffer.from('bar'),
-          Buffer.from('baz'),
-        ];
-        const contentLength = chunks.reduce((sum, c) => sum + c.length, 0);
-
-        // a stream that will emit chunks
-        const originalStream = ReadableStream.from(chunks);
-        const verifyData = async ({
-          // @ts-expect-error
-          data,
-          txId,
-        }: {
-          data: ReadableStream;
-          txId: string;
-        }): Promise<void> => {
-          throw new Error('Verification failed for txId: ' + txId);
-        };
-
-        const txId = 'test-tx-1';
-        const emitter = new EventEmitter();
-        const events: { type: string; txId: string }[] = [];
-        emitter.on('verification-progress', (e) =>
-          events.push({ type: 'verification-progress', ...e }),
-        );
-        emitter.on('verification-failed', (e) =>
-          events.push({ type: 'verification-failed', ...e }),
-        );
-
-        // tap with verification
-        const tapped = tapAndVerifyStream({
-          originalStream,
-          contentLength,
-          verifyData,
-          txId,
-          emitter,
-        });
-
-        // read the stream
-        try {
+          // read the stream
           const out: Buffer[] = [];
           for await (const chunk of tapped) {
             out.push(chunk);
           }
-        } catch (error) {
+
+          // assert the stream is the same
+          assert.strictEqual(
+            Buffer.concat(out).toString(),
+            Buffer.concat(chunks).toString(),
+            'The tapped stream should emit exactly the original data',
+          );
+
+          assert.ok(
+            events.find((e) => e.type === 'verification-progress'),
+            'Should emit at least one verification-progress',
+          );
           assert.ok(
             events.find(
-              (e) => e.type === 'verification-failed' && e.txId === txId,
+              (e) => e.type === 'verification-succeeded' && e.txId === txId,
             ),
-            'Should emit at least one verification-failed',
+            'Should emit at least one verification-succeeded',
           );
-        }
+        });
+
+        it('should throw an error on the client stream if verification fails', async () => {
+          const chunks = [
+            Buffer.from('foo'),
+            Buffer.from('bar'),
+            Buffer.from('baz'),
+          ];
+          const contentLength = chunks.reduce((sum, c) => sum + c.length, 0);
+
+          // a stream that will emit chunks
+          const originalStream = ReadableStream.from(chunks);
+          const verifyData = async ({
+            // @ts-expect-error
+            data,
+            txId,
+          }: {
+            data: ReadableStream;
+            txId: string;
+          }): Promise<void> => {
+            throw new Error('Verification failed for txId: ' + txId);
+          };
+
+          const txId = 'test-tx-1';
+          const emitter = new EventEmitter();
+          const events: { type: string; txId: string }[] = [];
+          emitter.on('verification-progress', (e) =>
+            events.push({ type: 'verification-progress', ...e }),
+          );
+          emitter.on('verification-failed', (e) =>
+            events.push({ type: 'verification-failed', ...e }),
+          );
+
+          // tap with verification (using strict mode)
+          const tapped = tapAndVerifyStream({
+            originalStream,
+            contentLength,
+            verifyData,
+            txId,
+            emitter,
+            strict: true,
+          });
+
+          // read the stream
+          try {
+            const out: Buffer[] = [];
+            for await (const chunk of tapped) {
+              out.push(chunk);
+            }
+          } catch (error) {
+            assert.ok(
+              events.find(
+                (e) => e.type === 'verification-failed' && e.txId === txId,
+              ),
+              'Should emit at least one verification-failed',
+            );
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
… data until verified