### PR TITLE
feat(ants): add support for fetching ant state from hyperbeam nodes

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -695,6 +695,15 @@ makeCommand<ProcessIdCLIOptions>({
   },
 });
 
+makeCommand<ProcessIdCLIOptions>({
+  name: 'get-ant-logo',
+  description: 'Get the logo of an ANT process',
+  options: [optionMap.processId],
+  action: async (options) => {
+    return readANTFromOptions(options).getLogo();
+  },
+});
+
 makeCommand<ProcessIdCLIOptions & { address?: string }>({
   name: 'get-ant-balance',
   description: 'Get the balance of an ANT process',

--- a/src/common/ant.ts
+++ b/src/common/ant.ts
@@ -104,9 +104,14 @@ export class AoANTReadable implements AoANTRead {
     this.checkHyperBeamPromise = this.checkHyperBeamCompatibility();
   }
 
+  /**
+   * Check if the process is hyperbeam compatible. If so, we'll use the hyperbeam node to fetch the state.
+   *
+   * @returns {Promise<boolean>} True if the process is hyperbeam compatible, false otherwise.
+   */
   private async checkHyperBeamCompatibility(): Promise<boolean> {
     const res = await fetch(
-      `${this.hyperbeamUrl}/${this.processId}~process@1.0/now/cache`,
+      `https://permanode.xyz/${this.processId}~process@1.0/now/cache`,
       {
         method: 'HEAD',
       },
@@ -370,12 +375,11 @@ export class AoANTReadable implements AoANTRead {
       if (!res.ok) {
         throw new Error('Failed to fetch ant balances');
       }
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { device, ...balances } = (await res.json()) as {
+      const result = (await res.json()) as {
         device: string;
-        [key: string]: any;
+        balances: Record<string, number>;
       };
-      return balances as Record<string, number>;
+      return result.balances;
     }
 
     const tags = [{ name: 'Action', value: 'Balances' }];

--- a/src/common/ant.ts
+++ b/src/common/ant.ts
@@ -106,7 +106,7 @@ export class AoANTReadable implements AoANTRead {
 
   private async checkHyperBeamCompatibility(): Promise<boolean> {
     const res = await fetch(
-      `https://permanode.xyz/${this.processId}~process@1.0/now/cache`,
+      `${this.hyperbeamUrl}/${this.processId}~process@1.0/now/cache`,
       {
         method: 'HEAD',
       },

--- a/src/common/ant.ts
+++ b/src/common/ant.ts
@@ -110,6 +110,10 @@ export class AoANTReadable implements AoANTRead {
    * @returns {Promise<boolean>} True if the process is hyperbeam compatible, false otherwise.
    */
   private async checkHyperBeamCompatibility(): Promise<boolean> {
+    if (this.checkHyperBeamPromise !== undefined) {
+      return this.checkHyperBeamPromise;
+    }
+
     const res = await fetch(
       `https://permanode.xyz/${this.processId}~process@1.0/now/cache`,
       {
@@ -117,17 +121,21 @@ export class AoANTReadable implements AoANTRead {
       },
     );
 
+    let isHyperBeamCompatible = false;
+
     if (res.ok) {
-      return true;
+      isHyperBeamCompatible = true;
     }
 
-    return false;
+    this.checkHyperBeamPromise = Promise.resolve(isHyperBeamCompatible);
+
+    return isHyperBeamCompatible;
   }
 
   async getState(
     { strict }: AntReadOptions = { strict: this.strict },
   ): Promise<AoANTState> {
-    if (await this.checkHyperBeamPromise) {
+    if (await this.checkHyperBeamCompatibility()) {
       const res = await fetch(
         `${this.hyperbeamUrl}/${this.processId}~process@1.0/now/cache/serialize~json@1.0`,
         {
@@ -170,7 +178,7 @@ export class AoANTReadable implements AoANTRead {
   async getInfo(
     { strict }: AntReadOptions = { strict: this.strict },
   ): Promise<AoANTInfo> {
-    if (await this.checkHyperBeamPromise) {
+    if (await this.checkHyperBeamCompatibility()) {
       const state = await this.getState();
       return {
         Name: state.Name,
@@ -216,7 +224,7 @@ export class AoANTReadable implements AoANTRead {
     { undername }: { undername: string },
     { strict }: AntReadOptions = { strict: this.strict },
   ): Promise<AoANTRecord> {
-    if (await this.checkHyperBeamPromise) {
+    if (await this.checkHyperBeamCompatibility()) {
       const records = await this.getRecords();
       const cachedRecord = records[undername];
 
@@ -251,7 +259,7 @@ export class AoANTReadable implements AoANTRead {
   async getRecords(
     { strict }: AntReadOptions = { strict: this.strict },
   ): Promise<SortedANTRecords> {
-    if (await this.checkHyperBeamPromise) {
+    if (await this.checkHyperBeamCompatibility()) {
       const state = await this.getState();
       return sortANTRecords(state.Records);
     }
@@ -278,7 +286,7 @@ export class AoANTReadable implements AoANTRead {
   async getOwner(
     { strict }: AntReadOptions = { strict: this.strict },
   ): Promise<string> {
-    if (await this.checkHyperBeamPromise) {
+    if (await this.checkHyperBeamCompatibility()) {
       const state = await this.getState();
       return state.Owner;
     }
@@ -298,7 +306,7 @@ export class AoANTReadable implements AoANTRead {
   async getControllers(
     { strict }: AntReadOptions = { strict: this.strict },
   ): Promise<WalletAddress[]> {
-    if (await this.checkHyperBeamPromise) {
+    if (await this.checkHyperBeamCompatibility()) {
       const state = await this.getState();
       return state.Controllers;
     }
@@ -322,7 +330,7 @@ export class AoANTReadable implements AoANTRead {
   async getName(
     { strict }: AntReadOptions = { strict: this.strict },
   ): Promise<string> {
-    if (await this.checkHyperBeamPromise) {
+    if (await this.checkHyperBeamCompatibility()) {
       const state = await this.getState();
       return state.Name;
     }
@@ -341,7 +349,7 @@ export class AoANTReadable implements AoANTRead {
   async getTicker(
     { strict }: AntReadOptions = { strict: this.strict },
   ): Promise<string> {
-    if (await this.checkHyperBeamPromise) {
+    if (await this.checkHyperBeamCompatibility()) {
       const state = await this.getState();
       return state.Ticker;
     }
@@ -360,7 +368,7 @@ export class AoANTReadable implements AoANTRead {
   async getBalances(
     { strict }: AntReadOptions = { strict: this.strict },
   ): Promise<Record<string, number>> {
-    if (await this.checkHyperBeamPromise) {
+    if (await this.checkHyperBeamCompatibility()) {
       const res = await fetch(
         `${this.hyperbeamUrl}/${this.processId}~process@1.0/now/cache/balances/serialize~json@1.0`,
         {
@@ -403,7 +411,7 @@ export class AoANTReadable implements AoANTRead {
     { address }: { address: string },
     { strict }: AntReadOptions = { strict: this.strict },
   ): Promise<number> {
-    if (await this.checkHyperBeamPromise) {
+    if (await this.checkHyperBeamCompatibility()) {
       const balances = await this.getBalances();
       return balances[address] ?? 0;
     }
@@ -427,7 +435,7 @@ export class AoANTReadable implements AoANTRead {
    * ```
    */
   async getHandlers(): Promise<AoANTHandler[]> {
-    if (await this.checkHyperBeamPromise) {
+    if (await this.checkHyperBeamCompatibility()) {
       throw new Error('Handlers are not supported on HyperBeam');
     }
     const info = await this.getInfo();

--- a/src/types/ant.ts
+++ b/src/types/ant.ts
@@ -106,6 +106,21 @@ export const AntStateSchema = z.object({
 
 export type AoANTState = z.infer<typeof AntStateSchema>;
 
+export type HyperBeamANTState = {
+  name: string;
+  ticker: string;
+  description: string;
+  keywords: string[];
+  denomination: string;
+  owner: string;
+  controllers: string[];
+  records: Record<string, { transactionid: string; ttlseconds: number }>;
+  balances: Record<string, number>;
+  logo: string;
+  totalsupply: number;
+  initialized: boolean;
+};
+
 export const SpawnANTStateSchema = z.object({
   name: z.string().describe('The name of the ANT.'),
   ticker: z.string().describe('The ticker symbol for the ANT.'),


### PR DESCRIPTION
This is an early implementation that needs some tuning, but the intent is with newer ANTs publishing patch messages of their state on changes, we can now start to lean in to using hyperbeam for cached state and lower the need for CUs. We may want to modify how we are verifying HyperBeam compatability vs. the HEAD check against a known hyperbeam node.'