### PR TITLE
feat(solana): switch SDK transfer() to standard SPL transferChecked

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "@dha-team/arbundles": "^1.0.1",
     "@permaweb/aoconnect": "0.0.68",
     "@solana-program/compute-budget": "^0.15.0",
+    "@solana-program/token": "^0.13.0",
     "@solana/kit": "^6.8.0",
     "arweave": "1.15.5",
     "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "module": "./lib/esm/node/index.js",
   "types": "./lib/types/node/index.d.ts",
   "type": "module",
+  "packageManager": "yarn@1.22.22",
   "engines": {
     "node": ">=18"
   },

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -119,6 +119,7 @@ function toGeneratedFundingSourceSpec(
   };
   return { kind: kindMap[s.kind], amount: s.amount };
 }
+import { getTransferCheckedInstruction } from '@solana-program/token';
 import { getSyncAttributesInstruction } from './generated/ant/instructions/syncAttributes.js';
 import {
   getApprovePrimaryNameInstructionAsync,
@@ -133,7 +134,6 @@ import {
   getRevokeVaultInstructionAsync,
   getVaultedTransferInstructionAsync,
 } from './generated/core/instructions/index.js';
-import { getTransferCheckedInstruction } from '@solana-program/token';
 import { getDelegationDecoder } from './generated/gar/accounts/delegation.js';
 import { getGatewayDecoder } from './generated/gar/accounts/gateway.js';
 import {

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -120,6 +120,7 @@ function toGeneratedFundingSourceSpec(
   return { kind: kindMap[s.kind], amount: s.amount };
 }
 import { getTransferCheckedInstruction } from '@solana-program/token';
+import { TOKEN_DECIMALS } from './constants.js';
 import { getSyncAttributesInstruction } from './generated/ant/instructions/syncAttributes.js';
 import {
   getApprovePrimaryNameInstructionAsync,
@@ -464,7 +465,7 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       destination: toATA,
       authority: this.signer,
       amount,
-      decimals: 6, // ARIO mint decimals (ONE_TOKEN = 1_000_000)
+      decimals: TOKEN_DECIMALS,
     });
 
     const sig = await this.sendTransaction([createToAtaIx, ix]);

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -131,9 +131,9 @@ import {
   getRequestPrimaryNameFromFundingPlanInstructionAsync,
   getRequestPrimaryNameInstructionAsync,
   getRevokeVaultInstructionAsync,
-  getTransferInstruction,
   getVaultedTransferInstructionAsync,
 } from './generated/core/instructions/index.js';
+import { getTransferCheckedInstruction } from '@solana-program/token';
 import { getDelegationDecoder } from './generated/gar/accounts/delegation.js';
 import { getGatewayDecoder } from './generated/gar/accounts/gateway.js';
 import {
@@ -441,11 +441,9 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     );
     const toATA = await getAssociatedTokenAddressKit(mint, recipient);
 
-    // The on-chain `Transfer` ix requires `to_token_account` to exist as a
-    // valid SPL TokenAccount (`AccountNotInitialized` #3012 otherwise).
-    // Bundle an idempotent CreateAssociatedTokenAccount so a fresh recipient
-    // wallet just works — same pattern as `vaultedTransfer` below. Idempotent
-    // means a second transfer to the same recipient is a no-op for this ix.
+    // SPL `transferChecked` requires the recipient ATA to exist; bundle
+    // an idempotent ATA-create so fresh recipients just work. Same
+    // pattern as `vaultedTransfer` below.
     const createToAtaIx = buildCreateAtaIdempotentIx(
       this.signer.address,
       toATA,
@@ -453,15 +451,21 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       mint,
     );
 
-    const ix = getTransferInstruction(
-      {
-        fromTokenAccount: fromATA,
-        toTokenAccount: toATA,
-        authority: this.signer,
-        amount,
-      },
-      { programAddress: this.coreProgram },
-    );
+    // Standard SPL Token `transferChecked`. The custom `ario-core::transfer`
+    // ix is deprecated — it added no protocol-level accounting, just wrapped
+    // this same CPI plus a `TransferEvent` emission that no major Solana
+    // indexer needs (Helius, Solscan, etc. all track SPL transfers natively).
+    // See `docs/REMOVE_CUSTOM_TRANSFER_PLAN.md` in `ar-io/solana-ar-io`.
+    // `transferChecked` (vs `transfer`) validates the mint + decimals
+    // on-chain, preventing cross-mint mistakes.
+    const ix = getTransferCheckedInstruction({
+      source: fromATA,
+      mint,
+      destination: toATA,
+      authority: this.signer,
+      amount,
+      decimals: 6, // ARIO mint decimals (ONE_TOKEN = 1_000_000)
+    });
 
     const sig = await this.sendTransaction([createToAtaIx, ix]);
     return { id: sig };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2576,10 +2576,22 @@
   resolved "https://registry.yarnpkg.com/@solana-program/system/-/system-0.10.0.tgz#f68ffb0a3e1c1d5e68ecfe111fbbe729f95a582a"
   integrity sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==
 
+"@solana-program/system@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@solana-program/system/-/system-0.12.0.tgz#a69ebdd9918d5a0d06246555965a59a829991ad9"
+  integrity sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng==
+
 "@solana-program/token-2022@^0.6.1":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@solana-program/token-2022/-/token-2022-0.6.1.tgz#dcc44d56228e34c3b90099d9d3cab97d84c12367"
   integrity sha512-Ex02cruDMGfBMvZZCrggVR45vdQQSI/unHVpt/7HPt/IwFYB4eTlXtO8otYZyqV/ce5GqZ8S6uwyRf0zy6fdbA==
+
+"@solana-program/token@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@solana-program/token/-/token-0.13.0.tgz#6ef44f5fdc9cc4f087fcda3a001da8fe033ab678"
+  integrity sha512-/Apjrd5lwOJGrPB0J5Rv7EBeclvyEBQPAGA85Scm7wBH+GpkbdLDM9uK3TNg8jjFKyWQYai/JtPHbrx7VgFLSg==
+  dependencies:
+    "@solana-program/system" "^0.12.0"
 
 "@solana-program/token@^0.9.0":
   version "0.9.0"


### PR DESCRIPTION
## Summary
- Add `@solana-program/token` ^0.13.0 (kit-flavored SPL Token client) as a runtime dep
- Rewrite `SolanaARIOWriteable.transfer()` to build standard SPL `transferChecked` instead of calling the custom `ario-core::transfer` ix
- **Method signature unchanged** — `ARIO.transfer({ target, qty })` keeps the same shape; no breaking change for SDK consumers

## Why
The custom `ario-core::transfer` instruction adds no protocol-level accounting — it's a thin wrapper around `token::transfer` CPI plus a `TransferEvent` emission. Every Solana indexer tracks SPL transfers natively, so the event isn't needed. Standard SPL `transferChecked` (vs `transfer`) also validates the mint + decimals on-chain, preventing cross-mint mistakes.

The on-chain ix is being marked deprecated in [ar-io/ar-io-solana-contracts#14](https://github.com/ar-io/ar-io-solana-contracts/pull/14) (kept for IDL stability; will be removed in a future program upgrade).

## Coordinated with
- [ar-io/ar-io-solana-contracts#14](https://github.com/ar-io/ar-io-solana-contracts/pull/14) — on-chain deprecation comment
- [`ar-io/solana-ar-io@main`](https://github.com/ar-io/solana-ar-io/tree/docs/transfer-deprecation-followups) — test removal + F1/BD-085/UAT_MATRIX docs

Plan: [`docs/REMOVE_CUSTOM_TRANSFER_PLAN.md`](https://github.com/ar-io/solana-ar-io/blob/main/docs/REMOVE_CUSTOM_TRANSFER_PLAN.md) in `ar-io/solana-ar-io`.

## Note for reviewers
The existing `@solana-program/compute-budget` dep in `package.json` is currently **unused** in source — `send.ts` hand-rolls compute budget IXs. This PR sets the precedent of actually consuming a `@solana-program/*` package. Worth a follow-up to either consolidate on `@solana-program/*` packages (and remove the hand-rolled compute budget code) or drop the unused dep.

## Test plan
- [ ] `yarn build:esm` succeeds with the new dep
- [ ] `yarn test:unit` — encoder unit tests in `events.test.ts` for `TransferEvent` still pass (event type unchanged)
- [ ] Localnet: `ARIO.transfer({ target, qty })` from a fresh wallet succeeds, recipient receives correct amount, ATA auto-created
- [ ] Localnet: `decimals: 6` validation rejects a mint with different decimals (smoke test)
- [ ] Verify the deleted `events.localnet.test.ts:192-243` block in [`ar-io/solana-ar-io`](https://github.com/ar-io/solana-ar-io/tree/docs/transfer-deprecation-followups) lands before this SDK release ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)