### PR TITLE
feat(buy-record): relax requirement for processId on buy-record

### DIFF
--- a/README.md
+++ b/README.md
@@ -1998,6 +1998,56 @@ const ant = ANT.init({
 
 ```
 
+#### `spawn({ signer, module?, ao?, scheduler?, state?, antRegistryId?, logger?, authority? })`
+
+Spawns a new ANT (Arweave Name Token) process. This static function creates a new ANT process on the AO network and returns the process ID.
+
+_Note: Requires `signer` to be provided to sign the spawn transaction._
+
+```typescript
+import { ANT } from '@ar.io/sdk';
+import { ArweaveSigner } from '@ar.io/sdk/node';
+
+const processId = await ANT.spawn({
+  signer: new ArweaveSigner(jwk),
+  state: {
+    name: 'My ANT',
+    ticker: 'MYANT',
+    description: 'My custom ANT token',
+  },
+});
+```
+
+**Parameters:**
+
+- `signer: AoSigner` - The signer used to authenticate the spawn transaction
+- `module?: string` - Optional module ID to use; if not provided, gets latest from ANT registry
+- `ao?: AoClient` - Optional AO client instance (defaults to legacy mode connection)
+- `scheduler?: string` - Optional scheduler ID
+- `state?: SpawnANTState` - Optional initial state for the ANT including name, ticker, description, etc.
+- `antRegistryId?: string` - Optional ANT registry ID
+- `logger?: Logger` - Optional logger instance
+- `authority?: string` - Optional authority
+
+**Returns:** `Promise<ProcessId>` - The process ID of the newly spawned ANT
+
+#### `versions`
+
+Returns an ANTVersions instance that provides access to available ANT versions from the ANT registry. This static property allows you to query version information without needing a specific ANT process.
+
+```typescript
+import { ANT } from '@ar.io/sdk';
+
+// Get all available ANT versions
+const antVersions = ANT.versions;
+const versions = await antVersions.getANTVersions();
+
+// Get the latest ANT version
+const latestVersion = await antVersions.getLatestANTVersion();
+```
+
+**Returns:** `AoANTVersionsRead` - A read-only ANT versions client
+
 #### `getInfo()`
 
 Retrieves the information of the ANT process.

--- a/README.md
+++ b/README.md
@@ -1233,9 +1233,17 @@ const record = await ario.resolveArNSName({ name: 'logo_ardrive' });
 
 #### `buyRecord({ name, type, years, processId })`
 
-Purchases a new ArNS record with the specified name, type, and duration.
+Purchases a new ArNS record with the specified name, type, processId, and duration.
 
 _Note: Requires `signer` to be provided on `ARIO.init` to sign the transaction._
+
+**Arguments:**
+
+- `name` - _required_: the name of the ArNS record to purchase
+- `type` - _required_: the type of ArNS record to purchase
+- `processId` - _optional_: the process id of an existing ANT process. If not provided, a new ANT process using the provided `signer` will be spawned, and the ArNS record will be assigned to that process.
+- `years` - _optional_: the duration of the ArNS record in years. If not provided and `type` is `lease`, the record will be leased for 1 year. If not provided and `type` is `permabuy`, the record will be permanently registered.
+- `referrer` - _optional_: track purchase referrals for analytics (e.g. `my-app.com`)
 
 ```typescript
 const ario = ARIO.mainnet({ signer });
@@ -1244,6 +1252,7 @@ const record = await ario.buyRecord(
     name: 'ardrive',
     type: 'lease',
     years: 1,
+    processId: 'bh9l1cy0aksiL_x9M359faGzM_yjralacHIUo8_nQXM', // optional: assign to existing ANT process
     referrer: 'my-app.com', // optional: track purchase referrals for analytics
   },
   {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -603,6 +603,8 @@ makeCommand({
   action: buyRecordCLICommand,
 });
 
+// TODO alias buy-record with buy-name
+
 makeCommand({
   name: 'upgrade-record',
   description: 'Upgrade the lease of a record to a permabuy',

--- a/src/cli/commands/arnsPurchaseCommands.ts
+++ b/src/cli/commands/arnsPurchaseCommands.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ANT } from '../../common/ant.js';
 import {
   AoArNSPurchaseParams,
   AoBuyRecordParams,
@@ -43,12 +44,7 @@ export async function buyRecordCLICommand(
   const years = positiveIntegerFromOptions(o, 'years');
   const fundFrom = fundFromFromOptions(o);
   const referrer = referrerFromOptions(o);
-
   const processId = o.processId;
-  if (processId === undefined) {
-    // TODO: Spawn ANT process, register it to ANT registry, get process ID
-    throw new Error('Process ID must be provided for buy-record');
-  }
 
   if (!o.skipConfirmation) {
     const existingRecord = await ario.getArNSRecord({
@@ -71,8 +67,15 @@ export async function buyRecordCLICommand(
       },
     });
 
+    // assert spawn new ant with module id
+    let antSpawnConfirmation = '';
+    if (processId === undefined) {
+      const { moduleId, version } = await ANT.versions.getLatestANTVersion();
+      antSpawnConfirmation = `Note: A new ANT process will be spawned with module ${moduleId} (v${version})) and assigned to this name.`;
+    }
+
     await assertConfirmationPrompt(
-      `Are you sure you want to ${type} the record ${name}?`,
+      `Are you sure you want to ${type} the record ${name}? ${antSpawnConfirmation}`,
       o,
     );
   }

--- a/src/cli/commands/arnsPurchaseCommands.ts
+++ b/src/cli/commands/arnsPurchaseCommands.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ANT } from '../../common/ant.js';
+import { ANTVersions } from '../../common/ant-versions.js';
 import {
   AoArNSPurchaseParams,
   AoBuyRecordParams,
@@ -70,8 +70,9 @@ export async function buyRecordCLICommand(
     // assert spawn new ant with module id
     let antSpawnConfirmation = '';
     if (processId === undefined) {
-      const { moduleId, version } = await ANT.versions.getLatestANTVersion();
-      antSpawnConfirmation = `Note: A new ANT process will be spawned with module ${moduleId} (v${version})) and assigned to this name.`;
+      const { moduleId, version } =
+        await ANTVersions.init().getLatestANTVersion();
+      antSpawnConfirmation = `Note: A new ANT process will be spawned with module ${moduleId} (v${version}) and assigned to this name.`;
     }
 
     await assertConfirmationPrompt(

--- a/src/cli/commands/arnsPurchaseCommands.ts
+++ b/src/cli/commands/arnsPurchaseCommands.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ANTVersions } from '../../common/ant-versions.js';
+import { ANT } from '../../common/ant.js';
 import {
   AoArNSPurchaseParams,
   AoBuyRecordParams,
@@ -70,8 +70,7 @@ export async function buyRecordCLICommand(
     // assert spawn new ant with module id
     let antSpawnConfirmation = '';
     if (processId === undefined) {
-      const { moduleId, version } =
-        await ANTVersions.init().getLatestANTVersion();
+      const { moduleId, version } = await ANT.versions.getLatestANTVersion();
       antSpawnConfirmation = `Note: A new ANT process will be spawned with module ${moduleId} (v${version}) and assigned to this name.`;
     }
 

--- a/src/common/ant.ts
+++ b/src/common/ant.ts
@@ -70,8 +70,12 @@ type ANTConfig = ANTConfigNoSigner | ANTConfigWithSigner;
 export class ANT {
   /**
    * Versions of ANTs according to the ANT registry.
+   *
+   * Needs to be wrapped in a getter to avoid circular dependency issues.
    */
-  static versions = ANTVersions.init();
+  static get versions() {
+    return ANTVersions.init();
+  }
   /**
    * Spawn a new ANT.
    */

--- a/src/common/ant.ts
+++ b/src/common/ant.ts
@@ -31,7 +31,6 @@ import {
   AoANTSetBaseNameRecordParams,
   AoANTSetUndernameRecordParams,
   AoANTState,
-  AoANTVersionsRead,
   AoANTWrite,
   HyperBeamANTState,
   SortedANTRecords,
@@ -51,7 +50,7 @@ import {
   isHyperBeamANTState,
   sortANTRecords,
 } from '../utils/ant.js';
-import { createAoSigner } from '../utils/ao.js';
+import { createAoSigner, spawnANT } from '../utils/ao.js';
 import { parseSchemaResult } from '../utils/schema.js';
 import { ANTVersions } from './ant-versions.js';
 import {
@@ -69,7 +68,14 @@ type ANTConfigWithSigner = WithSigner<ANTConfigOptionalStrict>;
 type ANTConfig = ANTConfigNoSigner | ANTConfigWithSigner;
 
 export class ANT {
-  static versions: AoANTVersionsRead = ANTVersions.init();
+  /**
+   * Versions of ANTs according to the ANT registry.
+   */
+  static versions = ANTVersions.init();
+  /**
+   * Spawn a new ANT.
+   */
+  static spawn = spawnANT;
   // no signer give read
   static init(config: ANTConfigNoSigner): AoANTRead;
 

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -88,7 +88,7 @@ import {
   isProcessIdConfiguration,
   mARIOToken,
 } from '../types/index.js';
-import { createAoSigner } from '../utils/ao.js';
+import { createAoSigner, spawnANT } from '../utils/ao.js';
 import {
   getEpochDataFromGqlWithCUFallback,
   paginationParamsToTags,
@@ -101,6 +101,7 @@ import { defaultArweave } from './arweave.js';
 import { AOProcess } from './contracts/ao-process.js';
 import { InvalidContractConfigurationError } from './error.js';
 import { createFaucet } from './faucet.js';
+import { Logger } from './logger.js';
 import {
   TurboArNSPaymentFactory,
   TurboArNSPaymentProviderAuthenticated,
@@ -214,6 +215,7 @@ export class ARIOReadable implements AoARIORead, ArNSNameResolver {
   protected epochSettings: AoEpochSettings | undefined;
   protected arweave: Arweave;
   protected paymentProvider: TurboArNSPaymentProviderUnauthenticated; // TODO: this could be an array/map of payment providers
+  protected logger = Logger.default;
 
   constructor(config?: ARIOConfigNoSigner) {
     this.arweave = config?.arweave ?? defaultArweave;
@@ -1420,6 +1422,20 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
     params: AoBuyRecordParams,
     options?: WriteOptions,
   ): Promise<AoMessageResult> {
+    // spawn a new ANT if not provided
+    if (params.processId === undefined) {
+      try {
+        params.processId = await spawnANT({
+          signer: this.signer,
+          ao: this.process.ao,
+          logger: this.logger,
+        });
+      } catch (error) {
+        throw new Error('Failed to spawn ANT for name purchase.', error);
+      }
+    }
+
+    // pay with turbo credits if available
     if (params.fundFrom === 'turbo') {
       if (
         !(this.paymentProvider instanceof TurboArNSPaymentProviderAuthenticated)

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -88,7 +88,7 @@ import {
   isProcessIdConfiguration,
   mARIOToken,
 } from '../types/index.js';
-import { createAoSigner, spawnANT } from '../utils/ao.js';
+import { createAoSigner } from '../utils/ao.js';
 import {
   getEpochDataFromGqlWithCUFallback,
   paginationParamsToTags,

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -1425,7 +1425,7 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
     // spawn a new ANT if not provided
     if (params.processId === undefined) {
       try {
-        params.processId = await spawnANT({
+        params.processId = await ANT.spawn({
           signer: this.signer,
           ao: this.process.ao,
           logger: this.logger,

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -1431,7 +1431,10 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
           logger: this.logger,
         });
       } catch (error) {
-        throw new Error('Failed to spawn ANT for name purchase.', error);
+        this.logger.error('Failed to spawn ANT for name purchase.', {
+          error,
+        });
+        throw error;
       }
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,7 +42,14 @@ export const ARIO_MAINNET_PROCESS_ID =
 
 export const ANT_REGISTRY_ID = 'i_le_yKKPVstLTDSmkHRqf-wYphMnwB9OhleiTgMkWc';
 export const MARIO_PER_ARIO = 1_000_000;
+
+/**
+ * @deprecated - use ANTVersions.getLatestANTVersion() to get latest ANT module
+ **/
 export const AOS_MODULE_ID = 'pb4fCvdJqwT-_bn38ERMdqnOF4weRMjoJ6bY6yfl4a8';
+/**
+ * @deprecated - use ANTVersions.getLatestANTVersions() to get latest ANT module
+ **/
 export const ANT_LUA_ID = 'OO2ewZKq4AHoqGQmYUIl-NhJ-llQyFJ3ha4Uf4-w5RI';
 
 export const AO_AUTHORITY = 'fcoN_xJeisVsPXA-trzVAuIiqO3ydLQxM-L4XbrQKzY';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -44,11 +44,11 @@ export const ANT_REGISTRY_ID = 'i_le_yKKPVstLTDSmkHRqf-wYphMnwB9OhleiTgMkWc';
 export const MARIO_PER_ARIO = 1_000_000;
 
 /**
- * @deprecated - use ANTVersions.getLatestANTVersion() to get latest ANT module
+ * @deprecated - use ANT.versions.getLatestANTVersion() to get latest ANT module
  **/
 export const AOS_MODULE_ID = 'pb4fCvdJqwT-_bn38ERMdqnOF4weRMjoJ6bY6yfl4a8';
 /**
- * @deprecated - use ANTVersions.getLatestANTVersions() to get latest ANT module
+ * @deprecated - use ANT.versions.getLatestANTVersion() to get latest ANT module
  **/
 export const ANT_LUA_ID = 'OO2ewZKq4AHoqGQmYUIl-NhJ-llQyFJ3ha4Uf4-w5RI';
 

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -488,7 +488,7 @@ export type AoArNSPurchaseParams = AoArNSNameParams & {
 export type AoBuyRecordParams = AoArNSPurchaseParams & {
   years?: number;
   type: 'lease' | 'permabuy';
-  processId: string;
+  processId?: string;
 };
 
 export type AoExtendLeaseParams = AoArNSPurchaseParams & {

--- a/src/utils/ao.ts
+++ b/src/utils/ao.ts
@@ -78,8 +78,11 @@ export async function spawnANT({
 
   if (module === undefined) {
     const antVersions = ANTVersions.init({
-      processId: antRegistryId,
-      // TODO: allow passing ao to init
+      process: new AOProcess({
+        processId: antRegistryId,
+        ao,
+        logger,
+      }),
     });
     const { moduleId: latestAntModule, version } =
       await antVersions.getLatestANTVersion();

--- a/src/utils/ao.ts
+++ b/src/utils/ao.ts
@@ -59,7 +59,6 @@ export type SpawnANTParams = {
    * @deprecated no longer in use due to compiled modules being preferred
    */
   arweave?: Arweave;
-  owner?: WalletAddress;
 };
 
 export async function spawnANT({

--- a/src/utils/ao.ts
+++ b/src/utils/ao.ts
@@ -216,39 +216,39 @@ export async function spawnANT({
    * This is to ensure the ANT is available via the ANT registry
    * for the owner to find and use the ANT.
    */
-  if (owner !== undefined) {
-    // check the ACL for the owner
-    const antRegistry = ANTRegistry.init({
-      signer,
-      processId: antRegistryId,
-    });
-    let attempts = 0;
-    const maxAttempts = 5;
-    while (attempts < maxAttempts) {
-      try {
-        const acl = await antRegistry.accessControlList({ address: owner });
-        if (acl === undefined) {
-          throw new Error('ACL not found for owner');
-        }
-        const { Owned } = acl;
-        if (!Owned.includes(processId)) {
-          throw new Error(
-            `Spawned ANT (${processId}) not found in registry for owner ${owner}`,
-          );
-        }
-        return processId;
-      } catch (error) {
-        logger.debug('Retrying ANT registry access control list fetch', {
-          owner,
-          antRegistryId,
-          attempts,
-          error,
-        });
-        attempts++;
-        await new Promise((resolve) =>
-          setTimeout(resolve, 1000 * attempts ** 2),
+  if (owner === undefined) {
+    throw new Error(`Spawning ANT (${processId}) failed to set owner`);
+  }
+
+  // check the ACL for the owner
+  const antRegistry = ANTRegistry.init({
+    signer,
+    processId: antRegistryId,
+  });
+  let attempts = 0;
+  const maxAttempts = 5;
+  while (attempts < maxAttempts) {
+    try {
+      const acl = await antRegistry.accessControlList({ address: owner });
+      if (acl === undefined) {
+        throw new Error('ACL not found for owner');
+      }
+      const { Owned } = acl;
+      if (!Owned.includes(processId)) {
+        throw new Error(
+          `Spawned ANT (${processId}) not found in registry for owner ${owner}`,
         );
       }
+      return processId;
+    } catch (error) {
+      logger.debug('Retrying ANT registry access control list fetch', {
+        owner,
+        antRegistryId,
+        attempts,
+        error,
+      });
+      attempts++;
+      await new Promise((resolve) => setTimeout(resolve, 1000 * attempts ** 2));
     }
   }
 


### PR DESCRIPTION
Adds support for spawning new ANT with latest module if not provided if processId is not provided. This should make it easier to buy names with latest ANT modules.

Testing:
```
❯ node lib/esm/cli/cli.js buy-record --testnet --name dtf3 --type lease --wallet-file ~/Documents/wallets/QGWqtJdLLgm2ehFWiiPzMaoFLD50CnGuzZIPEdoDRGQ.json
✔ Are you sure you want to lease the record dtf3? Note: A new ANT process will be spawned with module nEjlSFA_8narJlVHApbczDPkMc9znSqYtqtf1iOdoxM (v22) and assigned to this name. … yes

{
  "id": "E1vkcQsJvY0o0ZIqWVUWP8MdB2VPBYJJsZSdDPAhEKM",
  "result": {
    "endTimestamp": 1785514727303,
    "purchasePrice": 14448000000,
    "name": "dtf3",
    "fundingResult": {
      "totalFunded": 14448000000,
      "newWithdrawVaults": []
    },
    "remainingBalance": 834961104000000,
    "baseRegistrationFee": 10000000000,
    "startTimestamp": 1753978727303,
    "type": "lease",
    "fundingPlan": {
      "shortfall": 0,
      "balance": 14448000000,
      "address": "QGWqtJdLLgm2ehFWiiPzMaoFLD50CnGuzZIPEdoDRGQ",
      "stakes": []
    },
    "processId": "J6ecljMzC8s0oIsvBMe8Ks5vHB3PWH6AjVixQU6OTak",
    "undernameLimit": 10
  }
}
```

The process created has the default state set by the ANT source code
```bash
❯ ar.io get-ant-state --process-id J6ecljMzC8s0oIsvBMe8Ks5vHB3PWH6AjVixQU6OTak --cu-url https://cu.ardrive.io
{
  "TotalSupply": 1,
  "Ticker": "ANT",
  "Keywords": [],
  "Records": {
    "@": {
      "ttlSeconds": 900,
      "transactionId": "-k7t8xMoB8hW482609Z9F4bTFMC3MnuW8bTvTyT8pFI",
      "priority": 0
    }
  },
  "Controllers": [
    "QGWqtJdLLgm2ehFWiiPzMaoFLD50CnGuzZIPEdoDRGQ"
  ],
  "Denomination": 0,
  "Initialized": false,
  "Owner": "QGWqtJdLLgm2ehFWiiPzMaoFLD50CnGuzZIPEdoDRGQ",
  "Balances": {
    "QGWqtJdLLgm2ehFWiiPzMaoFLD50CnGuzZIPEdoDRGQ": 1
  },
  "Logo": "Sie_26dvgyok0PZD_-iQAFOhOd5YxDTkczOLoqTTL_A",
  "Name": "aos",
  "Description": "A brief description of this ANT."
}
```
and the record is assigned the process id
```bash
❯ ar.io get-arns-record --name dtf3 --testnet
{
  "processId": "J6ecljMzC8s0oIsvBMe8Ks5vHB3PWH6AjVixQU6OTak",
  "startTimestamp": 1753978727303,
  "type": "lease",
  "endTimestamp": 1785514727303,
  "purchasePrice": 14448000000,
  "undernameLimit": 10
}
```