### PR TITLE
fix(solana): bundle CreateATA on fresh-wallet paths + add prune surface

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -59,6 +59,19 @@ import {
   updateGatewaySettings,
 } from './commands/gatewayWriteCommands.js';
 import {
+  closeDrainedWithdrawalCLICommand,
+  closeEmptyDelegationCLICommand,
+  closeExpiredRequestCLICommand,
+  closeObservationCLICommand,
+  finalizeGoneCLICommand,
+  pruneExpiredNamesCLICommand,
+  pruneExpiredReservationCLICommand,
+  pruneGatewayCLICommand,
+  pruneNameToReturnedCLICommand,
+  pruneReturnedNamesCLICommand,
+  releaseVaultCLICommand,
+} from './commands/pruneCommands.js';
+import {
   getAllGatewayVaults,
   getAllowedDelegates,
   getArNSRecord,
@@ -680,6 +693,97 @@ makeCommand<AddressAndNameCLIOptions>({
   description: 'Set an ArNS name you own as your primary name',
   options: arnsPurchaseOptions,
   action: setPrimaryNameCLICommand,
+});
+
+// # Prune / cleanup (Solana-only — permissionless crank surface)
+makeCommand({
+  name: 'prune-expired-names',
+  description:
+    'Batch-prune expired ArnsRecord PDAs (Solana-only). Discovers eligible records ' +
+    'via getExpiredArnsRecords if --arns-records is omitted.',
+  options: [...writeActionOptions, optionMap.max, optionMap.arnsRecords],
+  action: pruneExpiredNamesCLICommand,
+});
+
+makeCommand({
+  name: 'prune-name-to-returned',
+  description:
+    'Convert a single expired-but-not-yet-returned lease into a ReturnedName ' +
+    '(starts the Dutch auction). Solana-only.',
+  options: [...writeActionOptions, optionMap.name],
+  action: pruneNameToReturnedCLICommand,
+});
+
+makeCommand({
+  name: 'prune-returned-names',
+  description:
+    'Batch-prune expired ReturnedName PDAs (Solana-only). Discovers via ' +
+    'getExpiredReturnedNames if --returned-names is omitted.',
+  options: [...writeActionOptions, optionMap.max, optionMap.returnedNames],
+  action: pruneReturnedNamesCLICommand,
+});
+
+makeCommand({
+  name: 'prune-expired-reservation',
+  description: 'Close an expired ReservedName PDA (Solana-only).',
+  options: [...writeActionOptions, optionMap.name],
+  action: pruneExpiredReservationCLICommand,
+});
+
+makeCommand({
+  name: 'prune-gateway',
+  description:
+    'Slash + remove a deficient gateway (≥30 consecutive failures). Solana-only.',
+  options: [...writeActionOptions, optionMap.gateway],
+  action: pruneGatewayCLICommand,
+});
+
+makeCommand({
+  name: 'finalize-gone',
+  description:
+    'GC a Leaving/Gone gateway whose leave window has fully elapsed. Solana-only.',
+  options: [...writeActionOptions, optionMap.gateway],
+  action: finalizeGoneCLICommand,
+});
+
+makeCommand({
+  name: 'close-observation',
+  description:
+    'Reclaim rent from an Observation PDA whose epoch has been distributed. Solana-only.',
+  options: [...writeActionOptions, optionMap.epochIndex, optionMap.observer],
+  action: closeObservationCLICommand,
+});
+
+makeCommand({
+  name: 'close-empty-delegation',
+  description:
+    'Close an empty Delegation PDA (amount == 0). Rent refunds to the original delegator. Solana-only.',
+  options: [...writeActionOptions, optionMap.gateway, optionMap.delegator],
+  action: closeEmptyDelegationCLICommand,
+});
+
+makeCommand({
+  name: 'close-drained-withdrawal',
+  description:
+    'Close a drained Withdrawal PDA (amount == 0). Rent refunds to the original owner. Solana-only.',
+  options: [...writeActionOptions, optionMap.owner, optionMap.withdrawalId],
+  action: closeDrainedWithdrawalCLICommand,
+});
+
+makeCommand({
+  name: 'release-vault',
+  description:
+    'Release tokens from an expired vault back to the owner (Solana-only). ' +
+    'NOT permissionless — must be called from the vault owner wallet.',
+  options: [...writeActionOptions, optionMap.vaultId, optionMap.owner],
+  action: releaseVaultCLICommand,
+});
+
+makeCommand({
+  name: 'close-expired-request',
+  description: 'Close an expired PrimaryNameRequest PDA. Solana-only.',
+  options: [...writeActionOptions, optionMap.initiator],
+  action: closeExpiredRequestCLICommand,
 });
 
 // # ANT Registry

--- a/src/cli/commands/pruneCommands.ts
+++ b/src/cli/commands/pruneCommands.ts
@@ -1,0 +1,273 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+/**
+ * CLI commands for the permissionless prune / cleanup surface.
+ *
+ * These mirror the Solana-only methods on `SolanaARIOWriteable` —
+ * see `sdk/src/solana/io-writeable.ts` and `docs/CRANKER_PRUNING_PLAN.md`.
+ * They have no AO analogue (Lua's `tick()` did this lazily), so each
+ * command rejects `--ao`.
+ */
+import type { SolanaARIOWriteable } from '../../solana/io-writeable.js';
+import type { WriteActionCLIOptions } from '../types.js';
+import {
+  assertConfirmationPrompt,
+  requiredStringFromOptions,
+  writeARIOFromOptions,
+} from '../utils.js';
+
+type PruneOptions = WriteActionCLIOptions & {
+  name?: string;
+  max?: string;
+  gateway?: string;
+  delegator?: string;
+  observer?: string;
+  initiator?: string;
+  owner?: string;
+  withdrawalId?: string;
+  vaultId?: string;
+  epochIndex?: string;
+  arnsRecords?: string[];
+  returnedNames?: string[];
+};
+
+function rejectAoBackend(o: PruneOptions, command: string): void {
+  if (o.ao) {
+    throw new Error(
+      `${command} is Solana-only — Lua's tick() handles the equivalent on AO. Drop --ao.`,
+    );
+  }
+}
+
+async function getSolanaWriter(o: PruneOptions): Promise<SolanaARIOWriteable> {
+  const { ario } = await writeARIOFromOptions(o);
+  return ario as unknown as SolanaARIOWriteable;
+}
+
+function parseMaxNames(o: PruneOptions): number {
+  const raw = o.max;
+  if (raw === undefined) {
+    throw new Error('--max <count> is required (u8 batch size, 1-255)');
+  }
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > 255) {
+    throw new Error(`--max must be an integer 1-255 (got ${raw})`);
+  }
+  return n;
+}
+
+// =========================================
+// ArNS prune
+// =========================================
+
+export async function pruneExpiredNamesCLICommand(o: PruneOptions) {
+  rejectAoBackend(o, 'prune-expired-names');
+  const max = parseMaxNames(o);
+  const ario = await getSolanaWriter(o);
+
+  // If `--arns-records` wasn't provided, discover them via the readable's
+  // helper. Cap at `max` so we never overshoot the ix's u8 batch parameter.
+  let records: string[] = o.arnsRecords ?? [];
+  if (records.length === 0) {
+    const now = Math.floor(Date.now() / 1000);
+    const expired = await ario.getExpiredArnsRecords(now);
+    records = expired.slice(0, max).map((r) => r.pubkey as string);
+    if (records.length === 0) {
+      return { message: 'No expired ArnsRecords to prune' };
+    }
+  } else {
+    records = records.slice(0, max);
+  }
+
+  await assertConfirmationPrompt(
+    `Prune ${records.length} expired ArnsRecord(s)?`,
+    o,
+  );
+
+  return ario.pruneExpiredNames({ maxNames: max, arnsRecords: records });
+}
+
+export async function pruneNameToReturnedCLICommand(o: PruneOptions) {
+  rejectAoBackend(o, 'prune-name-to-returned');
+  const name = requiredStringFromOptions(o, 'name');
+  const ario = await getSolanaWriter(o);
+
+  await assertConfirmationPrompt(
+    `Convert expired lease for "${name}" to a ReturnedName (Dutch auction)?`,
+    o,
+  );
+
+  return ario.pruneNameToReturned({ name });
+}
+
+export async function pruneReturnedNamesCLICommand(o: PruneOptions) {
+  rejectAoBackend(o, 'prune-returned-names');
+  const max = parseMaxNames(o);
+  const ario = await getSolanaWriter(o);
+
+  let returned: string[] = o.returnedNames ?? [];
+  if (returned.length === 0) {
+    const now = Math.floor(Date.now() / 1000);
+    const expired = await ario.getExpiredReturnedNames(now);
+    returned = expired.slice(0, max).map((r) => r.pubkey as string);
+    if (returned.length === 0) {
+      return { message: 'No expired ReturnedNames to prune' };
+    }
+  } else {
+    returned = returned.slice(0, max);
+  }
+
+  await assertConfirmationPrompt(
+    `Prune ${returned.length} expired ReturnedName(s)?`,
+    o,
+  );
+
+  return ario.pruneReturnedNames({
+    maxNames: max,
+    returnedNames: returned,
+  });
+}
+
+export async function pruneExpiredReservationCLICommand(o: PruneOptions) {
+  rejectAoBackend(o, 'prune-expired-reservation');
+  const name = requiredStringFromOptions(o, 'name');
+  const ario = await getSolanaWriter(o);
+
+  await assertConfirmationPrompt(`Close expired reservation for "${name}"?`, o);
+
+  return ario.pruneExpiredReservation({ name });
+}
+
+// =========================================
+// Gateway prune
+// =========================================
+
+export async function pruneGatewayCLICommand(o: PruneOptions) {
+  rejectAoBackend(o, 'prune-gateway');
+  const gateway = requiredStringFromOptions(o, 'gateway');
+  const ario = await getSolanaWriter(o);
+
+  await assertConfirmationPrompt(
+    `Slash + remove deficient gateway ${gateway}?`,
+    o,
+  );
+
+  return ario.pruneGateway({ gateway });
+}
+
+export async function finalizeGoneCLICommand(o: PruneOptions) {
+  rejectAoBackend(o, 'finalize-gone');
+  const gateway = requiredStringFromOptions(o, 'gateway');
+  const ario = await getSolanaWriter(o);
+
+  await assertConfirmationPrompt(
+    `Finalize-GC departed gateway ${gateway} (reclaim PDA rent)?`,
+    o,
+  );
+
+  return ario.finalizeGone({ gateway });
+}
+
+// =========================================
+// Rent reclaim
+// =========================================
+
+export async function closeObservationCLICommand(o: PruneOptions) {
+  rejectAoBackend(o, 'close-observation');
+  const epochIndexStr = requiredStringFromOptions(o, 'epochIndex');
+  const observer = requiredStringFromOptions(o, 'observer');
+  const epochIndex = Number(epochIndexStr);
+  if (!Number.isInteger(epochIndex) || epochIndex < 0) {
+    throw new Error(
+      `--epoch-index must be a non-negative integer (got ${epochIndexStr})`,
+    );
+  }
+  const ario = await getSolanaWriter(o);
+
+  await assertConfirmationPrompt(
+    `Close Observation PDA (epoch ${epochIndex}, observer ${observer})?`,
+    o,
+  );
+
+  return ario.closeObservation({ epochIndex, observer });
+}
+
+export async function closeEmptyDelegationCLICommand(o: PruneOptions) {
+  rejectAoBackend(o, 'close-empty-delegation');
+  const gateway = requiredStringFromOptions(o, 'gateway');
+  const delegator = requiredStringFromOptions(o, 'delegator');
+  const ario = await getSolanaWriter(o);
+
+  await assertConfirmationPrompt(
+    `Close empty Delegation PDA (gateway=${gateway}, delegator=${delegator})?`,
+    o,
+  );
+
+  return ario.closeEmptyDelegation({ gateway, delegator });
+}
+
+export async function closeDrainedWithdrawalCLICommand(o: PruneOptions) {
+  rejectAoBackend(o, 'close-drained-withdrawal');
+  const owner = requiredStringFromOptions(o, 'owner');
+  const withdrawalIdStr = requiredStringFromOptions(o, 'withdrawalId');
+  const withdrawalId = BigInt(withdrawalIdStr);
+  const ario = await getSolanaWriter(o);
+
+  await assertConfirmationPrompt(
+    `Close drained Withdrawal PDA (owner=${owner}, id=${withdrawalIdStr})?`,
+    o,
+  );
+
+  return ario.closeDrainedWithdrawal({ owner, withdrawalId });
+}
+
+// =========================================
+// Vault + primary-name request
+// =========================================
+
+export async function releaseVaultCLICommand(o: PruneOptions) {
+  rejectAoBackend(o, 'release-vault');
+  // The on-chain handler requires `owner: Signer` — the SDK uses the
+  // configured signer as the owner. The `--owner` flag is accepted as
+  // documentation but ignored unless it matches the signer; fail loud if
+  // it doesn't, so users don't think they can release someone else's vault.
+  const ario = await getSolanaWriter(o);
+  if (o.owner) {
+    const signerAddr = (await writeARIOFromOptions(o)).signerAddress;
+    if (o.owner !== signerAddr) {
+      throw new Error(
+        `release-vault: --owner ${o.owner} does not match signer ${signerAddr}. ` +
+          `release_vault is owner-signed; use the owner's wallet to call it.`,
+      );
+    }
+  }
+  const vaultIdStr = requiredStringFromOptions(o, 'vaultId');
+  const vaultId = vaultIdStr;
+
+  await assertConfirmationPrompt(
+    `Release expired vault id=${vaultIdStr} (transfer tokens back to owner)?`,
+    o,
+  );
+
+  return ario.releaseVault({ vaultId });
+}
+
+export async function closeExpiredRequestCLICommand(o: PruneOptions) {
+  rejectAoBackend(o, 'close-expired-request');
+  const initiator = requiredStringFromOptions(o, 'initiator');
+  const ario = await getSolanaWriter(o);
+
+  await assertConfirmationPrompt(
+    `Close expired primary-name request from ${initiator}?`,
+    o,
+  );
+
+  return ario.closeExpiredRequest({ initiator });
+}

--- a/src/cli/commands/pruneCommands.ts
+++ b/src/cli/commands/pruneCommands.ts
@@ -217,6 +217,15 @@ export async function closeDrainedWithdrawalCLICommand(o: PruneOptions) {
   rejectAoBackend(o, 'close-drained-withdrawal');
   const owner = requiredStringFromOptions(o, 'owner');
   const withdrawalIdStr = requiredStringFromOptions(o, 'withdrawalId');
+  // Validate before BigInt() — `BigInt('0xff')` and `BigInt('  1  ')` succeed
+  // and `BigInt('abc')` throws an opaque SyntaxError. Restrict to the u64
+  // decimal form the on-chain seed encoder expects so the CLI fails with a
+  // clear message instead of a downstream parser error.
+  if (!/^\d+$/.test(withdrawalIdStr)) {
+    throw new Error(
+      `--withdrawal-id must be a non-negative decimal integer (got "${withdrawalIdStr}")`,
+    );
+  }
   const withdrawalId = BigInt(withdrawalIdStr);
   const ario = await getSolanaWriter(o);
 

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -445,6 +445,38 @@ export const optionMap = {
     description: 'Reassign all affiliated names to the new process',
     type: 'boolean',
   },
+  // -----------------------------------------------------------------
+  // Prune / cleanup flags (Solana-only — see pruneCommands.ts)
+  // -----------------------------------------------------------------
+  gateway: {
+    alias: '--gateway <gateway>',
+    description: 'The gateway operator address (prune / finalize commands)',
+  },
+  delegator: {
+    alias: '--delegator <delegator>',
+    description: 'The delegator address (close-empty-delegation)',
+  },
+  observer: {
+    alias: '--observer <observer>',
+    description: 'The observer address (close-observation)',
+  },
+  max: {
+    alias: '--max <max>',
+    description:
+      'Per-tx batch size (1-255, u8) for prune-expired-names / prune-returned-names',
+  },
+  arnsRecords: {
+    alias: '--arns-records <arnsRecords...>',
+    description:
+      'Explicit ArnsRecord PDAs to prune. Default: discover via getExpiredArnsRecords.',
+    type: 'array',
+  },
+  returnedNames: {
+    alias: '--returned-names <returnedNames...>',
+    description:
+      'Explicit ReturnedName PDAs to prune. Default: discover via getExpiredReturnedNames.',
+    type: 'array',
+  },
 };
 
 export const walletOptions = [

--- a/src/solana/deserialize.ts
+++ b/src/solana/deserialize.ts
@@ -357,6 +357,9 @@ export function deserializeGateway(
   const statusIdx = r.readU8(); // 0=Joined, 1=Leaving
   const startTimestamp = r.readI64AsNumber();
   const leaveTimestamp = r.readOptionI64();
+  // leave_epoch_duration: i64 — snapshot of epoch_settings.epoch_duration captured
+  // at leave_network/prune_gateway. Not surfaced on AoGateway; consume to stay aligned.
+  r.skip(8);
 
   // GatewayStats
   const passedEpochCount = r.readU32();
@@ -367,18 +370,18 @@ export function deserializeGateway(
   const failedConsecutiveEpochs = r.readU8();
   const passedConsecutiveEpochs = r.readU8();
 
-  // GatewayWeights (6 x u64)
+  // GatewayWeights (7 x u64 — 7th is weights_epoch, set by tally_weights)
   const stakeWeight = r.readU64AsNumber();
   const tenureWeight = r.readU64AsNumber();
   const gatewayPerformanceRatio = r.readU64AsNumber();
   const observerPerformanceRatio = r.readU64AsNumber();
   const compositeWeight = r.readU64AsNumber();
   const normalizedCompositeWeight = r.readU64AsNumber();
+  r.skip(8); // weights_epoch — not surfaced on AoGatewayWeights
 
-  // GatewaySettings2
+  // GatewaySettings2 (auto_stake removed in cfc7a8b2 — never existed on Solana)
   const allowDelegatedStaking = r.readBool();
   const delegateRewardShareRatio = r.readU16();
-  const autoStake = r.readBool();
   const minDelegatedStake = r.readU64AsNumber();
   const allowlistEnabled = r.readBool();
 
@@ -423,7 +426,7 @@ export function deserializeGateway(
     delegateRewardShareRatio,
     allowedDelegates: [], // populated separately from allowlist PDAs
     minDelegatedStake,
-    autoStake,
+    autoStake: false, // not an on-chain field on Solana; preserved on AoGatewaySettings for AO parity
     label,
     note,
     properties,

--- a/src/solana/escrow.ts
+++ b/src/solana/escrow.ts
@@ -762,8 +762,16 @@ export class TokenEscrow {
       saltLen: args.saltLen ?? 32,
       messageNonce: escrow.nonce,
     });
+    // The on-chain claim handler delivers liquid tokens to
+    // `claimantTokenAccount`; for fresh-wallet claimants the canonical ATA
+    // doesn't exist yet (#3012). Idempotent-create when canonical.
+    const createAtaIx = await this._createClaimantAtaIfCanonical(
+      args.claimant,
+      args.claimantTokenAccount,
+      escrow.arioMint,
+    );
     // RSA-PSS-4096 verification is CU-intensive; use 400K.
-    return this.send([ix], 400_000);
+    return this.send(createAtaIx ? [createAtaIx, ix] : [ix], 400_000);
   }
 
   async claimTokensArweaveIx(args: {
@@ -826,7 +834,14 @@ export class TokenEscrow {
       ...args,
       messageNonce: escrow.nonce,
     });
-    return this.send([ix]);
+    // Same fresh-wallet #3012 vector as claimTokensArweave — bundle a
+    // canonical-ATA idempotent-create when applicable.
+    const createAtaIx = await this._createClaimantAtaIfCanonical(
+      args.claimant,
+      args.claimantTokenAccount,
+      escrow.arioMint,
+    );
+    return this.send(createAtaIx ? [createAtaIx, ix] : [ix]);
   }
 
   async claimTokensEthereumIx(args: {
@@ -984,15 +999,59 @@ export class TokenEscrow {
    * (see the introspection function's tolerance), so any modest clock skew
    * between client and chain is absorbed.
    */
+  /**
+   * Idempotent-create the claimant's canonical ATA when needed.
+   *
+   * The on-chain claim handler delivers liquid tokens directly to
+   * `claimantTokenAccount` for expired vaults AND for token escrows.
+   * For active vaults, the `claim_vault_*` Anchor Accounts struct still
+   * declares `claimant_token_account: Account<TokenAccount>`, which forces
+   * Anchor's account-load-time validation to require the account exist
+   * even though the active path doesn't write to it. Either way: if the
+   * claimant is a fresh wallet that has never held this mint, the ATA
+   * doesn't exist and the tx fails with `AccountNotInitialized` (#3012).
+   *
+   * Returns `null` when the caller passed a non-canonical
+   * `claimantTokenAccount` (manually-created non-ATA token account,
+   * presumably already exists — caller's responsibility).
+   */
+  private async _createClaimantAtaIfCanonical(
+    claimant: Address,
+    claimantTokenAccount: Address,
+    mint: Address,
+  ): Promise<Instruction | null> {
+    const canonical = await getAssociatedTokenAddressKit(mint, claimant);
+    if (claimantTokenAccount !== canonical) return null;
+    const signer = this.requireSigner('createClaimantAtaIfCanonical');
+    return buildCreateAtaIdempotentIx(
+      signer.address,
+      canonical,
+      claimant,
+      mint,
+    );
+  }
+
   private async maybeBundleVaultedTransfer(
     escrow: EscrowTokenState,
-    args: { claimant: Address; payerTokenAccount: Address },
+    args: {
+      claimant: Address;
+      claimantTokenAccount: Address;
+      payerTokenAccount: Address;
+    },
     claimIx: Instruction,
   ): Promise<Instruction[]> {
     const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
     const remaining = escrow.vaultEndTimestamp - nowSeconds;
     if (remaining <= 0n) {
-      return [claimIx];
+      // Expired vault → claim handler delivers liquid to claimantTokenAccount.
+      // Idempotent-create that ATA if it's the canonical derivation so a
+      // first-time recipient just works.
+      const createClaimantAtaIx = await this._createClaimantAtaIfCanonical(
+        args.claimant,
+        args.claimantTokenAccount,
+        escrow.arioMint,
+      );
+      return createClaimantAtaIx ? [createClaimantAtaIx, claimIx] : [claimIx];
     }
     const signer = this.requireSigner('maybeBundleVaultedTransfer');
     const nextId = await this.getNextVaultId(args.claimant);
@@ -1005,6 +1064,25 @@ export class TokenEscrow {
       escrow.arioMint,
       vaultPda,
       true,
+    );
+    // Active-vault path: `claim_vault_*` still validates the claimant ATA
+    // at account-load-time (Anchor `Account<TokenAccount>` constraint),
+    // even though no liquid is written to it. Idempotent-create so a fresh
+    // claimant doesn't fail the ix with AccountNotInitialized (#3012).
+    const createClaimantAtaIx = await this._createClaimantAtaIfCanonical(
+      args.claimant,
+      args.claimantTokenAccount,
+      escrow.arioMint,
+    );
+    // The new vault PDA's ATA must exist before `vaulted_transfer` reads it
+    // (else `AccountNotInitialized` #3012). Idempotent so a retry after a
+    // partial-failure tx is safe. Placed after the claim ix to preserve
+    // the "claim first" tx ordering invariant.
+    const createVaultAtaIx = buildCreateAtaIdempotentIx(
+      signer.address,
+      vaultATA,
+      vaultPda,
+      escrow.arioMint,
     );
     const vaultedIx = await getVaultedTransferInstructionAsync(
       {
@@ -1019,7 +1097,8 @@ export class TokenEscrow {
       },
       { programAddress: this.coreProgram },
     );
-    return [claimIx, vaultedIx];
+    const head = createClaimantAtaIx ? [createClaimantAtaIx] : [];
+    return [...head, claimIx, createVaultAtaIx, vaultedIx];
   }
 
   /** Read the recipient's `VaultCounter.nextId`, defaulting to 0n if the

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -90,22 +90,49 @@ import {
   deserializeVault,
   deserializeWithdrawal,
 } from './deserialize.js';
-import { ARNS_RECORD_DISCRIMINATOR } from './generated/arns/accounts/arnsRecord.js';
-import { RESERVED_NAME_DISCRIMINATOR } from './generated/arns/accounts/reservedName.js';
-import { RETURNED_NAME_DISCRIMINATOR } from './generated/arns/accounts/returnedName.js';
+import { getArnsConfigDecoder } from './generated/arns/accounts/arnsConfig.js';
+import {
+  ARNS_RECORD_DISCRIMINATOR,
+  getArnsRecordDecoder,
+} from './generated/arns/accounts/arnsRecord.js';
+import {
+  RESERVED_NAME_DISCRIMINATOR,
+  getReservedNameDecoder,
+} from './generated/arns/accounts/reservedName.js';
+import {
+  RETURNED_NAME_DISCRIMINATOR,
+  getReturnedNameDecoder,
+} from './generated/arns/accounts/returnedName.js';
 import { PRIMARY_NAME_DISCRIMINATOR } from './generated/core/accounts/primaryName.js';
-import { PRIMARY_NAME_REQUEST_DISCRIMINATOR } from './generated/core/accounts/primaryNameRequest.js';
-import { VAULT_DISCRIMINATOR } from './generated/core/accounts/vault.js';
+import {
+  PRIMARY_NAME_REQUEST_DISCRIMINATOR,
+  getPrimaryNameRequestDecoder,
+} from './generated/core/accounts/primaryNameRequest.js';
+import {
+  VAULT_DISCRIMINATOR,
+  getVaultDecoder,
+} from './generated/core/accounts/vault.js';
 import { ALLOWLIST_ENTRY_DISCRIMINATOR } from './generated/gar/accounts/allowlistEntry.js';
-import { DELEGATION_DISCRIMINATOR } from './generated/gar/accounts/delegation.js';
-import { GATEWAY_DISCRIMINATOR } from './generated/gar/accounts/gateway.js';
+import {
+  DELEGATION_DISCRIMINATOR,
+  getDelegationDecoder,
+} from './generated/gar/accounts/delegation.js';
+import {
+  GATEWAY_DISCRIMINATOR,
+  getGatewayDecoder,
+} from './generated/gar/accounts/gateway.js';
 import { OBSERVATION_DISCRIMINATOR } from './generated/gar/accounts/observation.js';
-import { WITHDRAWAL_DISCRIMINATOR } from './generated/gar/accounts/withdrawal.js';
+import {
+  WITHDRAWAL_DISCRIMINATOR,
+  getWithdrawalDecoder,
+} from './generated/gar/accounts/withdrawal.js';
+import { GatewayStatus } from './generated/gar/types/index.js';
 import { TOKEN_PROGRAM_ADDRESS } from './instruction.js';
 import {
   getArioConfigPDA,
   getArnsRecordPDA,
   getArnsRecordPDAFromHash,
+  getArnsSettingsPDA,
   getDemandFactorPDA,
   getEpochPDA,
   getEpochSettingsPDA,
@@ -1753,6 +1780,344 @@ export class SolanaARIOReadable {
     }
 
     return paginate(items, params);
+  }
+
+  // =========================================
+  // Prune / cleanup discovery (Solana-only)
+  // =========================================
+  //
+  // These helpers enumerate accounts eligible for the permissionless prune
+  // ix surface (see SolanaARIOWriteable). All read on-chain via
+  // `getProgramAccounts` + the Codama decoders, then post-filter
+  // client-side because most eligibility predicates can't be expressed as
+  // memcmp filters (variable-length names shift offsets; Option<i64>
+  // adds a tag byte). Volume is bounded — the cranker is expected to
+  // call these once per epoch cycle, not per-tx.
+  //
+  // See `docs/CRANKER_PRUNING_PLAN.md` for the design.
+
+  /**
+   * Enumerate ArnsRecord PDAs whose lease has fully expired
+   * (`end_timestamp + grace_period + return_auction_duration <= now`).
+   * Permabuys (no `end_timestamp`) are excluded. Pass a unix-seconds `now`.
+   */
+  async getExpiredArnsRecords(
+    now: number,
+  ): Promise<Array<{ pubkey: Address; name: string; endTimestamp: bigint }>> {
+    const [arnsConfigPda] = await getArnsSettingsPDA(this.arnsProgram);
+    const cfgAccount = await this.getAccount(arnsConfigPda);
+    if (!cfgAccount.exists) return [];
+    const cfg = getArnsConfigDecoder().decode(cfgAccount.data);
+    const grace = Number(cfg.gracePeriodSeconds);
+    const auction = Number(cfg.returnAuctionDurationSeconds);
+
+    const accounts = await this.getAccountsByDiscriminator(
+      this.arnsProgram,
+      ARNS_RECORD_DISCRIMINATOR,
+    );
+    const decoder = getArnsRecordDecoder();
+    const out: Array<{
+      pubkey: Address;
+      name: string;
+      endTimestamp: bigint;
+    }> = [];
+    for (const { pubkey, data } of accounts) {
+      try {
+        const r = decoder.decode(data);
+        if (r.endTimestamp.__option !== 'Some') continue;
+        const end = Number(r.endTimestamp.value);
+        if (end + grace + auction <= now) {
+          out.push({
+            pubkey,
+            name: r.name,
+            endTimestamp: r.endTimestamp.value,
+          });
+        }
+      } catch {
+        // skip malformed
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Enumerate ReturnedName PDAs whose Dutch auction window has fully
+   * elapsed (`returned_at + return_auction_duration <= now`).
+   */
+  async getExpiredReturnedNames(
+    now: number,
+  ): Promise<Array<{ pubkey: Address; name: string; returnedAt: bigint }>> {
+    const [arnsConfigPda] = await getArnsSettingsPDA(this.arnsProgram);
+    const cfgAccount = await this.getAccount(arnsConfigPda);
+    if (!cfgAccount.exists) return [];
+    const cfg = getArnsConfigDecoder().decode(cfgAccount.data);
+    const auction = Number(cfg.returnAuctionDurationSeconds);
+
+    const accounts = await this.getAccountsByDiscriminator(
+      this.arnsProgram,
+      RETURNED_NAME_DISCRIMINATOR,
+    );
+    const decoder = getReturnedNameDecoder();
+    const out: Array<{
+      pubkey: Address;
+      name: string;
+      returnedAt: bigint;
+    }> = [];
+    for (const { pubkey, data } of accounts) {
+      try {
+        const r = decoder.decode(data);
+        if (Number(r.returnedAt) + auction <= now) {
+          out.push({ pubkey, name: r.name, returnedAt: r.returnedAt });
+        }
+      } catch {
+        // skip malformed
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Enumerate ReservedName PDAs whose `expires_at` has passed.
+   * Permanent reservations (`expires_at: None`) are excluded.
+   */
+  async getExpiredReservations(
+    now: number,
+  ): Promise<Array<{ pubkey: Address; name: string }>> {
+    const accounts = await this.getAccountsByDiscriminator(
+      this.arnsProgram,
+      RESERVED_NAME_DISCRIMINATOR,
+    );
+    const decoder = getReservedNameDecoder();
+    const out: Array<{ pubkey: Address; name: string }> = [];
+    for (const { pubkey, data } of accounts) {
+      try {
+        const r = decoder.decode(data);
+        if (r.expiresAt.__option !== 'Some') continue;
+        if (Number(r.expiresAt.value) <= now) {
+          out.push({ pubkey, name: r.name });
+        }
+      } catch {
+        // skip malformed
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Enumerate Gateway PDAs in `Joined` status with
+   * `stats.failed_consecutive >= maxFailures`. These are eligible for
+   * `pruneGateway` (slash + remove from registry).
+   */
+  async getDeficientGateways(
+    maxFailures: number,
+  ): Promise<
+    Array<{ pubkey: Address; operator: Address; failedConsecutive: number }>
+  > {
+    const accounts = await this.getAccountsByDiscriminator(
+      this.garProgram,
+      GATEWAY_DISCRIMINATOR,
+    );
+    const decoder = getGatewayDecoder();
+    const out: Array<{
+      pubkey: Address;
+      operator: Address;
+      failedConsecutive: number;
+    }> = [];
+    for (const { pubkey, data } of accounts) {
+      try {
+        const g = decoder.decode(data);
+        if (g.status !== GatewayStatus.Joined) continue;
+        if (g.stats.failedConsecutive >= maxFailures) {
+          out.push({
+            pubkey,
+            operator: g.operator,
+            failedConsecutive: g.stats.failedConsecutive,
+          });
+        }
+      } catch {
+        // skip malformed
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Enumerate Gateway PDAs whose `status == Gone` (already left the
+   * network but PDA not yet GC'd). Eligible for `finalizeGone`.
+   */
+  async getGoneGateways(): Promise<
+    Array<{ pubkey: Address; operator: Address }>
+  > {
+    const accounts = await this.getAccountsByDiscriminator(
+      this.garProgram,
+      GATEWAY_DISCRIMINATOR,
+    );
+    const decoder = getGatewayDecoder();
+    const out: Array<{ pubkey: Address; operator: Address }> = [];
+    for (const { pubkey, data } of accounts) {
+      try {
+        const g = decoder.decode(data);
+        if (g.status === GatewayStatus.Gone) {
+          out.push({ pubkey, operator: g.operator });
+        }
+      } catch {
+        // skip malformed
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Enumerate Delegation PDAs with `amount == 0`. Eligible for
+   * `closeEmptyDelegation` (rent refund to the original delegator).
+   */
+  async getEmptyDelegations(): Promise<
+    Array<{ pubkey: Address; gateway: Address; delegator: Address }>
+  > {
+    const accounts = await this.getAccountsByDiscriminator(
+      this.garProgram,
+      DELEGATION_DISCRIMINATOR,
+    );
+    const decoder = getDelegationDecoder();
+    const out: Array<{
+      pubkey: Address;
+      gateway: Address;
+      delegator: Address;
+    }> = [];
+    for (const { pubkey, data } of accounts) {
+      try {
+        const d = decoder.decode(data);
+        if (d.amount === 0n) {
+          out.push({ pubkey, gateway: d.gateway, delegator: d.delegator });
+        }
+      } catch {
+        // skip malformed
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Enumerate Withdrawal PDAs with `amount == 0` (drained via
+   * fund-from-withdrawal payments). Eligible for `closeDrainedWithdrawal`
+   * (rent refund to owner).
+   */
+  async getDrainedWithdrawals(): Promise<
+    Array<{ pubkey: Address; owner: Address; withdrawalId: bigint }>
+  > {
+    const accounts = await this.getAccountsByDiscriminator(
+      this.garProgram,
+      WITHDRAWAL_DISCRIMINATOR,
+    );
+    const decoder = getWithdrawalDecoder();
+    const out: Array<{
+      pubkey: Address;
+      owner: Address;
+      withdrawalId: bigint;
+    }> = [];
+    for (const { pubkey, data } of accounts) {
+      try {
+        const w = decoder.decode(data);
+        if (w.amount === 0n) {
+          out.push({ pubkey, owner: w.owner, withdrawalId: w.withdrawalId });
+        }
+      } catch {
+        // skip malformed
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Enumerate Vault PDAs whose `end_timestamp` has passed (eligible for
+   * `releaseVault`). Note: `releaseVault` is owner-signed, so the cranker
+   * can only release its own vaults — the helper still surfaces every
+   * expired vault so other consumers (UIs, indexers) can use it too.
+   */
+  async getExpiredVaults(now: number): Promise<
+    Array<{
+      pubkey: Address;
+      owner: Address;
+      vaultId: bigint;
+      endTimestamp: bigint;
+    }>
+  > {
+    const accounts = await this.getAccountsByDiscriminator(
+      this.coreProgram,
+      VAULT_DISCRIMINATOR,
+    );
+    const decoder = getVaultDecoder();
+    const out: Array<{
+      pubkey: Address;
+      owner: Address;
+      vaultId: bigint;
+      endTimestamp: bigint;
+    }> = [];
+    for (const { pubkey, data } of accounts) {
+      try {
+        const v = decoder.decode(data);
+        if (Number(v.endTimestamp) <= now) {
+          out.push({
+            pubkey,
+            owner: v.owner,
+            vaultId: v.vaultId,
+            endTimestamp: v.endTimestamp,
+          });
+        }
+      } catch {
+        // skip malformed
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Enumerate PrimaryNameRequest PDAs whose `expires_at` has passed.
+   * Eligible for `closeExpiredRequest` (rent refund to original initiator).
+   */
+  async getExpiredPrimaryNameRequests(
+    now: number,
+  ): Promise<Array<{ pubkey: Address; initiator: Address }>> {
+    const accounts = await this.getAccountsByDiscriminator(
+      this.coreProgram,
+      PRIMARY_NAME_REQUEST_DISCRIMINATOR,
+    );
+    const decoder = getPrimaryNameRequestDecoder();
+    const out: Array<{ pubkey: Address; initiator: Address }> = [];
+    for (const { pubkey, data } of accounts) {
+      try {
+        const r = decoder.decode(data);
+        if (Number(r.expiresAt) <= now) {
+          out.push({ pubkey, initiator: r.initiator });
+        }
+      } catch {
+        // skip malformed
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Read the live `ArnsConfig` (used by the cranker to gate
+   * `pruneExpiredNames` / `pruneReturnedNames` on the
+   * `next_*_prune_timestamp` hints).
+   */
+  async getArnsConfigRaw(): Promise<{
+    nextRecordsPruneTimestamp: bigint;
+    nextReturnedNamesPruneTimestamp: bigint;
+    gracePeriodSeconds: bigint;
+    returnAuctionDurationSeconds: bigint;
+  } | null> {
+    const [pda] = await getArnsSettingsPDA(this.arnsProgram);
+    const account = await this.getAccount(pda);
+    if (!account.exists) return null;
+    const cfg = getArnsConfigDecoder().decode(account.data);
+    return {
+      nextRecordsPruneTimestamp: cfg.nextRecordsPruneTimestamp,
+      nextReturnedNamesPruneTimestamp: cfg.nextReturnedNamesPruneTimestamp,
+      gracePeriodSeconds: cfg.gracePeriodSeconds,
+      returnAuctionDurationSeconds: cfg.returnAuctionDurationSeconds,
+    };
   }
 
   // =========================================

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -693,7 +693,6 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
         protocol: Protocol.Https,
         properties: params.properties ?? null,
         note: params.note ?? null,
-        autoStake: params.autoStake ?? false,
         allowDelegatedStaking:
           params.allowDelegatedStaking === true ||
           params.allowDelegatedStaking === 'allowlist',
@@ -760,7 +759,6 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
         protocol: null,
         properties: params.properties ?? null,
         note: params.note ?? null,
-        autoStake: params.autoStake ?? null,
         allowDelegatedStaking:
           typeof params.allowDelegatedStaking === 'boolean'
             ? params.allowDelegatedStaking

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -84,6 +84,10 @@ import {
   getIncreaseUndernameLimitFromOperatorStakeInstructionAsync,
   getIncreaseUndernameLimitFromWithdrawalInstructionAsync,
   getIncreaseUndernameLimitInstructionAsync,
+  getPruneExpiredNamesInstructionAsync,
+  getPruneExpiredReservationInstruction,
+  getPruneNameToReturnedInstructionAsync,
+  getPruneReturnedNamesInstructionAsync,
   getReassignNameInstructionAsync,
   getReleaseNameInstructionAsync,
   getUpgradeNameFromDelegationInstructionAsync,
@@ -137,18 +141,23 @@ import {
   getCancelWithdrawalInstruction,
   getClaimDelegateFromLeavingGatewayInstructionAsync,
   getClaimWithdrawalInstructionAsync,
+  getCloseDrainedWithdrawalInstruction,
+  getCloseEmptyDelegationInstruction,
   getCloseEpochInstructionAsync,
+  getCloseObservationInstructionAsync,
   getCreateEpochInstructionAsync,
   getDecreaseDelegateStakeInstructionAsync,
   getDecreaseOperatorStakeInstructionAsync,
   getDelegateStakeInstructionAsync,
   getDisallowDelegateInstructionAsync,
   getDistributeEpochInstructionAsync,
+  getFinalizeGoneInstructionAsync,
   getIncreaseOperatorStakeInstructionAsync,
   getInstantWithdrawalInstructionAsync,
   getJoinNetworkInstructionAsync,
   getLeaveNetworkInstructionAsync,
   getPrescribeEpochInstructionAsync,
+  getPruneGatewayInstructionAsync,
   getRedelegateStakeInstructionAsync,
   getSaveObservationsInstructionAsync,
   getSetAllowlistEnabledInstructionAsync,
@@ -170,6 +179,7 @@ import {
   getGarSettingsPDA,
   getGatewayPDA,
   getGatewayRegistryPDA,
+  getObservationPDA,
   getObserverLookupPDA,
   getPrimaryNamePDA,
   getPrimaryNameRequestPDA,
@@ -431,6 +441,18 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     );
     const toATA = await getAssociatedTokenAddressKit(mint, recipient);
 
+    // The on-chain `Transfer` ix requires `to_token_account` to exist as a
+    // valid SPL TokenAccount (`AccountNotInitialized` #3012 otherwise).
+    // Bundle an idempotent CreateAssociatedTokenAccount so a fresh recipient
+    // wallet just works — same pattern as `vaultedTransfer` below. Idempotent
+    // means a second transfer to the same recipient is a no-op for this ix.
+    const createToAtaIx = buildCreateAtaIdempotentIx(
+      this.signer.address,
+      toATA,
+      recipient,
+      mint,
+    );
+
     const ix = getTransferInstruction(
       {
         fromTokenAccount: fromATA,
@@ -441,7 +463,7 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       { programAddress: this.coreProgram },
     );
 
-    const sig = await this.sendTransaction([ix]);
+    const sig = await this.sendTransaction([createToAtaIx, ix]);
     return { id: sig };
   }
 
@@ -1522,19 +1544,17 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       commitment: this.commitment,
     });
     if (!dfAccount.exists) throw new Error('DemandFactor not found');
-    // Layout: disc(8) + current_demand_factor(8) + ... + fees[51](u64×51).
-    // Fees array starts at offset that depends on the struct layout — we
-    // safely read the first 8+51*8 bytes.
     const data = Buffer.from(dfAccount.data);
     const dv = new DataView(data.buffer, data.byteOffset, data.byteLength);
     const demandFactor = dv.getBigUint64(8, true);
-    // Fees layout is: disc(8) + current_demand_factor(8) +
-    //                 purchases_this_period(8) + revenue_this_period(8) +
-    //                 period_zero_start_timestamp(8) + ... + fees[51]
-    // To stay decoupled from non-fee fields, we read the whole array
-    // assuming fees starts at a known offset. See ArNS DemandFactor struct.
-    // Pragmatic fallback: use a fixed fees offset of 56 (post-disc + 6 u64s).
-    const FEES_OFFSET = 56;
+    // DemandFactor layout (Borsh, packed; ario-arns/src/state/mod.rs):
+    //   disc(8) + current_demand_factor(u64) + current_period(u64) +
+    //   purchases_this_period(u64) + revenue_this_period(u64) +
+    //   consecutive_periods_with_min_demand_factor(u32) +
+    //   trailing_period_purchases([u64; 7]) +
+    //   trailing_period_revenues([u64; 7]) + fees([u64; 51]) + ...
+    // -> fees starts at 8 + 8 + 8 + 8 + 8 + 4 + 56 + 56 = 156.
+    const FEES_OFFSET = 156;
     if (data.length < FEES_OFFSET + 51 * 8) {
       throw new Error('DemandFactor account data too short for fees array');
     }
@@ -1919,7 +1939,7 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     const data = Buffer.from(dfAccount.data);
     const dv = new DataView(data.buffer, data.byteOffset, data.byteLength);
     const demandFactor = dv.getBigUint64(8, true);
-    const FEES_OFFSET = 56;
+    const FEES_OFFSET = 156; // see DemandFactor layout note above
     const idx = Math.min(Math.max(args.name.length, 1), 51) - 1;
     const baseFee = dv.getBigUint64(FEES_OFFSET + idx * 8, true);
     const SCALE = 1_000_000n;
@@ -3047,4 +3067,292 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       endTimestamp,
     };
   }
+
+  // =========================================
+  // Prune / cleanup (permissionless crank)
+  // =========================================
+  //
+  // These mirror `tick()`-driven lazy pruning in the Lua source — on Solana
+  // each is a discrete instruction someone has to call. All are
+  // permissionless except `releaseVault`, which the on-chain handler still
+  // gates on `owner: Signer` (ADR / vault.rs::ReleaseVault). See
+  // docs/CRANKER_PRUNING_PLAN.md for the full design.
+
+  /**
+   * Batch-prune expired ArnsRecord PDAs from the NameRegistry. The caller
+   * supplies the eligible records as `arnsRecords` — they're appended as
+   * `remaining_accounts` and the on-chain handler verifies each is past
+   * `end_timestamp + grace_period + return_auction_duration` before closing.
+   * `maxNames` caps the per-tx work (u8). Submit in batches of ~10-15.
+   */
+  async pruneExpiredNames(
+    params: { maxNames: number; arnsRecords: string[] },
+    _options?: WriteOptions,
+  ): Promise<AoMessageResult> {
+    const ix = await getPruneExpiredNamesInstructionAsync(
+      await this.withArnsDefaults({
+        payer: this.signer,
+        maxNames: params.maxNames,
+      }),
+      { programAddress: this.arnsProgram },
+    );
+
+    const remaining: AccountMeta[] = params.arnsRecords.map((a) => ({
+      address: address(a),
+      role: AccountRole.WRITABLE,
+    }));
+
+    const sig = await this.sendTransaction(
+      [withRemainingAccounts(ix, remaining)],
+      1_000_000,
+    );
+    return { id: sig };
+  }
+
+  /**
+   * Convert a single expired-but-not-yet-returned lease into a `ReturnedName`
+   * (kicks off the Dutch auction). Permissionless.
+   */
+  async pruneNameToReturned(
+    params: { name: string },
+    _options?: WriteOptions,
+  ): Promise<AoMessageResult> {
+    const [arnsRecord] = await getArnsRecordPDA(params.name, this.arnsProgram);
+    const [returnedName] = await getReturnedNamePDA(
+      params.name,
+      this.arnsProgram,
+    );
+
+    const ix = await getPruneNameToReturnedInstructionAsync(
+      await this.withArnsDefaults({
+        arnsRecord,
+        returnedName,
+        payer: this.signer,
+      }),
+      { programAddress: this.arnsProgram },
+    );
+
+    const sig = await this.sendTransaction([ix]);
+    return { id: sig };
+  }
+
+  /**
+   * Batch-prune expired ReturnedName PDAs (auction window elapsed). Caller
+   * supplies the eligible PDAs as `returnedNames`; they're appended as
+   * `remaining_accounts`. `maxNames` caps per-tx work (u8).
+   */
+  async pruneReturnedNames(
+    params: { maxNames: number; returnedNames: string[] },
+    _options?: WriteOptions,
+  ): Promise<AoMessageResult> {
+    const ix = await getPruneReturnedNamesInstructionAsync(
+      await this.withArnsDefaults({
+        payer: this.signer,
+        maxNames: params.maxNames,
+      }),
+      { programAddress: this.arnsProgram },
+    );
+
+    const remaining: AccountMeta[] = params.returnedNames.map((a) => ({
+      address: address(a),
+      role: AccountRole.WRITABLE,
+    }));
+
+    const sig = await this.sendTransaction([
+      withRemainingAccounts(ix, remaining),
+    ]);
+    return { id: sig };
+  }
+
+  /**
+   * Close a single expired ReservedName PDA. Permissionless after
+   * `expires_at`.
+   */
+  async pruneExpiredReservation(
+    params: { name: string },
+    _options?: WriteOptions,
+  ): Promise<AoMessageResult> {
+    const [reservedName] = await getReservedNamePDA(
+      params.name,
+      this.arnsProgram,
+    );
+
+    const ix = getPruneExpiredReservationInstruction(
+      {
+        reservedName,
+        payer: this.signer,
+      },
+      { programAddress: this.arnsProgram },
+    );
+
+    const sig = await this.sendTransaction([ix]);
+    return { id: sig };
+  }
+
+  /**
+   * Slash and remove a deficient gateway (`stats.failed_consecutive >=
+   * max_consecutive_failures`). Builds the protected exit vault for the
+   * post-slash min portion plus the optional excess vault for any surplus.
+   * The contract's `excess_withdrawal: Option<UncheckedAccount>` slot is
+   * always passed (PDA derived from `next_id + 1`); the handler consumes
+   * it only when the post-slash stake exceeds `min_operator_stake`.
+   * Permissionless.
+   */
+  async pruneGateway(
+    params: { gateway: string },
+    _options?: WriteOptions,
+  ): Promise<AoMessageResult> {
+    const gatewayAddr = address(params.gateway);
+    const garConfig = await this.getGarConfig();
+
+    const [gatewayPda] = await getGatewayPDA(gatewayAddr, this.garProgram);
+    const [withdrawalCounterPda] = await getWithdrawalCounterPDA(
+      gatewayAddr,
+      this.garProgram,
+    );
+    const nextId = await this.getNextWithdrawalId(gatewayAddr);
+    const [withdrawalPda] = await getWithdrawalPDA(
+      gatewayAddr,
+      nextId,
+      this.garProgram,
+    );
+    const [excessWithdrawalPda] = await getWithdrawalPDA(
+      gatewayAddr,
+      nextId + 1n,
+      this.garProgram,
+    );
+
+    const ix = await getPruneGatewayInstructionAsync(
+      await this.withGarDefaults({
+        gateway: gatewayPda,
+        withdrawalCounter: withdrawalCounterPda,
+        withdrawal: withdrawalPda,
+        excessWithdrawal: excessWithdrawalPda,
+        stakeTokenAccount: garConfig.stakeTokenAccount,
+        protocolTokenAccount: garConfig.protocolTokenAccount,
+        payer: this.signer,
+      }),
+      { programAddress: this.garProgram },
+    );
+
+    const sig = await this.sendTransaction([ix], 1_000_000);
+    return { id: sig };
+  }
+
+  /**
+   * GC a `Leaving`/`Gone` gateway whose leave window has fully elapsed.
+   * Closes the Gateway PDA and refunds rent to the caller. Permissionless.
+   */
+  async finalizeGone(
+    params: { gateway: string },
+    _options?: WriteOptions,
+  ): Promise<AoMessageResult> {
+    const gatewayAddr = address(params.gateway);
+    const [gatewayPda] = await getGatewayPDA(gatewayAddr, this.garProgram);
+
+    const ix = await getFinalizeGoneInstructionAsync(
+      await this.withGarDefaults({
+        gateway: gatewayPda,
+        caller: this.signer,
+      }),
+      { programAddress: this.garProgram },
+    );
+
+    const sig = await this.sendTransaction([ix]);
+    return { id: sig };
+  }
+
+  /**
+   * Reclaim rent from an Observation PDA whose epoch has been distributed.
+   * Permissionless. Pass `epochIndex` and the `observer` address used as
+   * the Observation seed.
+   */
+  async closeObservation(
+    params: { epochIndex: number; observer: string },
+    _options?: WriteOptions,
+  ): Promise<AoMessageResult> {
+    const observerAddr = address(params.observer);
+    const [observationPda] = await getObservationPDA(
+      params.epochIndex,
+      observerAddr,
+      this.garProgram,
+    );
+
+    const ix = await getCloseObservationInstructionAsync(
+      {
+        observation: observationPda,
+        payer: this.signer,
+        epochIndex: BigInt(params.epochIndex),
+      },
+      { programAddress: this.garProgram },
+    );
+
+    const sig = await this.sendTransaction([ix]);
+    return { id: sig };
+  }
+
+  /**
+   * Close an empty Delegation PDA (`amount == 0`) and refund rent to the
+   * original delegator (NOT the caller — see GAR-016, prevents griefing).
+   * Permissionless.
+   */
+  async closeEmptyDelegation(
+    params: { gateway: string; delegator: string },
+    _options?: WriteOptions,
+  ): Promise<AoMessageResult> {
+    const gatewayAddr = address(params.gateway);
+    const delegatorAddr = address(params.delegator);
+    const [gatewayPda] = await getGatewayPDA(gatewayAddr, this.garProgram);
+    const [delegationPda] = await getDelegationPDA(
+      gatewayAddr,
+      delegatorAddr,
+      this.garProgram,
+    );
+
+    const ix = getCloseEmptyDelegationInstruction(
+      {
+        gateway: gatewayPda,
+        delegation: delegationPda,
+        delegator: delegatorAddr,
+        payer: this.signer,
+      },
+      { programAddress: this.garProgram },
+    );
+
+    const sig = await this.sendTransaction([ix]);
+    return { id: sig };
+  }
+
+  /**
+   * Close a drained Withdrawal PDA (`amount == 0`) and refund rent to the
+   * original owner (NOT the caller). Permissionless.
+   */
+  async closeDrainedWithdrawal(
+    params: { owner: string; withdrawalId: number | bigint },
+    _options?: WriteOptions,
+  ): Promise<AoMessageResult> {
+    const ownerAddr = address(params.owner);
+    const [withdrawalPda] = await getWithdrawalPDA(
+      ownerAddr,
+      BigInt(params.withdrawalId),
+      this.garProgram,
+    );
+
+    const ix = getCloseDrainedWithdrawalInstruction(
+      {
+        withdrawal: withdrawalPda,
+        owner: ownerAddr,
+        closer: this.signer,
+      },
+      { programAddress: this.garProgram },
+    );
+
+    const sig = await this.sendTransaction([ix]);
+    return { id: sig };
+  }
+
+  // NOTE: `releaseVault` and `closeExpiredRequest` already exist higher in
+  // this class (under `Vault release` / `Close expired primary name request`
+  // sections). Both fit the cranker's permissionless cleanup surface, so the
+  // cranker uses them in `runCleanup()` directly.
 }

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -3158,9 +3158,13 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       role: AccountRole.WRITABLE,
     }));
 
-    const sig = await this.sendTransaction([
-      withRemainingAccounts(ix, remaining),
-    ]);
+    // Match `pruneExpiredNames` (1M CU) — both dispatch the same batched
+    // shape over `remaining_accounts`, and the default 400K is too tight
+    // when the cranker batches near `maxNames` (≈15) on a busy registry.
+    const sig = await this.sendTransaction(
+      [withRemainingAccounts(ix, remaining)],
+      1_000_000,
+    );
     return { id: sig };
   }
 

--- a/src/solana/prune-discovery.test.ts
+++ b/src/solana/prune-discovery.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Unit tests for the SolanaARIOReadable prune-discovery surface.
+ *
+ * Each helper uses the shape:
+ *   1. `getProgramAccounts(programId, { filters: [discriminator, ...] })`
+ *   2. Decode bytes via the codama-generated decoder
+ *   3. Apply a pure filter predicate
+ *
+ * These tests stub the rpc layer and inject pre-encoded account bytes,
+ * exercising the decode + filter pipeline end-to-end without standing
+ * up Surfpool. The codama encoders are the same ones the on-chain
+ * program uses, so this also validates wire-format parity for the
+ * subset of accounts the helpers touch.
+ *
+ * Coverage target: 9 discovery helpers + getArnsConfigRaw on
+ * SolanaARIOReadable. The remaining 2 (`getExpiredArnsRecords`,
+ * `getExpiredReturnedNames`) need a 2-step rpc dance (config fetch +
+ * account scan) and are exercised by the localnet smoke instead.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { type Address, address, createSolanaRpc } from '@solana/kit';
+
+import { ARIO_GAR_PROGRAM_ID } from './constants.js';
+import { getPrimaryNameRequestEncoder } from './generated/core/accounts/primaryNameRequest.js';
+import { getVaultEncoder } from './generated/core/accounts/vault.js';
+import { getDelegationEncoder } from './generated/gar/accounts/delegation.js';
+import { getGatewayEncoder } from './generated/gar/accounts/gateway.js';
+import { getWithdrawalEncoder } from './generated/gar/accounts/withdrawal.js';
+import { GatewayStatus, Protocol } from './generated/gar/types/index.js';
+import { SolanaARIOReadable } from './io-readable.js';
+
+// ---------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------
+
+const ADDR_A = '11111111111111111111111111111111' as Address;
+const ADDR_B = '22222222222222222222222222222222' as Address;
+const ADDR_C = '33333333333333333333333333333333' as Address;
+// 44-char base58 strings that decode to exactly 32 bytes — same fixture
+// pattern as funding-plan.test.ts.
+const PUBKEY_1 = 'GatewayAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as Address;
+const PUBKEY_2 = 'GatewayBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' as Address;
+const PUBKEY_3 = 'GatewayCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC' as Address;
+
+/**
+ * Build a minimal stub rpc that returns canned `getProgramAccounts`
+ * results. The helpers under test are agnostic to which programId they
+ * scan — we only validate the response shape downstream.
+ */
+function stubRpcReturning(
+  rows: Array<{ pubkey: Address; bytes: Uint8Array }>,
+): unknown {
+  const send = async () =>
+    rows.map(({ pubkey, bytes }) => ({
+      pubkey,
+      account: {
+        data: [Buffer.from(bytes).toString('base64'), 'base64'] as readonly [
+          string,
+          string,
+        ],
+      },
+    }));
+  return {
+    getProgramAccounts: () => ({ send }),
+    // Some helpers (getArnsConfigRaw, getExpiredArnsRecords) call
+    // fetchEncodedAccount under the hood, which uses getAccountInfo.
+    // Tests that don't exercise those skip the stub.
+    getAccountInfo: () => ({ send: async () => ({ value: null }) }),
+  };
+}
+
+function buildReadable(rpc: unknown): SolanaARIOReadable {
+  return new SolanaARIOReadable({
+    rpc: rpc as ReturnType<typeof createSolanaRpc>,
+  });
+}
+
+// ---------------------------------------------------------------
+// Delegation: getEmptyDelegations filters amount === 0n
+// ---------------------------------------------------------------
+
+describe('SolanaARIOReadable.getEmptyDelegations', () => {
+  it('returns only delegations with amount === 0', async () => {
+    const enc = getDelegationEncoder();
+    const empty = enc.encode({
+      gateway: PUBKEY_1,
+      delegator: PUBKEY_2,
+      amount: 0n,
+      startTimestamp: 1_000n,
+      rewardDebt: 0n,
+      bump: 254,
+    });
+    const nonEmpty = enc.encode({
+      gateway: PUBKEY_1,
+      delegator: PUBKEY_3,
+      amount: 12345n,
+      startTimestamp: 1_000n,
+      rewardDebt: 0n,
+      bump: 254,
+    });
+    const rpc = stubRpcReturning([
+      { pubkey: ADDR_A, bytes: empty },
+      { pubkey: ADDR_B, bytes: nonEmpty },
+    ]);
+    const r = buildReadable(rpc);
+
+    const out = await r.getEmptyDelegations();
+    assert.equal(out.length, 1, 'only the amount=0 row should survive');
+    assert.equal(out[0].pubkey, ADDR_A);
+    assert.equal(out[0].gateway, PUBKEY_1);
+    assert.equal(out[0].delegator, PUBKEY_2);
+  });
+
+  it('returns empty array when nothing matches', async () => {
+    const enc = getDelegationEncoder();
+    const nonEmpty = enc.encode({
+      gateway: PUBKEY_1,
+      delegator: PUBKEY_2,
+      amount: 999n,
+      startTimestamp: 1_000n,
+      rewardDebt: 0n,
+      bump: 254,
+    });
+    const rpc = stubRpcReturning([{ pubkey: ADDR_A, bytes: nonEmpty }]);
+    const r = buildReadable(rpc);
+
+    const out = await r.getEmptyDelegations();
+    assert.equal(out.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------
+// Withdrawal: getDrainedWithdrawals filters amount === 0n
+// ---------------------------------------------------------------
+
+describe('SolanaARIOReadable.getDrainedWithdrawals', () => {
+  it('returns only withdrawals with amount === 0', async () => {
+    const enc = getWithdrawalEncoder();
+    const drained = enc.encode({
+      owner: PUBKEY_1,
+      withdrawalId: 7n,
+      gateway: PUBKEY_2,
+      amount: 0n,
+      createdAt: 100n,
+      availableAt: 200n,
+      isDelegate: false,
+      isExitVault: false,
+      isProtected: false,
+      bump: 253,
+    });
+    const live = enc.encode({
+      owner: PUBKEY_1,
+      withdrawalId: 8n,
+      gateway: PUBKEY_2,
+      amount: 1_000_000n,
+      createdAt: 100n,
+      availableAt: 200n,
+      isDelegate: true,
+      isExitVault: false,
+      isProtected: false,
+      bump: 253,
+    });
+    const rpc = stubRpcReturning([
+      { pubkey: ADDR_A, bytes: drained },
+      { pubkey: ADDR_B, bytes: live },
+    ]);
+    const r = buildReadable(rpc);
+
+    const out = await r.getDrainedWithdrawals();
+    assert.equal(out.length, 1);
+    assert.equal(out[0].pubkey, ADDR_A);
+    assert.equal(out[0].owner, PUBKEY_1);
+    assert.equal(out[0].withdrawalId, 7n);
+  });
+});
+
+// ---------------------------------------------------------------
+// Vault: getExpiredVaults filters endTimestamp <= now
+// ---------------------------------------------------------------
+
+describe('SolanaARIOReadable.getExpiredVaults', () => {
+  it('returns vaults whose endTimestamp <= now', async () => {
+    const enc = getVaultEncoder();
+    const expired = enc.encode({
+      owner: PUBKEY_1,
+      vaultId: 1n,
+      amount: 100n,
+      startTimestamp: 0n,
+      endTimestamp: 500n,
+      controller: null,
+      revocable: false,
+      bump: 252,
+    });
+    const future = enc.encode({
+      owner: PUBKEY_1,
+      vaultId: 2n,
+      amount: 100n,
+      startTimestamp: 0n,
+      endTimestamp: 9_999_999n,
+      controller: null,
+      revocable: false,
+      bump: 252,
+    });
+    const rpc = stubRpcReturning([
+      { pubkey: ADDR_A, bytes: expired },
+      { pubkey: ADDR_B, bytes: future },
+    ]);
+    const r = buildReadable(rpc);
+
+    const out = await r.getExpiredVaults(/* now */ 1_000);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].pubkey, ADDR_A);
+    assert.equal(out[0].vaultId, 1n);
+    assert.equal(out[0].endTimestamp, 500n);
+  });
+
+  it('exact-equality endTimestamp === now is treated as expired', async () => {
+    const enc = getVaultEncoder();
+    const exact = enc.encode({
+      owner: PUBKEY_1,
+      vaultId: 9n,
+      amount: 1n,
+      startTimestamp: 0n,
+      endTimestamp: 1_000n,
+      controller: null,
+      revocable: false,
+      bump: 252,
+    });
+    const rpc = stubRpcReturning([{ pubkey: ADDR_A, bytes: exact }]);
+    const r = buildReadable(rpc);
+
+    const out = await r.getExpiredVaults(1_000);
+    assert.equal(out.length, 1, 'endTimestamp === now boundary is inclusive');
+  });
+});
+
+// ---------------------------------------------------------------
+// PrimaryNameRequest: getExpiredPrimaryNameRequests filters expiresAt <= now
+// ---------------------------------------------------------------
+
+describe('SolanaARIOReadable.getExpiredPrimaryNameRequests', () => {
+  it('returns requests whose expiresAt <= now', async () => {
+    const enc = getPrimaryNameRequestEncoder();
+    const expired = enc.encode({
+      initiator: PUBKEY_1,
+      name: 'oldname',
+      createdAt: 0n,
+      expiresAt: 100n,
+      bump: 251,
+    });
+    const future = enc.encode({
+      initiator: PUBKEY_2,
+      name: 'futurename',
+      createdAt: 0n,
+      expiresAt: 9_999_999n,
+      bump: 251,
+    });
+    const rpc = stubRpcReturning([
+      { pubkey: ADDR_A, bytes: expired },
+      { pubkey: ADDR_B, bytes: future },
+    ]);
+    const r = buildReadable(rpc);
+
+    const out = await r.getExpiredPrimaryNameRequests(/* now */ 1_000);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].pubkey, ADDR_A);
+    assert.equal(out[0].initiator, PUBKEY_1);
+  });
+});
+
+// ---------------------------------------------------------------
+// Gateway: getDeficientGateways + getGoneGateways filter on status + stats
+// ---------------------------------------------------------------
+
+function makeGatewayBytes(
+  operator: Address,
+  status: GatewayStatus,
+  failedConsecutive: number,
+): Uint8Array {
+  const enc = getGatewayEncoder();
+  return enc.encode({
+    operator,
+    label: 'lbl',
+    fqdn: 'gw.example',
+    port: 443,
+    protocol: Protocol.Https,
+    properties: '',
+    note: '',
+    operatorStake: 1_000n,
+    totalDelegatedStake: 0n,
+    status,
+    startTimestamp: 0n,
+    leaveTimestamp: null,
+    leaveEpochDuration: 0n,
+    stats: {
+      passedEpochs: 0,
+      failedEpochs: failedConsecutive,
+      totalEpochs: failedConsecutive,
+      prescribedEpochs: 0,
+      observedEpochs: 0,
+      failedConsecutive,
+      passedConsecutive: 0,
+    },
+    weights: {
+      stakeWeight: 0n,
+      tenureWeight: 0n,
+      gatewayPerformanceRatio: 0n,
+      observerPerformanceRatio: 0n,
+      compositeWeight: 0n,
+      normalizedCompositeWeight: 0n,
+      weightsEpoch: 0n,
+    },
+    settings: {
+      allowDelegatedStaking: false,
+      delegateRewardShareRatio: 0,
+      minDelegationAmount: 0n,
+      allowlistEnabled: false,
+    },
+    registryIndex: { index: 0, _reserved: 0 },
+    observerAddress: operator,
+    cumulativeRewardPerToken: 0n,
+    bump: 250,
+  });
+}
+
+describe('SolanaARIOReadable.getDeficientGateways', () => {
+  it('returns Joined gateways with failedConsecutive >= threshold', async () => {
+    const deficient = makeGatewayBytes(PUBKEY_1, GatewayStatus.Joined, 30);
+    const healthy = makeGatewayBytes(PUBKEY_2, GatewayStatus.Joined, 5);
+    const goneFailing = makeGatewayBytes(PUBKEY_3, GatewayStatus.Gone, 99);
+    const rpc = stubRpcReturning([
+      { pubkey: ADDR_A, bytes: deficient },
+      { pubkey: ADDR_B, bytes: healthy },
+      { pubkey: ADDR_C, bytes: goneFailing },
+    ]);
+    const r = buildReadable(rpc);
+
+    const out = await r.getDeficientGateways(30);
+    assert.equal(
+      out.length,
+      1,
+      'only Joined+failedConsecutive>=30 should match (Gone gateways excluded)',
+    );
+    assert.equal(out[0].pubkey, ADDR_A);
+    assert.equal(out[0].operator, PUBKEY_1);
+    assert.equal(out[0].failedConsecutive, 30);
+  });
+
+  it('respects custom threshold', async () => {
+    const at5 = makeGatewayBytes(PUBKEY_1, GatewayStatus.Joined, 5);
+    const at10 = makeGatewayBytes(PUBKEY_2, GatewayStatus.Joined, 10);
+    const rpc = stubRpcReturning([
+      { pubkey: ADDR_A, bytes: at5 },
+      { pubkey: ADDR_B, bytes: at10 },
+    ]);
+    const r = buildReadable(rpc);
+
+    const out = await r.getDeficientGateways(7);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].failedConsecutive, 10);
+  });
+});
+
+describe('SolanaARIOReadable.getGoneGateways', () => {
+  it('returns only gateways with status === Gone', async () => {
+    const joined = makeGatewayBytes(PUBKEY_1, GatewayStatus.Joined, 0);
+    const leaving = makeGatewayBytes(PUBKEY_2, GatewayStatus.Leaving, 0);
+    const gone = makeGatewayBytes(PUBKEY_3, GatewayStatus.Gone, 0);
+    const rpc = stubRpcReturning([
+      { pubkey: ADDR_A, bytes: joined },
+      { pubkey: ADDR_B, bytes: leaving },
+      { pubkey: ADDR_C, bytes: gone },
+    ]);
+    const r = buildReadable(rpc);
+
+    const out = await r.getGoneGateways();
+    assert.equal(
+      out.length,
+      1,
+      'only Gone gateways are eligible for finalize_gone GC',
+    );
+    assert.equal(out[0].pubkey, ADDR_C);
+    assert.equal(out[0].operator, PUBKEY_3);
+  });
+});
+
+// ---------------------------------------------------------------
+// Resilience: malformed bytes don't crash discovery
+// ---------------------------------------------------------------
+
+describe('Discovery helpers gracefully skip undecodable rows', () => {
+  it('getEmptyDelegations skips a row whose bytes are too short', async () => {
+    const enc = getDelegationEncoder();
+    const valid = enc.encode({
+      gateway: PUBKEY_1,
+      delegator: PUBKEY_2,
+      amount: 0n,
+      startTimestamp: 1_000n,
+      rewardDebt: 0n,
+      bump: 254,
+    });
+    const truncated = valid.subarray(0, 16); // half a Delegation
+    const rpc = stubRpcReturning([
+      { pubkey: ADDR_A, bytes: valid },
+      { pubkey: ADDR_B, bytes: truncated },
+    ]);
+    const r = buildReadable(rpc);
+
+    const out = await r.getEmptyDelegations();
+    // Malformed row is skipped silently — partial results > total failure.
+    assert.equal(out.length, 1);
+    assert.equal(out[0].pubkey, ADDR_A);
+  });
+});

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -833,6 +833,16 @@ export interface AoARIOWrite extends AoARIORead {
    * Solana-only: throws on the AO backend (AO ANTs have no NFT trait surface).
    */
   syncAttributes: AoWriteAction<{ name: string }, AoMessageResult>;
+
+  // NOTE: prune / cleanup methods (`pruneExpiredNames`, `pruneNameToReturned`,
+  // `pruneReturnedNames`, `pruneExpiredReservation`, `pruneGateway`,
+  // `finalizeGone`, `closeObservation`, `closeEmptyDelegation`,
+  // `closeDrainedWithdrawal`, `releaseVault`, `closeExpiredRequest`) are
+  // Solana-only and intentionally NOT on this interface — they have no AO
+  // analogue (Lua's `tick()` did this lazily). Consumers needing them
+  // should type the client as `SolanaARIOWriteable` directly. Keeps the
+  // cross-backend interface minimal and avoids stubs that throw on AO.
+  // See docs/CRANKER_PRUNING_PLAN.md.
 }
 
 // Type-guard functions


### PR DESCRIPTION
## Summary

Closes the `AccountNotInitialized` (#3012) gap reporters hit on devnet 2026-05-07 across three call sites the on-chain handlers leave to the SDK to set up. The .2 / .3 publishes that landed on the `solana` dist-tag earlier today were version-bump-only and didn't include PR #112's fix; this PR ports it cleanly + tightens the active-vault gap PR #112 missed. Also bundles the Solana-only permissionless prune / cleanup surface that mirrors Lua `tick()`.

## Bug fixes — all three are #3012 (`AccountNotInitialized`) for fresh-wallet recipients

1. **`SolanaARIOWriteable.transfer`** — sending ARIO to a wallet that has never received ARIO failed. Now prepends an idempotent `CreateAssociatedTokenAccount` for `toATA`. **(Reporter's bug.)**
2. **`ANTEscrow.maybeBundleVaultedTransfer`** — both branches now bundle the claimant ATA. The on-chain `ClaimVaultEthereum` / `ClaimVaultArweave` Accounts struct declares `claimant_token_account: Account<TokenAccount>`, which forces Anchor's account-load-time validation to require the account exist for **both** active and expired vault claims, even though the active path doesn't write to it. PR #112 fixed only the expired branch; this PR extends to active too.
3. **`claimTokensArweave` / `claimTokensEthereum`** — same fresh-wallet vector. Now prepends createATA for canonical claimant ATAs.

In all three places the createATA is skipped for non-canonical token accounts (caller-supplied non-ATAs are caller's responsibility). Adds a `_createClaimantAtaIfCanonical` private helper used by all three paths.

## Additive — Solana-only prune / cleanup surface (no AO analogue)

- **9 new `SolanaARIOWriteable` methods**: `pruneExpiredNames`, `pruneNameToReturned`, `pruneReturnedNames`, `pruneExpiredReservation`, `pruneGateway`, `finalizeGone`, `closeObservation`, `closeEmptyDelegation`, `closeDrainedWithdrawal`. The pre-existing `releaseVault` / `closeExpiredRequest` are unchanged.
- **10 `SolanaARIOReadable` discovery helpers**: `getExpiredArnsRecords`, `getExpiredReturnedNames`, `getExpiredReservations`, `getDeficientGateways`, `getGoneGateways`, `getEmptyDelegations`, `getDrainedWithdrawals`, `getExpiredVaults`, `getExpiredPrimaryNameRequests`, `getArnsConfigRaw`. Used by a cranker / UI to populate batches for the new ix wrappers.
- **11 CLI commands** (`yarn cli prune-expired-names`, ...) wired via a new `src/cli/commands/pruneCommands.ts`.

These prune methods are intentionally NOT on the cross-backend `AoARIOWrite` interface — they have no AO analogue (Lua `tick()` did this lazily). Consumers needing them type the client as `SolanaARIOWriteable` directly.

## Verification

- [x] `yarn build` (web + ESM + CJS) — clean
- [x] `yarn lint:check` — clean
- [x] `yarn test:unit` — 202/202 pass
- [x] `grep buildCreateAtaIdempotentIx lib/esm/solana/io-writeable.js` — 4 callsites (transfer + 3 escrow paths)
- [ ] Devnet smoke: reporter retries failing flow against `@ar.io/sdk@solana` once 4.0.0-solana.4 publishes
- [ ] `migration/import/smoke-test-escrow.ts` Test 5 (active-vault claim to fresh keypair) against devnet `8jj9gDRwNK9qLHzyA2V5CmU3EMVhHys13SN9pxbRpGpC`

## Test plan

- Wait for CI green on this branch
- Confirm semantic-release publishes 4.0.0-solana.4 on merge
- Verify the published artifact: `npm pack @ar.io/sdk@4.0.0-solana.4` → `grep -A2 "async transfer" package/lib/esm/solana/io-writeable.js` must show `buildCreateAtaIdempotentIx` before the transfer ix
- Reporter retries devnet transfer to a fresh keypair — should succeed

## Notes

- Commit prefix is `fix:` (not `feat:`) so semantic-release stays in the `4.0.0-solana.x` patch line. The prune surface is genuinely new capability but bundled here for shipping speed alongside the urgent #3012 fixes.
- Monorepo (`ar-io/solana-ar-io`) has a sibling PR landing the cranker integration + the same active-vault tightening backport so the trees stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added maintenance CLI commands for Solana, enabling users to perform cleanup operations on expired entries and drained accounts.
- Improved token claims and transfers with automatic account initialization to prevent failures.

**Bug Fixes**
- Resolved token claim failures for new wallet recipients by automatically creating required accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->