### PR TITLE
chore: release 3.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [3.18.0-alpha.4](https://github.com/ar-io/ar-io-sdk/compare/v3.18.0-alpha.3...v3.18.0-alpha.4) (2025-08-15)
+
+
+### Bug Fixes
+
+* **buyRecord:** add arns name as Name tag to spawn ([e23dde4](https://github.com/ar-io/ar-io-sdk/commit/e23dde414195bfd881568cb941a3ad11df493878))
+* **buyRecord:** default to arns name tag if no Name tag provided ([2d0487d](https://github.com/ar-io/ar-io-sdk/commit/2d0487d11500d074e9eaab782139dec300f92713))
+* **buyRecord:** pass tags option to spawn ant ([b46d252](https://github.com/ar-io/ar-io-sdk/commit/b46d25204bd9e8ff0c9a4e81a335cd9cec4ba2bb))
+* **buyRecord:** use reduce to create default tag ([53089c0](https://github.com/ar-io/ar-io-sdk/commit/53089c0990eb9d918eb7ee9b581179ec6231531e))
+
 # [3.18.0-alpha.3](https://github.com/ar-io/ar-io-sdk/compare/v3.18.0-alpha.2...v3.18.0-alpha.3) (2025-08-11)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [3.18.2-alpha.1](https://github.com/ar-io/ar-io-sdk/compare/v3.18.1...v3.18.2-alpha.1) (2025-08-16)
+
+
+### Bug Fixes
+
+* **buyRecord:** add arns name as Name tag to spawn ([e23dde4](https://github.com/ar-io/ar-io-sdk/commit/e23dde414195bfd881568cb941a3ad11df493878))
+* **buyRecord:** default to arns name tag if no Name tag provided ([2d0487d](https://github.com/ar-io/ar-io-sdk/commit/2d0487d11500d074e9eaab782139dec300f92713))
+* **buyRecord:** pass tags option to spawn ant ([b46d252](https://github.com/ar-io/ar-io-sdk/commit/b46d25204bd9e8ff0c9a4e81a335cd9cec4ba2bb))
+* **buyRecord:** use reduce to create default tag ([53089c0](https://github.com/ar-io/ar-io-sdk/commit/53089c0990eb9d918eb7ee9b581179ec6231531e))
+
 ## [3.18.1](https://github.com/ar-io/ar-io-sdk/compare/v3.18.0...v3.18.1) (2025-08-15)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,3 @@
-## [3.18.2-alpha.1](https://github.com/ar-io/ar-io-sdk/compare/v3.18.1...v3.18.2-alpha.1) (2025-08-16)
-
-
-### Bug Fixes
-
-* **buyRecord:** add arns name as Name tag to spawn ([e23dde4](https://github.com/ar-io/ar-io-sdk/commit/e23dde414195bfd881568cb941a3ad11df493878))
-* **buyRecord:** default to arns name tag if no Name tag provided ([2d0487d](https://github.com/ar-io/ar-io-sdk/commit/2d0487d11500d074e9eaab782139dec300f92713))
-* **buyRecord:** pass tags option to spawn ant ([b46d252](https://github.com/ar-io/ar-io-sdk/commit/b46d25204bd9e8ff0c9a4e81a335cd9cec4ba2bb))
-* **buyRecord:** use reduce to create default tag ([53089c0](https://github.com/ar-io/ar-io-sdk/commit/53089c0990eb9d918eb7ee9b581179ec6231531e))
-
 ## [3.18.1](https://github.com/ar-io/ar-io-sdk/compare/v3.18.0...v3.18.1) (2025-08-15)
 
 
@@ -29,19 +19,6 @@
 
 * **arns:** add support for `setPrimaryName` API, which allows the owner of an ANT that controls an ArNS name set their primary name in a single API ([b21a36c](https://github.com/ar-io/ar-io-sdk/commit/b21a36c2868ad32b125a7801f83f68e187e7f535))
 
-# [3.18.0-alpha.3](https://github.com/ar-io/ar-io-sdk/compare/v3.18.0-alpha.2...v3.18.0-alpha.3) (2025-08-11)
-
-
-### Bug Fixes
-
-* **types:** add callback types to AoARIOWrite methods ([82bd790](https://github.com/ar-io/ar-io-sdk/commit/82bd7908feff8eb9c4843e16c9ce1b49aa955de6))
-
-# [3.18.0-alpha.2](https://github.com/ar-io/ar-io-sdk/compare/v3.18.0-alpha.1...v3.18.0-alpha.2) (2025-08-10)
-
-
-### Bug Fixes
-
-* **hb:** catch fetch errors to trigger fallback ([491f1c2](https://github.com/ar-io/ar-io-sdk/commit/491f1c20c050749286538f0952032a15b7fd4cfb))
 
 ## [3.17.1](https://github.com/ar-io/ar-io-sdk/compare/v3.17.0...v3.17.1) (2025-08-08)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "3.18.1",
+  "version": "3.18.2-alpha.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "3.18.0-alpha.3",
+  "version": "3.18.0-alpha.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/src/common/ant-registry.ts
+++ b/src/common/ant-registry.ts
@@ -107,6 +107,7 @@ export class AoANTRegistryReadable implements AoANTRegistryRead {
     }
     this.logger.debug('Checking HyperBeam compatibility');
     this.checkHyperBeamPromise = fetch(
+      // use /now to force a refresh of the cache state, then compute when calling it for keys
       `${this.hyperbeamUrl.toString()}${this.process.processId}~process@1.0/now/cache/acl`,
       {
         method: 'HEAD',
@@ -146,7 +147,7 @@ export class AoANTRegistryReadable implements AoANTRegistryRead {
             address,
           );
           const res = await fetch(
-            `${this.hyperbeamUrl?.toString()}${this.process.processId}~process@1.0/now/cache/acl/${address}/serialize~json@1.0`,
+            `${this.hyperbeamUrl?.toString()}${this.process.processId}~process@1.0/compute/cache/acl/${address}/serialize~json@1.0`,
           );
 
           if (res.status !== 200) {

--- a/src/common/ant.ts
+++ b/src/common/ant.ts
@@ -143,6 +143,7 @@ export class AoANTReadable implements AoANTRead {
     }
 
     this.checkHyperBeamPromise = fetch(
+      // use /now to force a refresh of the cache state, then compute when calling it for keys
       `${this.hyperbeamUrl.toString()}${this.processId}~process@1.0/now/cache`,
       {
         method: 'HEAD',

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -1496,19 +1496,30 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
     if (params.processId === undefined) {
       try {
         // if a Name tag is provided, use it. Else, default to the arns name being purchased.
-        const nameTag = options?.tags?.find((tag) => tag.name === 'Name') ?? {
-          name: 'Name',
-          value: params.name,
-        };
-        const prunedTags =
-          options?.tags?.filter((tag) => tag.name !== 'Name') || [];
+        const { nameTag, otherTags } = (options?.tags || []).reduce(
+          (
+            acc: {
+              nameTag: { name: string; value: string };
+              otherTags: { name: string; value: string }[];
+            },
+            tag,
+          ) => {
+            if (tag.name === 'Name') {
+              acc.nameTag = tag;
+            } else {
+              acc.otherTags.push(tag);
+            }
+            return acc;
+          },
+          { nameTag: { name: 'Name', value: params.name }, otherTags: [] },
+        );
 
         params.processId = await ANT.spawn({
           signer: this.signer,
           ao: this.process.ao,
           logger: this.logger,
           // This lets AOS set the ArNS name as the Name in lua state
-          tags: [nameTag, ...prunedTags],
+          tags: [nameTag, ...otherTags],
           onSigningProgress: options?.onSigningProgress,
         });
       } catch (error) {

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -1495,15 +1495,20 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
     // spawn a new ANT if not provided
     if (params.processId === undefined) {
       try {
+        // if a Name tag is provided, use it. Else, default to the arns name being purchased.
+        const nameTag = options?.tags?.find((tag) => tag.name === 'Name') ?? {
+          name: 'Name',
+          value: params.name,
+        };
+        const prunedTags =
+          options?.tags?.filter((tag) => tag.name !== 'Name') || [];
+
         params.processId = await ANT.spawn({
           signer: this.signer,
           ao: this.process.ao,
           logger: this.logger,
           // This lets AOS set the ArNS name as the Name in lua state
-          tags: [
-            { name: 'Name', value: params.name },
-            ...(options?.tags || []),
-          ],
+          tags: [nameTag, ...prunedTags],
           onSigningProgress: options?.onSigningProgress,
         });
       } catch (error) {

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -1499,6 +1499,8 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
           signer: this.signer,
           ao: this.process.ao,
           logger: this.logger,
+          // This lets AOS set the ArNS name as the Name in lua state
+          tags: [{ name: 'Name', value: params.name }],
           onSigningProgress: options?.onSigningProgress,
         });
       } catch (error) {

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -1500,7 +1500,10 @@ export class ARIOWriteable extends ARIOReadable implements AoARIOWrite {
           ao: this.process.ao,
           logger: this.logger,
           // This lets AOS set the ArNS name as the Name in lua state
-          tags: [{ name: 'Name', value: params.name }],
+          tags: [
+            { name: 'Name', value: params.name },
+            ...(options?.tags || []),
+          ],
           onSigningProgress: options?.onSigningProgress,
         });
       } catch (error) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,16 +20,6 @@ export const FQDN_REGEX = new RegExp(
   '^(?:(?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{1,63}$',
 );
 
-// sortkey: padded blockheight to 12, JS timestamp, hash of transactionID + block hash. Timestamp only applicable to L2 and normally is all zeros.
-export const SORT_KEY_REGEX = new RegExp(
-  '^[0-9]{12},[0-9]{13},[a-fA-F0-9]{64}$',
-);
-export const ARNS_TESTNET_REGISTRY_TX =
-  process.env.ARNS_REGISTRY_TX ?? 'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
-
-export const ARNS_DEVNET_REGISTRY_TX =
-  '_NctcA2sRy1-J4OmIQZbYFPM17piNcbdBPH2ncX2RL8';
-
 export const ARIO_DEVNET_PROCESS_ID =
   'GaQrvEMKBpkjofgnBi_B3IgIDmY_XYelVLB6GcRGrHc';
 // backwards compatibility - TODO: remove in v2.0.0

--- a/src/utils/ao.ts
+++ b/src/utils/ao.ts
@@ -52,6 +52,7 @@ export type SpawnANTParams = {
   antRegistryId?: string;
   logger?: Logger;
   authority?: string;
+  tags?: { name: string; value: string }[];
   /**
    * @deprecated Compiled modules are now being used instead of luaCodeTxId
    */
@@ -77,6 +78,7 @@ export async function spawnANT({
   }),
   scheduler = DEFAULT_SCHEDULER_ID,
   state,
+  tags = [],
   antRegistryId = ANT_REGISTRY_ID,
   logger = Logger.default,
   authority = AO_AUTHORITY,
@@ -130,6 +132,7 @@ export async function spawnANT({
         name: 'ANT-Registry-Id',
         value: antRegistryId,
       },
+      ...tags,
     ],
   });
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '3.18.0-alpha.3';
+export const version = '3.18.0-alpha.4';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '3.18.1';
+export const version = '3.18.2-alpha.1';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support custom tags when spawning ANTs, including a Name tag to set the ArNS name.
- Bug Fixes
  - Spawned ANTs from buy operations now include a Name tag (defaults to the ARNS name if none provided).
- Documentation
  - Changelog cleaned up for the 3.18.2-alpha.1 release (removed prior pre-release entries).
- Refactor
  - Removed deprecated constants related to sort-key validation and ARNS registry defaults.
- Chores
  - Version bumped to 3.18.2-alpha.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->