### PR TITLE
fix(ant-readable): use static crypto import for undername hash in getRecords

### DIFF
--- a/src/solana/ant-readable.ts
+++ b/src/solana/ant-readable.ts
@@ -317,9 +317,7 @@ export class SolanaANTReadable {
       try {
         const buf = Buffer.from(account.data[0], 'base64');
         const record = deserializeAntRecord(buf);
-        // Look up metadata by computing the undername hash
-        const { createHash } = await import('crypto');
-        const hash = createHash('sha256')
+        const hash = __createHash('sha256')
           .update(record.undername.toLowerCase())
           .digest('hex');
         const meta: Partial<ReturnType<typeof deserializeAntRecordMetadata>> =


### PR DESCRIPTION
## Summary

- Replaces the dynamic `await import('crypto')` inside the `getRecords` loop with the already-imported `__createHash` alias from module scope
- The dynamic import bypasses bundler polyfills (e.g. Vite's `node-stdlib-browser`), causing silent failures in browser environments when looking up `AntRecordMetadata` for undername records
- `__createHash` is already imported at the top of the file for the `ANT_RECORD_METADATA_DISCRIMINATOR` computation — this just reuses it

## Test plan

- [x] Verified ANT record + metadata loading works in the ArNS portal (Vite/React) against devnet after this fix
- [ ] `yarn test:unit` passes
- [ ] `yarn build` passes


Made with [Cursor](https://cursor.com)