### PR TITLE
fix(wayfinder): use native fetch http client for allr requests,

### DIFF
--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -1,56 +1,14 @@
-import { ARIO, ARIOToken, Logger, mARIOToken } from '@ar.io/sdk/web';
-import {
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
-import { useEffect, useRef, useState } from 'react';
+import { ARIO, Logger } from '@ar.io/sdk/web';
 
 import './App.css';
 import { ArNSNamesExample } from './components/ArNSNames';
 import { FaucetExample } from './components/Faucet';
 import { GatewaysExample } from './components/Gateways';
 import { WayfinderExample } from './components/Wayfinder';
-import { useArNSRecords } from './hooks/useArNS';
-import { useGatewayDelegations, useGateways } from './hooks/useGatewayRegistry';
 
 Logger.default.setLogLevel('debug');
-const ario = ARIO.testnet();
 
 function App() {
-  const [balance, setBalance] = useState<number | null>(null);
-  const [tokenRequestMessage, setTokenRequestMessage] = useState<string | null>(
-    null,
-  );
-  const [connectedAddress, setConnectedAddress] = useState<string | null>(null);
-  const [selectedAddress, setSelectedAddress] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (window.arweaveWallet) {
-      window.arweaveWallet.getActiveAddress().then((address) => {
-        setConnectedAddress(address);
-        setSelectedAddress(address);
-      });
-    }
-  }, [window.arweaveWallet]);
-
-  useEffect(() => {
-    fetchBalance();
-  }, [ario, selectedAddress]);
-
-  const fetchBalance = async () => {
-    setBalance(null);
-    if (!selectedAddress) return;
-    await ario
-      .getBalance({
-        address: selectedAddress,
-      })
-      .then((balance) => {
-        const arioBalance = new mARIOToken(balance).toARIO().valueOf();
-        setBalance(arioBalance);
-      });
-  };
-
   const examples = [
     {
       name: 'Wayfinder',

--- a/examples/vite/src/components/Wayfinder.tsx
+++ b/examples/vite/src/components/Wayfinder.tsx
@@ -10,7 +10,7 @@ import {
 import { useEffect, useState } from 'react';
 
 // @ts-ignore
-const wayfinder = new Wayfinder<typeof fetch>({
+const wayfinder = new Wayfinder({
   gatewaysProvider: new SimpleCacheGatewaysProvider({
     ttlSeconds: 60,
     gatewaysProvider: new NetworkGatewaysProvider({

--- a/src/common/wayfinder/wayfinder.test.ts
+++ b/src/common/wayfinder/wayfinder.test.ts
@@ -1,13 +1,13 @@
-import axios from 'axios';
-import got from 'got';
 import assert from 'node:assert';
 import { EventEmitter } from 'node:events';
 import { Readable } from 'node:stream';
-import { buffer } from 'node:stream/consumers';
 import { before, describe, it } from 'node:test';
 
 import { Logger } from '../../common/logger.js';
-import { GatewaysProvider } from '../../types/wayfinder.js';
+import {
+  DataVerificationStrategy,
+  GatewaysProvider,
+} from '../../types/wayfinder.js';
 import { RandomRoutingStrategy } from './routing/strategies/random.js';
 import { StaticRoutingStrategy } from './routing/strategies/static.js';
 import { Wayfinder, tapAndVerifyStream } from './wayfinder.js';
@@ -23,10 +23,9 @@ Logger.default.setLogLevel('none');
 describe('Wayfinder', () => {
   describe('http wrapper', () => {
     describe('fetch', () => {
-      let wayfinder: Wayfinder<typeof fetch>;
+      let wayfinder: Wayfinder;
       before(() => {
         wayfinder = new Wayfinder({
-          httpClient: fetch,
           routingStrategy: new RandomRoutingStrategy(),
           gatewaysProvider: stubbedGatewaysProvider,
         });
@@ -53,9 +52,9 @@ describe('Wayfinder', () => {
           // follow redirects
           { redirect: 'follow' },
         );
+        // wayfinder redirects by default
         const response = await wayfinder.request(
           'ar://KKmRbIfrc7wiLcG0zvY1etlO0NBx1926dSCksxCIN3A',
-          { redirect: 'follow' },
         );
         assert.strictEqual(response.status, 200);
         assert.strictEqual(response.status, nativeFetch.status);
@@ -67,10 +66,7 @@ describe('Wayfinder', () => {
             method: 'HEAD',
             redirect: 'follow',
           }),
-          wayfinder.request(`https://${gatewayUrl}/`, {
-            method: 'HEAD',
-            redirect: 'follow',
-          }),
+          wayfinder.request(`https://${gatewayUrl}/`, { method: 'HEAD' }),
         ]);
         assert.strictEqual(response.status, 200);
         assert.strictEqual(response.status, nativeFetch.status);
@@ -80,12 +76,8 @@ describe('Wayfinder', () => {
       for (const api of ['/info', '/block/current']) {
         it.skip(`supports native arweave node apis ${api}`, async () => {
           const [nativeFetch, response] = await Promise.all([
-            fetch(`https://${gatewayUrl}${api}`, {
-              redirect: 'follow',
-            }),
-            wayfinder.request(`ar://${api}`, {
-              redirect: 'follow',
-            }),
+            fetch(`https://${gatewayUrl}${api}`),
+            wayfinder.request(`ar://${api}`),
           ]);
           assert.strictEqual(response.status, 200);
           assert.strictEqual(response.status, nativeFetch.status);
@@ -108,7 +100,6 @@ describe('Wayfinder', () => {
       it('supports a post request to graphql', async () => {
         const response = await wayfinder.request('ar:///graphql', {
           method: 'POST',
-          redirect: 'follow',
           headers: {
             'Content-Type': 'application/json',
           },
@@ -145,144 +136,11 @@ describe('Wayfinder', () => {
 
       it('returns the error from the target gateway if the route is not found', async () => {
         const [nativeFetch, response] = await Promise.all([
-          fetch(`https://${gatewayUrl}/ar-io/not-found`, {
-            redirect: 'follow',
-          }),
-          wayfinder.request('ar:///ar-io/not-found', {
-            redirect: 'follow',
-          }),
+          fetch(`https://${gatewayUrl}/ar-io/not-found`),
+          wayfinder.request('ar:///ar-io/not-found'),
         ]);
         assert.strictEqual(response.status, nativeFetch.status);
         assert.strictEqual(response.statusText, nativeFetch.statusText);
-      });
-    });
-
-    describe('axios', () => {
-      let wayfinder: Wayfinder<typeof axios>;
-      before(() => {
-        wayfinder = new Wayfinder({
-          httpClient: axios,
-          routingStrategy: new RandomRoutingStrategy(),
-          gatewaysProvider: stubbedGatewaysProvider,
-        });
-      });
-      it('should fetch the data using axios default function against the target gateway', async () => {
-        const [nativeAxios, response] = await Promise.all([
-          axios(`https://ao.${gatewayUrl}`),
-          wayfinder.request('ar://ao', {
-            maxRedirects: 5,
-          }),
-        ]);
-        assert.strictEqual(response.status, nativeAxios.status);
-        // assert the arns headers are the same
-        const arnsHeaders = Object.entries(response.headers)
-          .sort()
-          .filter(([key]) => key.startsWith('x-arns-'));
-        const nativeAxiosHeaders = Object.entries(nativeAxios.headers).filter(
-          ([key]) => key.startsWith('x-arns-'),
-        );
-        assert.deepStrictEqual(arnsHeaders.sort(), nativeAxiosHeaders.sort());
-      });
-
-      it('should fetch the data using the axios.get method against the target gateway', async () => {
-        const [nativeAxios, response] = await Promise.all([
-          axios.get(`https://ao.${gatewayUrl}`),
-          wayfinder.request.get('ar://ao'),
-        ]);
-        assert.strictEqual(response.status, nativeAxios.status);
-        // assert the arns headers are the same
-        const arnsHeaders = Object.entries(response.headers)
-          .sort()
-          .filter(([key]) => key.startsWith('x-arns-'));
-        const nativeAxiosHeaders = Object.entries(nativeAxios.headers).filter(
-          ([key]) => key.startsWith('x-arns-'),
-        );
-        assert.deepStrictEqual(arnsHeaders.sort(), nativeAxiosHeaders.sort());
-      });
-
-      it('should route a non-ar:// url as a normal axios request', async () => {
-        const [nativeAxios, response] = await Promise.all([
-          axios(`https://${gatewayUrl}/`),
-          wayfinder.request(`https://${gatewayUrl}/`),
-        ]);
-        assert.strictEqual(response.status, 200);
-        assert.strictEqual(response.status, nativeAxios.status);
-        // TODO: ensure the headers are the same excluding unique headers
-      });
-
-      for (const api of ['/info', '/block/current']) {
-        it.skip(`supports native arweave node apis ${api}`, async () => {
-          const [nativeAxios, response] = await Promise.all([
-            axios(`https://${gatewayUrl}${api}`),
-            wayfinder.request(`ar://${api}`),
-          ]);
-          assert.strictEqual(response.status, 200);
-          assert.strictEqual(response.status, nativeAxios.status);
-          // TODO: ensure the headers are the same excluding unique headers
-        });
-      }
-
-      for (const api of ['/ar-io/info', '/ar-io/__gateway_metrics']) {
-        it(`supports native ario node gateway apis ${api}`, async () => {
-          const [nativeAxios, response] = await Promise.all([
-            axios(`https://${gatewayUrl}${api}`),
-            wayfinder.request(`ar://${api}`),
-          ]);
-          assert.strictEqual(response.status, 200);
-          assert.strictEqual(response.status, nativeAxios.status);
-          // TODO: ensure the headers are the same excluding unique headers
-        });
-      }
-
-      it('should return the error from the target gateway if the route is not found', async () => {
-        const axiosInstance = axios.create({
-          validateStatus: () => true, // don't throw so we can compare axios result with wrapped axios result
-        });
-        const wayfinder = new Wayfinder({
-          httpClient: axiosInstance,
-          routingStrategy: new RandomRoutingStrategy(),
-        });
-        const [nativeAxios, response] = await Promise.all([
-          axiosInstance(`https://${gatewayUrl}/ar-io/not-found`),
-          wayfinder.request('ar:///ar-io/not-found'),
-        ]);
-        assert.strictEqual(response.status, nativeAxios.status);
-      });
-    });
-
-    describe('got', () => {
-      let wayfinder: Wayfinder<typeof got>;
-      before(() => {
-        wayfinder = new Wayfinder({
-          httpClient: got,
-          routingStrategy: new RandomRoutingStrategy(),
-          gatewaysProvider: stubbedGatewaysProvider,
-        });
-      });
-
-      it('should fetch the data using the got default function against the target gateway', async () => {
-        const [nativeGot, response] = await Promise.all([
-          got(`https://ao.${gatewayUrl}`),
-          wayfinder.request('ar://ao'),
-        ]);
-        assert.strictEqual(response.statusCode, nativeGot.statusCode);
-        assert.deepStrictEqual(response.body, nativeGot.body);
-      });
-
-      it('should stream the data using got.stream against the selected target gateway', async () => {
-        const nativeBuffer = await buffer(
-          await got.stream(`https://ao.${gatewayUrl}`, {
-            decompress: false,
-            followRedirect: true,
-          }),
-        );
-        const wayfinderBuffer = await buffer(
-          await wayfinder.request.stream('ar://ao', {
-            decompress: false,
-            followRedirect: true,
-          }),
-        );
-        assert.deepStrictEqual(wayfinderBuffer, nativeBuffer);
       });
     });
   });
@@ -290,13 +148,11 @@ describe('Wayfinder', () => {
   describe('events', () => {
     it('should emit events on the wayfinder event emitter', async () => {
       const wayfinder = new Wayfinder({
-        httpClient: fetch,
         routingStrategy: new StaticRoutingStrategy({
           gateway: `http://${gatewayUrl}`,
         }),
         verificationStrategy: {
-          // @ts-expect-error
-          verifyData: async (params: { data: Buffer; txId: string }) => {
+          verifyData: async () => {
             return;
           },
         },
@@ -314,9 +170,6 @@ describe('Wayfinder', () => {
       // request data and assert the event is emitted
       const response = await wayfinder.request(
         'ar://c7wkwt6TKgcWJUfgvpJ5q5qi4DIZyJ1_TqhjXgURh0U',
-        {
-          redirect: 'follow',
-        },
       );
       // read the full response body to ensure the stream is fully consumed
       await response.text();
@@ -332,7 +185,6 @@ describe('Wayfinder', () => {
       let verificationProgress = false;
       let verificationPassed = false;
       const wayfinder = new Wayfinder({
-        httpClient: fetch,
         routingStrategy: new StaticRoutingStrategy({
           gateway: `http://${gatewayUrl}`,
         }),
@@ -351,9 +203,6 @@ describe('Wayfinder', () => {
       });
       const response = await wayfinder.request(
         'ar://c7wkwt6TKgcWJUfgvpJ5q5qi4DIZyJ1_TqhjXgURh0U',
-        {
-          redirect: 'follow',
-        },
       );
       // read the full response body to ensure the stream is fully consumed
       await response.text();
@@ -382,24 +231,21 @@ describe('Wayfinder', () => {
           // a stream that will emit chunks
           const originalStream = Readable.from(chunks);
           let seen = Buffer.alloc(0);
-          const verifyData = async ({
+
+          const verifyData: DataVerificationStrategy['verifyData'] = async ({
             data,
-            // @ts-expect-error
             txId,
-          }: {
-            data: Readable;
-            txId: string;
-          }): Promise<void> => {
+          }) => {
             return new Promise((resolve, reject) => {
-              data.on('data', (chunk) => {
+              (data as Readable).on('data', (chunk) => {
                 seen = Buffer.concat([seen, chunk]);
               });
-              data.on('end', () => {
+              (data as Readable).on('end', () => {
                 // Should have seen exactly the full payload
                 assert.strictEqual(seen.length, contentLength);
                 resolve();
               });
-              data.on('error', reject);
+              (data as Readable).on('error', reject);
             });
           };
 
@@ -458,14 +304,11 @@ describe('Wayfinder', () => {
 
           // a stream that will emit chunks
           const originalStream = Readable.from(chunks);
-          const verifyData = async ({
-            // @ts-expect-error
+
+          const verifyData: DataVerificationStrategy['verifyData'] = async ({
             data,
             txId,
-          }: {
-            data: Readable;
-            txId: string;
-          }): Promise<void> => {
+          }) => {
             throw new Error('Verification failed for txId: ' + txId);
           };
 
@@ -521,18 +364,21 @@ describe('Wayfinder', () => {
           const contentLength = chunks.reduce((sum, c) => sum + c.length, 0);
 
           // a stream that will emit chunks
-          const originalStream = ReadableStream.from(chunks);
+          const originalStream = new ReadableStream({
+            start(controller) {
+              chunks.forEach((chunk) => controller.enqueue(chunk));
+              controller.close();
+            },
+          });
+
           let seen = Buffer.alloc(0);
-          const verifyData = async ({
+
+          const verifyData: DataVerificationStrategy['verifyData'] = async ({
             data,
-            // @ts-expect-error
             txId,
-          }: {
-            data: ReadableStream;
-            txId: string;
-          }): Promise<void> => {
+          }) => {
             return new Promise(async (resolve, reject) => {
-              const reader = data.getReader();
+              const reader = (data as ReadableStream).getReader();
               while (true) {
                 try {
                   const { done, value } = await reader.read();
@@ -602,15 +448,17 @@ describe('Wayfinder', () => {
           const contentLength = chunks.reduce((sum, c) => sum + c.length, 0);
 
           // a stream that will emit chunks
-          const originalStream = ReadableStream.from(chunks);
-          const verifyData = async ({
-            // @ts-expect-error
+          const originalStream = new ReadableStream({
+            start(controller) {
+              chunks.forEach((chunk) => controller.enqueue(chunk));
+              controller.close();
+            },
+          });
+
+          const verifyData: DataVerificationStrategy['verifyData'] = async ({
             data,
             txId,
-          }: {
-            data: ReadableStream;
-            txId: string;
-          }): Promise<void> => {
+          }) => {
             throw new Error('Verification failed for txId: ' + txId);
           };
 
@@ -654,10 +502,9 @@ describe('Wayfinder', () => {
   });
 
   describe('URL resolution', () => {
-    let wayfinder: Wayfinder<typeof fetch>;
+    let wayfinder: Wayfinder;
     before(() => {
       wayfinder = new Wayfinder({
-        httpClient: fetch,
         routingStrategy: new StaticRoutingStrategy({
           gateway: `http://${gatewayUrl}`,
         }),


### PR DESCRIPTION
Some notes:
- fetch is native in both node and all major browsers - https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
- handling ReadableStreams exclusively is easier than checking the type of responses returned by other http clients, and reduces edge cases for issues
- ReadableStreams are generally easy to work with when adding event flows and notifications, as you have finer grain control of data flowing and they are portable for both node and web environments

This is technically a breaking change, but since we are in beta and fetch is used by default, those using it with custom clients will have to fix.