### PR TITLE
chore(sdk): consolidate compute-budget on @solana-program/compute-budget

### DIFF
--- a/src/solana/send.ts
+++ b/src/solana/send.ts
@@ -1,13 +1,21 @@
 /**
  * Shared helpers for building, signing, and sending Solana transactions
  * with @solana/kit. Used by SolanaARIOWriteable and SolanaANTWriteable.
+ *
+ * Compute budget instruction builders come from `@solana-program/compute-budget`
+ * (kit-flavored Codama client); the previous hand-rolled
+ * `setComputeUnitLimitIx` / `setComputeUnitPriceIx` helpers were removed in
+ * favor of the official package. See `sendAndConfirm` below for why we always
+ * pin BOTH instructions (even with a 0 priority fee).
  */
 import {
-  type Address,
+  getSetComputeUnitLimitInstruction,
+  getSetComputeUnitPriceInstruction,
+} from '@solana-program/compute-budget';
+import {
   type Commitment,
   type Instruction,
   type TransactionSigner,
-  address,
   appendTransactionMessageInstructions,
   compileTransaction,
   createTransactionMessage,
@@ -21,68 +29,6 @@ import {
 } from '@solana/kit';
 
 import type { SolanaRpc, SolanaRpcSubscriptions } from './types.js';
-
-const COMPUTE_BUDGET_PROGRAM: Address = address(
-  'ComputeBudget111111111111111111111111111111',
-);
-
-/**
- * Build a `SetComputeUnitLimit` instruction.
- *
- * Layout (per solana-program/compute-budget):
- *   [0]     u8 = 2  (discriminator for SetComputeUnitLimit)
- *   [1..5]  u32 LE = units
- */
-export function setComputeUnitLimitIx(units: number): Instruction {
-  const data = new Uint8Array(5);
-  data[0] = 2;
-  // u32 little-endian
-  data[1] = units & 0xff;
-  data[2] = (units >>> 8) & 0xff;
-  data[3] = (units >>> 16) & 0xff;
-  data[4] = (units >>> 24) & 0xff;
-  return {
-    programAddress: COMPUTE_BUDGET_PROGRAM,
-    accounts: [],
-    data,
-  };
-}
-
-/**
- * Build a `SetComputeUnitPrice` instruction.
- *
- * Layout (per solana-program/compute-budget):
- *   [0]     u8 = 3  (discriminator for SetComputeUnitPrice)
- *   [1..9]  u64 LE = micro-lamports per compute unit
- *
- * We always prepend this (alongside `SetComputeUnitLimit`) before sending,
- * even with a 0 priority fee. Wallets like Phantom will silently *append*
- * their own compute-budget instructions when the transaction is missing
- * either, and that mutation invalidates any signatures already attached by
- * paired keypair signers (e.g. the ANT mint signer in `spawnSolanaANT`),
- * producing `Transaction did not pass signature verification` on the
- * validator. Pre-supplying both keeps the wallet from rewriting the
- * message, so signatures over the original bytes still verify.
- */
-export function setComputeUnitPriceIx(
-  microLamports: bigint | number,
-): Instruction {
-  const lamports =
-    typeof microLamports === 'bigint' ? microLamports : BigInt(microLamports);
-  const data = new Uint8Array(9);
-  data[0] = 3;
-  // u64 little-endian
-  let v = lamports;
-  for (let i = 0; i < 8; i++) {
-    data[1 + i] = Number(v & 0xffn);
-    v >>= 8n;
-  }
-  return {
-    programAddress: COMPUTE_BUDGET_PROGRAM,
-    accounts: [],
-    data,
-  };
-}
 
 /**
  * Build, sign, send, and confirm a transaction in one call.
@@ -114,12 +60,17 @@ export async function sendAndConfirm({
     (tx) =>
       appendTransactionMessageInstructions(
         [
-          setComputeUnitLimitIx(computeUnitLimit),
+          getSetComputeUnitLimitInstruction({ units: computeUnitLimit }),
           // Always pin the priority fee (even at 0) so wallets like Phantom
-          // don't silently append their own compute-budget instructions and
-          // invalidate paired keypair-signer signatures. See
-          // `setComputeUnitPriceIx` doc comment for the full story.
-          setComputeUnitPriceIx(0n),
+          // don't silently *append* their own compute-budget instructions
+          // when the transaction is missing either limit or price. That
+          // mutation invalidates signatures already attached by paired
+          // keypair signers (e.g. the ANT mint signer in `spawnSolanaANT`),
+          // producing `Transaction did not pass signature verification` on
+          // the validator. Pre-supplying both keeps the wallet from
+          // rewriting the message, so signatures over the original bytes
+          // still verify.
+          getSetComputeUnitPriceInstruction({ microLamports: 0n }),
           ...instructions,
         ],
         tx,

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -32,13 +32,16 @@ import {
   signTransactionMessageWithSigners,
 } from '@solana/kit';
 
+import {
+  getSetComputeUnitLimitInstruction,
+  getSetComputeUnitPriceInstruction,
+} from '@solana-program/compute-budget';
 import { SolanaANTRegistryWriteable } from './ant-registry-writeable.js';
 import { ARIO_ANT_PROGRAM_ID } from './constants.js';
 import { getInitializeInstructionAsync } from './generated/ant/instructions/index.js';
 import { getCreateV1Instruction } from './generated/mpl-core/instructions/index.js';
 import { DataState } from './generated/mpl-core/types/index.js';
 import { getAntRecordPDA } from './pda.js';
-import { setComputeUnitLimitIx, setComputeUnitPriceIx } from './send.js';
 import type {
   SolanaRpc,
   SolanaRpcSubscriptions,
@@ -336,12 +339,12 @@ export async function spawnSolanaANT(
     (tx) =>
       appendTransactionMessageInstructions(
         [
-          setComputeUnitLimitIx(computeUnitLimit),
+          getSetComputeUnitLimitInstruction({ units: computeUnitLimit }),
           // Pin the priority fee (at 0) so wallets like Phantom don't
           // silently append their own compute-budget instructions and
           // invalidate the paired mint keypair signer's signature. See
-          // `setComputeUnitPriceIx` for the full story.
-          setComputeUnitPriceIx(0n),
+          // `sendAndConfirm` in `./send.js` for the full rationale.
+          getSetComputeUnitPriceInstruction({ microLamports: 0n }),
           createIx,
           initIx,
           ...aclIxs,


### PR DESCRIPTION
Closes #624.

## Summary

`@solana-program/compute-budget` was already a declared runtime dep but unused in source — `send.ts` hand-rolled `setComputeUnitLimitIx` / `setComputeUnitPriceIx` with the wire layout written out byte by byte. That was the worst of both worlds: bundle bloat from the dep + a hand-written codec to maintain.

This PR switches to the official kit-flavored builders:
- `getSetComputeUnitLimitInstruction({ units })`
- `getSetComputeUnitPriceInstruction({ microLamports })`

Both are Codama-generated against the same on-chain program and produce byte-identical instructions to what we were rolling by hand. Same direction as [#623](https://github.com/ar-io/ar-io-sdk/pull/623) (`@solana-program/token` for SPL transfer) and as the `TODO(C7)` in `src/solana/ata.ts:6` (planned migration to `@solana-program/associated-token`).

## Changes

| File | Change |
|---|---|
| `src/solana/send.ts` | Drop the two hand-rolled helpers, the `COMPUTE_BUDGET_PROGRAM` address constant, and the now-unused `Address` / `address` imports from `@solana/kit`. Update internal call site in `sendAndConfirm`. Module JSDoc refreshed. |
| `src/solana/spawn-ant.ts` | Change import source from `./send.js` to `@solana-program/compute-budget`. Update both call sites; cross-reference comment now points at `sendAndConfirm` rather than the deleted helper. |

Net delta: **−73 lines of hand-rolled bytes + comments, +27 lines of imports and updated call sites.**

## Behavior

No behavioral change. Same instruction discriminators (2 and 3), same Compute Budget program (`ComputeBudget11...`), same data layout. Only the source of the builder code changes.

The `priority-fee-must-be-pinned-even-at-zero` invariant (because Phantom et al. silently append compute-budget instructions and invalidate paired keypair signatures otherwise) is preserved — the inline comment at the call site still spells it out.

## Test plan

- [x] `yarn lint:check` passes
- [x] `yarn format:check` passes
- [x] `yarn build:esm` passes
- [x] `yarn test:unit` passes
- [ ] Localnet smoke (`yarn test:localnet:permissionless` or similar) to confirm a real `spawnSolanaANT` still works end-to-end with the new builders — recommend reviewer runs locally before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)