### PR TITLE
fix(turbo): apply publicKey to signed req headers on node PE-8459

### DIFF
--- a/src/common/turbo.ts
+++ b/src/common/turbo.ts
@@ -86,6 +86,10 @@ export async function signedRequestHeadersFromSigner({
     if ('setPublicKey' in signer && signer['publicKey'] === undefined) {
       await signer.setPublicKey();
     }
+
+    if (signer.publicKey !== undefined) {
+      publicKey = toB64Url(signer.publicKey);
+    }
     signature = toB64Url(
       Buffer.from(await signer.sign(Uint8Array.from(Buffer.from(nonce)))),
     );

--- a/src/common/turbo.ts
+++ b/src/common/turbo.ts
@@ -86,10 +86,6 @@ export async function signedRequestHeadersFromSigner({
     if ('setPublicKey' in signer && signer['publicKey'] === undefined) {
       await signer.setPublicKey();
     }
-
-    if (signer.publicKey !== undefined) {
-      publicKey = toB64Url(signer.publicKey);
-    }
     signature = toB64Url(
       Buffer.from(await signer.sign(Uint8Array.from(Buffer.from(nonce)))),
     );
@@ -102,7 +98,10 @@ export async function signedRequestHeadersFromSigner({
       } else if ('setPublicKey' in signer) {
         await signer.setPublicKey();
         publicKey = toB64Url(signer.publicKey);
+      } else if ((signer as ArweaveSigner).publicKey !== undefined) {
+        publicKey = toB64Url((signer as ArweaveSigner).publicKey);
       }
+
       break;
     case SignatureConfig.ETHEREUM:
       if ('publicKey' in signer) {

--- a/src/common/turbo.ts
+++ b/src/common/turbo.ts
@@ -98,7 +98,7 @@ export async function signedRequestHeadersFromSigner({
       } else if ('setPublicKey' in signer) {
         await signer.setPublicKey();
         publicKey = toB64Url(signer.publicKey);
-      } else if ((signer as ArweaveSigner).publicKey !== undefined) {
+      } else if ('publicKey' in signer) {
         publicKey = toB64Url((signer as ArweaveSigner).publicKey);
       }
 

--- a/src/common/turbo.ts
+++ b/src/common/turbo.ts
@@ -99,7 +99,7 @@ export async function signedRequestHeadersFromSigner({
         await signer.setPublicKey();
         publicKey = toB64Url(signer.publicKey);
       } else if ('publicKey' in signer) {
-        publicKey = toB64Url((signer as ArweaveSigner).publicKey);
+        publicKey = toB64Url(signer.publicKey);
       }
 
       break;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * Ensures Arweave-based signers now consistently include public keys in request headers, preventing intermittent authentication/signing failures.

* Improvements
  * Improves reliability and interoperability of signed requests across wallets/providers by using available signer public keys as a fallback for more consistent request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->