### PR TITLE
feat(arns): add support for `setPrimaryName` API, which allows the ow…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1970,9 +1970,21 @@ const name = await ario.getPrimaryName({
 
 </details>
 
+#### `setPrimaryName({ name })`
+
+Sets an ArNS name already owned by the `signer` as their primary name. Note: `signer` must be the owner of the `processId` that is assigned to the name. If not, the transaction will fail.
+
+_Note: Requires `signer` to be provided on `ARIO.init` to sign the transaction._
+
+```typescript
+const signer = new ArweaveSigner(jwk);
+const ario = ARIO.mainnet({ signer });
+await ario.setPrimaryName({ name: 'my-arns-name' }); // the caller must already have purchased the name my-arns-name and be assigned as the owner of the processId that is assigned to the name
+```
+
 #### `requestPrimaryName({ name })`
 
-Requests a primary name for the caller's address. The request must be approved by the new owner of the requested name via the `approvePrimaryNameRequest`[#approveprimarynamerequest-name-address-] API.
+Requests a primary name for the `signer`'s address. The request must be approved by the new owner of the requested name via the `approvePrimaryNameRequest`[#approveprimarynamerequest-name-address-] API.
 
 _Note: Requires `signer` to be provided on `ARIO.init` to sign the transaction._
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -30,6 +30,7 @@ import {
   extendLeaseCLICommand,
   increaseUndernameLimitCLICommand,
   requestPrimaryNameCLICommand,
+  setPrimaryNameCLICommand,
   upgradeRecordCLICommand,
 } from './commands/arnsPurchaseCommands.js';
 import {
@@ -355,6 +356,13 @@ makeCommand<InitiatorCLIOptions>({
             message: `No primary name request found`,
           },
       ),
+});
+
+makeCommand<AddressAndNameCLIOptions>({
+  name: 'set-primary-name',
+  description: 'Set primary name',
+  options: [optionMap.address, optionMap.name],
+  action: setPrimaryNameCLICommand,
 });
 
 makeCommand<AddressCLIOptions>({

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -358,13 +358,6 @@ makeCommand<InitiatorCLIOptions>({
       ),
 });
 
-makeCommand<AddressAndNameCLIOptions>({
-  name: 'set-primary-name',
-  description: 'Set primary name',
-  options: [optionMap.address, optionMap.name],
-  action: setPrimaryNameCLICommand,
-});
-
 makeCommand<AddressCLIOptions>({
   name: 'get-redelegation-fee',
   description: 'Get redelegation fee',
@@ -651,6 +644,13 @@ makeCommand({
   description: 'Request a primary name',
   options: arnsPurchaseOptions,
   action: requestPrimaryNameCLICommand,
+});
+
+makeCommand<AddressAndNameCLIOptions>({
+  name: 'set-primary-name',
+  description: 'Set an ArNS name you own as your primary name',
+  options: arnsPurchaseOptions,
+  action: setPrimaryNameCLICommand,
 });
 
 // # ANT Registry

--- a/src/cli/commands/arnsPurchaseCommands.ts
+++ b/src/cli/commands/arnsPurchaseCommands.ts
@@ -259,7 +259,7 @@ export async function requestPrimaryNameCLICommand(
     );
   }
 
-  return ario.requestPrimaryName(
+  const { result } = await ario.requestPrimaryName(
     {
       name,
       fundFrom,
@@ -268,4 +268,28 @@ export async function requestPrimaryNameCLICommand(
     },
     customTagsFromOptions(o),
   );
+
+  if (result?.request === undefined) {
+    throw new Error('Failed to request primary name for name ' + name);
+  }
+
+  return result.request;
+}
+
+export async function setPrimaryNameCLICommand(
+  o: CLIWriteOptionsFromAoParams<AoArNSPurchaseParams>,
+) {
+  const { ario, signerAddress } = writeARIOFromOptions(o);
+  const name = requiredStringFromOptions(o, 'name');
+  const fundFrom = fundFromFromOptions(o);
+  const referrer = referrerFromOptions(o);
+
+  if (!o.skipConfirmation) {
+    await assertConfirmationPrompt(
+      `Are you sure you want to set the primary name ${name} for address ${signerAddress}?`,
+      o,
+    );
+  }
+
+  return ario.setPrimaryName({ name, fundFrom, referrer });
 }

--- a/src/cli/commands/arnsPurchaseCommands.ts
+++ b/src/cli/commands/arnsPurchaseCommands.ts
@@ -240,8 +240,6 @@ export async function requestPrimaryNameCLICommand(
   const name = requiredStringFromOptions(o, 'name');
 
   if (!o.skipConfirmation) {
-    // TODO: Assert name requested is not already owned?
-    // TODO: More assertions?
     await assertEnoughBalanceForArNSPurchase({
       ario,
       address: signerAddress,
@@ -259,7 +257,7 @@ export async function requestPrimaryNameCLICommand(
     );
   }
 
-  return ario.requestPrimaryName(
+  const { result } = await ario.requestPrimaryName(
     {
       name,
       fundFrom,
@@ -268,6 +266,12 @@ export async function requestPrimaryNameCLICommand(
     },
     customTagsFromOptions(o),
   );
+
+  if (result?.request === undefined) {
+    throw new Error('Failed to request primary name for name ' + name);
+  }
+
+  return result.request;
 }
 
 export async function setPrimaryNameCLICommand(

--- a/src/cli/commands/arnsPurchaseCommands.ts
+++ b/src/cli/commands/arnsPurchaseCommands.ts
@@ -259,7 +259,7 @@ export async function requestPrimaryNameCLICommand(
     );
   }
 
-  const { result } = await ario.requestPrimaryName(
+  return ario.requestPrimaryName(
     {
       name,
       fundFrom,
@@ -268,12 +268,6 @@ export async function requestPrimaryNameCLICommand(
     },
     customTagsFromOptions(o),
   );
-
-  if (result?.request === undefined) {
-    throw new Error('Failed to request primary name for name ' + name);
-  }
-
-  return result.request;
 }
 
 export async function setPrimaryNameCLICommand(

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -1739,7 +1739,6 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
     // create the primary name request, if it already exists, get the request and base name owner
     const requestResult = await this.requestPrimaryName(params, options).catch(
       async (error) => {
-        console.log('error', error);
         // check for the error message, it may be due to the request already being made
         if (error.message.includes('already exists')) {
           // parse out the initiator from the error message `		"Primary name request by '" .. initiator .. "' for '" .. name .. "' already exists"
@@ -1771,6 +1770,9 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
             result: {
               request: primaryNameRequest,
               baseNameOwner: arnsRecord.processId,
+              fundingPlan: {
+                address: initiator,
+              },
             },
           };
         }
@@ -1779,12 +1781,16 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
       },
     );
 
+    // the result is either a new primary name request or an existing one
+    // for new primary name requests the result includes the request, funding plan, and base name owner
+    // for existing primary name requests the result includes just the request and base name owner
+    const primaryNameRequest = requestResult.result;
+
     const initiator =
-      requestResult.result?.request?.initiator === undefined
-        ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          requestResult.result?.fundingPlan?.address
-        : requestResult.result?.request?.initiator;
+      primaryNameRequest?.request?.initiator ??
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      primaryNameRequest?.fundingPlan?.address;
     if (
       initiator === undefined ||
       requestResult.result?.baseNameOwner === undefined

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -34,6 +34,7 @@ import {
   AoArNSReservedNameDataWithName,
   AoBalanceWithAddress,
   AoBuyRecordParams,
+  AoCreatePrimaryNameRequest,
   AoCreateVaultParams,
   AoDelegation,
   AoEligibleDistribution,
@@ -1702,7 +1703,7 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
   async requestPrimaryName(
     params: AoArNSPurchaseParams,
     options?: WriteOptions,
-  ): Promise<AoMessageResult<AoPrimaryNameRequest>> {
+  ): Promise<AoMessageResult<AoCreatePrimaryNameRequest>> {
     if (params.fundFrom === 'turbo') {
       throw new Error(
         'Turbo funding is not yet supported for primary name requests',
@@ -1729,59 +1730,89 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
       SetPrimaryNameProgressEvents[keyof SetPrimaryNameProgressEvents]
     >,
   ): Promise<AoMessageResult> {
-    options?.onSigningProgress?.('validating-request', params);
-
-    // check the name exists
-    const arnsRecord = await this.getArNSRecord({ name: params.name });
-    if (arnsRecord === undefined) {
-      throw new Error(`ARNS name '${params.name}' does not exist`);
-    }
-
-    const antClient = ANT.init({
-      process: new AOProcess({
-        processId: arnsRecord.processId,
-        ao: this.process.ao,
-      }),
-      signer: this.signer,
-    });
-
-    // TODO: we could allow user to forcefully remove an existing primary name if they want to
-
-    // TODO: uncomment this when we have a way to get the owner address of the current signer
-    // const signerAddress = await this.signer.getAddress();
-    // const antOwner = await antClient.getOwner();
-    // if (antOwner !== signerAddress) {
-    //   throw new Error(
-    //     `Signer ${signerAddress} is not the owner of ANT process ${processId} for name '${params.name}'. Owner is ${antOwner}`,
-    //   );
-    // }
-
     options?.onSigningProgress?.('requesting-primary-name', {
       name: params.name,
       fundFrom: params.fundFrom,
       referrer: params.referrer,
-      processId: arnsRecord.processId,
     });
 
-    // create the primary name request
-    const requestResult = await this.requestPrimaryName(params, options);
-    if (!requestResult.id || requestResult.result?.initiator === undefined) {
-      throw new Error('Failed to request primary name for name ' + params.name);
+    // create the primary name request, if it already exists, get the request and base name owner
+    const requestResult = await this.requestPrimaryName(params, options).catch(
+      async (error) => {
+        console.log('error', error);
+        // check for the error message, it may be due to the request already being made
+        if (error.message.includes('already exists')) {
+          // parse out the initiator from the error message `		"Primary name request by '" .. initiator .. "' for '" .. name .. "' already exists"
+          const initiator = error.message.match(/by '([^']+)'/)?.[1];
+          if (initiator === undefined) {
+            throw error;
+          }
+          options?.onSigningProgress?.('request-already-exists', {
+            name: params.name,
+            initiator,
+          });
+          // get the primary name request
+          const primaryNameRequest = await this.getPrimaryNameRequest({
+            initiator,
+          });
+          // check the name exists
+          const arnsRecord = await this.getArNSRecord({ name: params.name });
+          // TODO: potentially provide callback saying primary name request already exists
+          if (arnsRecord === undefined) {
+            throw new Error(`ARNS name '${params.name}' does not exist`);
+          }
+          if (primaryNameRequest.initiator !== initiator) {
+            throw new Error(
+              `Primary name request for name '${params.name}' was not approved`,
+            );
+          }
+          return {
+            id: 'stub-id', // stub-id to indicate that the request already exists
+            result: {
+              request: primaryNameRequest,
+              baseNameOwner: arnsRecord.processId,
+            },
+          };
+        }
+        // throw any other errors from the contract
+        throw error;
+      },
+    );
+
+    const initiator =
+      requestResult.result?.request?.initiator === undefined
+        ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          requestResult.result?.fundingPlan?.address
+        : requestResult.result?.request?.initiator;
+    if (
+      initiator === undefined ||
+      requestResult.result?.baseNameOwner === undefined
+    ) {
+      throw new Error(
+        `Failed to request primary name ${params.name} for ${initiator}`,
+      );
     }
 
     options?.onSigningProgress?.('approving-request', {
       name: params.name,
-      initiator: requestResult.result?.initiator,
-      startTimestamp: requestResult.result?.startTimestamp,
-      endTimestamp: requestResult.result?.endTimestamp,
-      processId: this.process.processId,
+      processId: requestResult.result?.baseNameOwner,
+      request: requestResult.result?.request,
+    });
+
+    const antClient = ANT.init({
+      process: new AOProcess({
+        processId: requestResult.result?.baseNameOwner,
+        ao: this.process.ao,
+      }),
+      signer: this.signer,
     });
 
     // approve the primary name request with the ant
     const approveResult = await antClient.approvePrimaryNameRequest(
       {
         name: params.name,
-        address: requestResult.result?.initiator,
+        address: initiator,
         arioProcessId: this.process.processId,
       },
       options,

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -91,6 +91,17 @@ export type AoPrimaryNameRequest = {
   endTimestamp: Timestamp;
 };
 
+export type AoCreatePrimaryNameRequest = {
+  request: Omit<AoPrimaryNameRequest, 'initiator'> & {
+    initiator: WalletAddress;
+  };
+  newPrimaryName: AoPrimaryName;
+  baseNameOwner: WalletAddress;
+  fundingPlan: Record<string, unknown>;
+  fundingResult: Record<string, unknown>;
+  demandFactor: Record<string, unknown>;
+};
+
 export type AoPrimaryName = {
   owner: WalletAddress;
   processId: ProcessId;
@@ -165,11 +176,16 @@ export type BuyArNSNameProgressEvents = SpawnAntProgressEvent & {
 };
 
 export type SetPrimaryNameProgressEvents = {
-  'validating-request': AoArNSPurchaseParams;
-  'requesting-primary-name': AoArNSPurchaseParams & {
+  'requesting-primary-name': AoArNSPurchaseParams;
+  'request-already-exists': {
+    name: string;
+    initiator: WalletAddress;
+  };
+  'approving-request': {
+    request: AoPrimaryNameRequest;
+    name: string;
     processId: ProcessId;
   };
-  'approving-request': AoPrimaryNameRequest;
 };
 
 export interface AOContract {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -32,7 +32,7 @@ import {
 import Arweave from 'arweave';
 
 import { SpawnANTState } from './ant.js';
-import { AoBuyRecordParams } from './io.js';
+import { AoArNSPurchaseParams, AoBuyRecordParams } from './io.js';
 import { AoSigner } from './token.js';
 
 export type BlockHeight = number;
@@ -162,6 +162,14 @@ export type SpawnAntProgressEvent = {
 
 export type BuyArNSNameProgressEvents = SpawnAntProgressEvent & {
   'buying-name': AoBuyRecordParams;
+};
+
+export type SetPrimaryNameProgressEvents = {
+  'validating-request': AoArNSPurchaseParams;
+  'requesting-primary-name': AoArNSPurchaseParams & {
+    processId: ProcessId;
+  };
+  'approving-request': AoPrimaryNameRequest;
 };
 
 export interface AOContract {

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -16,6 +16,7 @@
 import { AOProcess } from '../common/index.js';
 import { validateArweaveId } from '../utils/arweave.js';
 import {
+  AoCreatePrimaryNameRequest,
   AoMessageResult,
   AoPrimaryName,
   AoPrimaryNameRequest,
@@ -747,7 +748,10 @@ export interface AoARIOWrite extends AoARIORead {
     gatewayAddress?: WalletAddress;
     vaultId: string;
   }>;
-  requestPrimaryName: AoWriteAction<AoArNSPurchaseParams>;
+  requestPrimaryName(
+    params: AoArNSPurchaseParams,
+    options?: WriteOptions,
+  ): Promise<AoMessageResult<AoCreatePrimaryNameRequest>>;
   setPrimaryName: AoWriteAction<AoArNSPurchaseParams>;
   redelegateStake: AoWriteAction<AoRedelegateStakeParams>;
 }

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -748,6 +748,7 @@ export interface AoARIOWrite extends AoARIORead {
     vaultId: string;
   }>;
   requestPrimaryName: AoWriteAction<AoArNSPurchaseParams>;
+  setPrimaryName: AoWriteAction<AoArNSPurchaseParams>;
   redelegateStake: AoWriteAction<AoRedelegateStakeParams>;
 }
 

--- a/src/utils/ao.ts
+++ b/src/utils/ao.ts
@@ -485,7 +485,10 @@ export function parseAoEpochData(
 
 export function errorMessageFromOutput(output: {
   Error?: string;
-  Messages?: { Tags?: { name: string; value: string }[] }[];
+  Messages?: {
+    Tags?: { name: string; value: string }[];
+    Data?: string;
+  }[];
 }): string | undefined {
   const errorData = output.Error;
 
@@ -495,9 +498,11 @@ export function errorMessageFromOutput(output: {
     output.Messages?.[0]?.Tags?.find((tag) => tag.name === 'Error')?.value;
 
   if (error !== undefined) {
+    const errorStackTrace = output.Messages?.[0]?.Data;
+    const errorMessage = errorStackTrace ?? error;
     // Regex to match AO error messages like: [string ".src.main"]:5111: Primary name data not found
     // or [string "aos"]:128: some error
-    const match = error.match(/\[string "(.+)"\]:(\d+):\s*(.*)/);
+    const match = errorMessage?.match(/\[string "(.+)"\]:(\d+):\s*(.*)/);
     if (match) {
       // The first group is the src file, the second is the line number, and the third is the error message
       const [, , lineNumber, errorMessage] = match;


### PR DESCRIPTION
…ner of an ANT that controls an ArNS name set their primary name in a single API