### PR TITLE
feat(solana): return live delegation balances from read methods

### DIFF
--- a/src/solana/constants.ts
+++ b/src/solana/constants.ts
@@ -30,6 +30,12 @@ export const MPL_CORE_PROGRAM_ID: Address = address(
 export const TOKEN_DECIMALS = 6;
 export const ONE_TOKEN = 1_000_000; // 1 ARIO = 1,000,000 mARIO
 export const RATE_SCALE = 1_000_000;
+/**
+ * Scaling factor for the per-share reward accumulator
+ * `Gateway.cumulative_reward_per_token` in `ario-gar`. Must match the
+ * `REWARD_PRECISION` constant in `programs/ario-gar/src/state/mod.rs`.
+ */
+export const REWARD_PRECISION = 1_000_000_000_000_000_000n; // 1e18
 
 // =========================================
 // PDA Seeds — ario-core

--- a/src/solana/delegation-math.test.ts
+++ b/src/solana/delegation-math.test.ts
@@ -1,0 +1,91 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { REWARD_PRECISION } from './constants.js';
+import { computeLiveDelegationBalance } from './delegation-math.js';
+
+describe('computeLiveDelegationBalance', () => {
+  it('returns the raw amount when there is no accumulator delta', () => {
+    const live = computeLiveDelegationBalance({
+      delegatedStake: 10_000_000_000, // 10k ARIO
+      rewardDebt: 1234n,
+      cumulativeRewardPerToken: 1234n,
+    });
+    assert.equal(live, 10_000_000_000);
+  });
+
+  it('returns the raw amount when delegated stake is zero', () => {
+    const live = computeLiveDelegationBalance({
+      delegatedStake: 0,
+      rewardDebt: 0n,
+      cumulativeRewardPerToken: 5_000_000_000_000_000_000n,
+    });
+    assert.equal(live, 0);
+  });
+
+  it('returns the raw amount when accumulator is behind the debt (no underflow)', () => {
+    // Should never happen in practice (accumulator is monotonically increasing
+    // per gateway), but the helper must short-circuit instead of producing a
+    // negative pending value.
+    const live = computeLiveDelegationBalance({
+      delegatedStake: 10_000_000_000,
+      rewardDebt: 100n,
+      cumulativeRewardPerToken: 50n,
+    });
+    assert.equal(live, 10_000_000_000);
+  });
+
+  it('compounds a one-epoch reward correctly (10 ARIO stake, 10% rate)', () => {
+    // If the per-share accumulator advanced by `0.1 * REWARD_PRECISION`,
+    // a 10 ARIO stake should accrue 1 ARIO of pending rewards.
+    const delegatedStake = 10_000_000; // 10 ARIO in mARIO
+    const rewardDebt = 0n;
+    const cumulativeRewardPerToken = REWARD_PRECISION / 10n; // 0.1 per share
+    const live = computeLiveDelegationBalance({
+      delegatedStake,
+      rewardDebt,
+      cumulativeRewardPerToken,
+    });
+    assert.equal(live, 11_000_000); // 10 + 1 ARIO
+  });
+
+  it('handles a non-zero rewardDebt snapshot', () => {
+    // Delegate already settled at `0.5 * REWARD_PRECISION`. Gateway now at
+    // `0.7 * REWARD_PRECISION`. Pending delta is 0.2 per share. With 100 ARIO
+    // staked the delegate is owed 20 ARIO.
+    const live = computeLiveDelegationBalance({
+      delegatedStake: 100_000_000, // 100 ARIO
+      rewardDebt: REWARD_PRECISION / 2n,
+      cumulativeRewardPerToken: (REWARD_PRECISION * 7n) / 10n,
+    });
+    assert.equal(live, 120_000_000); // 100 + 20 ARIO
+  });
+
+  it('matches the on-chain quotient/remainder split on large multipliers', () => {
+    // delta * amount exceeds u128 if done naively. The helper splits into
+    // quotient/remainder to preserve precision. Verify the same number is
+    // produced regardless of representation: with delta = 1e18 (exactly
+    // REWARD_PRECISION), per-share rate is 1.0, so pending == amount.
+    const live = computeLiveDelegationBalance({
+      delegatedStake: 500_000_000_000, // 500k ARIO
+      rewardDebt: 0n,
+      cumulativeRewardPerToken: REWARD_PRECISION,
+    });
+    // amount + amount * (1.0) = 2 * amount
+    assert.equal(live, 1_000_000_000_000); // 1M ARIO
+  });
+
+  it('saturates at u64::MAX rather than overflowing', () => {
+    // Pathological inputs that would overflow u64. The helper caps live at
+    // u64::MAX = 18_446_744_073_709_551_615. Number representation past
+    // 2^53 loses precision but the cap behavior is what we're verifying.
+    const live = computeLiveDelegationBalance({
+      delegatedStake: Number.MAX_SAFE_INTEGER,
+      rewardDebt: 0n,
+      cumulativeRewardPerToken: REWARD_PRECISION * 1_000_000n,
+    });
+    // Should be capped at u64::MAX (representable as a Number, lossily).
+    const U64_MAX = Number((1n << 64n) - 1n);
+    assert.equal(live, U64_MAX);
+  });
+});

--- a/src/solana/delegation-math.ts
+++ b/src/solana/delegation-math.ts
@@ -1,0 +1,76 @@
+/**
+ * Delegation balance math.
+ *
+ * On-chain, `Delegation.amount` is the last-settled principal. Pending rewards
+ * are tracked separately via the gateway's per-share accumulator
+ * (`Gateway.cumulative_reward_per_token`) and the delegate's snapshot of that
+ * accumulator at the last settlement (`Delegation.reward_debt`). The
+ * `distribute_epoch` instruction advances the accumulator but does NOT touch
+ * per-`Delegation.amount` — that field is updated lazily on the next
+ * delegation interaction (or via the permissionless
+ * `compound_delegation_rewards` instruction).
+ *
+ * Off-chain readers (indexers, wallets, the network portal) that want to show
+ * a delegate's current balance must therefore compute the live value from the
+ * accumulator + reward_debt; reading `Delegation.amount` directly under-reports
+ * every epoch of pending rewards.
+ *
+ * This module mirrors the on-chain `settle_delegate_rewards` math from
+ * `programs/ario-gar/src/state/mod.rs` so the SDK can return live values from
+ * its read-side methods (`getGatewayDelegates`, `getDelegations`,
+ * `getAllDelegates`) without needing an on-chain settlement call.
+ *
+ * See `INVARIANTS.md` in the contracts repo for the broader stake-pool
+ * invariant context.
+ */
+import { REWARD_PRECISION } from './constants.js';
+
+const U64_MAX = (1n << 64n) - 1n;
+
+/**
+ * Compute the live delegation balance: the last-settled principal plus any
+ * pending rewards accrued since the last settlement.
+ *
+ * Mirrors `settle_delegate_rewards` in
+ * `programs/ario-gar/src/state/mod.rs` — including the u128 overflow-safe
+ * quotient/remainder split and the saturating-to-`u64::MAX` cap at the end —
+ * so a value computed here matches what the on-chain instruction would write
+ * if it were called right now.
+ *
+ * @param delegatedStake          - `Delegation.amount` (u64 → number).
+ * @param rewardDebt              - `Delegation.reward_debt` (u128 → bigint).
+ * @param cumulativeRewardPerToken - `Gateway.cumulative_reward_per_token` (u128 → bigint).
+ * @returns The delegate's live balance in mARIO, saturating-capped at `u64::MAX`.
+ */
+export function computeLiveDelegationBalance({
+  delegatedStake,
+  rewardDebt,
+  cumulativeRewardPerToken,
+}: {
+  delegatedStake: number;
+  rewardDebt: bigint;
+  cumulativeRewardPerToken: bigint;
+}): number {
+  // Fast paths matching the on-chain `if` guards: zero principal or no
+  // accumulator delta means no pending rewards to settle.
+  if (delegatedStake <= 0 || cumulativeRewardPerToken <= rewardDebt) {
+    return delegatedStake;
+  }
+
+  const amount = BigInt(delegatedStake);
+  const delta = cumulativeRewardPerToken - rewardDebt;
+
+  // Quotient / remainder split mirrors the on-chain `checked_mul ... unwrap_or_else`
+  // fallback. BigInt has no native overflow, so we always take the split path
+  // for parity; the result is identical either way.
+  const quot = delta / REWARD_PRECISION;
+  const rem = delta % REWARD_PRECISION;
+  const fromQuot = amount * quot; // saturating not needed — BigInt is unbounded
+  const fromRem = (amount * rem) / REWARD_PRECISION;
+  const pending = fromQuot + fromRem;
+
+  // Saturating cap at u64::MAX to match the on-chain `u64::try_from(...).unwrap_or(u64::MAX)`.
+  const live = amount + pending;
+  const capped = live > U64_MAX ? U64_MAX : live;
+  return Number(capped);
+}

--- a/src/solana/deserialize.test.ts
+++ b/src/solana/deserialize.test.ts
@@ -3,7 +3,11 @@ import { describe, it } from 'node:test';
 
 import { REWARD_PRECISION } from './constants.js';
 import { computeLiveDelegationBalance } from './delegation-math.js';
-import { deserializeDelegation, deserializeGateway } from './deserialize.js';
+import {
+  deserializeDelegation,
+  deserializeGateway,
+  deserializeGatewayWithAccumulator,
+} from './deserialize.js';
 
 /**
  * Synthetic-byte round-trip tests for the two accumulator-related deserializers
@@ -213,7 +217,7 @@ describe('deserializeGateway (synthetic round-trip — cumulativeRewardPerToken)
       totalDelegatedStake: 5_000_000_000n,
       cumulativeRewardPerToken: 750_000_000_000_000_000n, // 0.75 * REWARD_PRECISION
     });
-    const gw = deserializeGateway(buf);
+    const gw = deserializeGatewayWithAccumulator(buf);
 
     assert.equal(gw.operatorStake, 30_000_000_000);
     assert.equal(gw.totalDelegatedStake, 5_000_000_000);
@@ -226,7 +230,7 @@ describe('deserializeGateway (synthetic round-trip — cumulativeRewardPerToken)
       totalDelegatedStake: 0n,
       cumulativeRewardPerToken: 0n,
     });
-    const gw = deserializeGateway(buf);
+    const gw = deserializeGatewayWithAccumulator(buf);
     assert.equal(gw.cumulativeRewardPerToken, 0n);
   });
 
@@ -239,7 +243,26 @@ describe('deserializeGateway (synthetic round-trip — cumulativeRewardPerToken)
       totalDelegatedStake: 0n,
       cumulativeRewardPerToken: big,
     });
-    const gw = deserializeGateway(buf);
+    const gw = deserializeGatewayWithAccumulator(buf);
     assert.equal(gw.cumulativeRewardPerToken, big);
+  });
+
+  it('public deserializeGateway does NOT expose cumulativeRewardPerToken', () => {
+    // Regression guard for CodeRabbit finding: bigint must not leak through
+    // the public AoGateway shape (it's not JSON-serializable, would crash
+    // `JSON.stringify` on getGateway() results).
+    const buf = buildGatewayBuffer({
+      operatorStake: 1_000n,
+      totalDelegatedStake: 0n,
+      cumulativeRewardPerToken: 999n,
+    });
+    const gw = deserializeGateway(buf);
+    assert.equal(
+      (gw as Record<string, unknown>).cumulativeRewardPerToken,
+      undefined,
+      'public deserializeGateway must not include the u128 accumulator',
+    );
+    // And JSON.stringify must succeed (would throw on a bigint field).
+    assert.doesNotThrow(() => JSON.stringify(gw));
   });
 });

--- a/src/solana/deserialize.test.ts
+++ b/src/solana/deserialize.test.ts
@@ -1,0 +1,245 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { REWARD_PRECISION } from './constants.js';
+import { computeLiveDelegationBalance } from './delegation-math.js';
+import { deserializeDelegation, deserializeGateway } from './deserialize.js';
+
+/**
+ * Synthetic-byte round-trip tests for the two accumulator-related deserializers
+ * that we updated to surface `reward_debt` (Delegation) and
+ * `cumulative_reward_per_token` (Gateway). These tests pin the byte offsets at
+ * which we extract those u128 fields — if the on-chain struct layout ever
+ * moves, these fail before the math goes wrong in production.
+ *
+ * The buffer constants mirror the on-chain struct definitions in
+ * `programs/ario-gar/src/state/mod.rs` (`Delegation` at line 441 and `Gateway`
+ * at line 182 of that file). When the struct layout changes, both this test
+ * and the deserializer need to move in lockstep.
+ */
+
+const U64_LO_MASK = (1n << 64n) - 1n;
+
+function writeU128LE(buf: Buffer, off: number, val: bigint): void {
+  buf.writeBigUInt64LE(val & U64_LO_MASK, off);
+  buf.writeBigUInt64LE(val >> 64n, off + 8);
+}
+
+describe('deserializeDelegation (synthetic round-trip)', () => {
+  // Delegation layout (105 bytes total):
+  //   8  disc
+  //   32 gateway: Pubkey
+  //   32 delegator: Pubkey
+  //   8  amount: u64
+  //   8  start_timestamp: i64
+  //   16 reward_debt: u128
+  //   1  bump: u8
+  const DELEGATION_SIZE = 8 + 32 + 32 + 8 + 8 + 16 + 1;
+
+  it('extracts amount, startTimestamp, and rewardDebt at the expected offsets', () => {
+    const buf = Buffer.alloc(DELEGATION_SIZE);
+    // 8 disc, 32 gateway, 32 delegator — leave as zeroes
+    buf.writeBigUInt64LE(10_000_000_000n, 72); // amount = 10,000 ARIO
+    buf.writeBigInt64LE(1_700_000_000n, 80); // start_timestamp
+    writeU128LE(buf, 88, 500_000_000_000_000_000n); // reward_debt = 0.5 * REWARD_PRECISION
+    buf.writeUInt8(255, 104); // bump
+
+    const result = deserializeDelegation(buf);
+
+    assert.equal(result.delegatedStake, 10_000_000_000);
+    assert.equal(result.startTimestamp, 1_700_000_000);
+    assert.equal(result.rewardDebt, 500_000_000_000_000_000n);
+  });
+
+  it('handles a zero-reward-debt fresh delegation', () => {
+    const buf = Buffer.alloc(DELEGATION_SIZE);
+    buf.writeBigUInt64LE(1_000_000n, 72); // 1 ARIO
+    buf.writeBigInt64LE(0n, 80);
+    writeU128LE(buf, 88, 0n);
+
+    const result = deserializeDelegation(buf);
+
+    assert.equal(result.delegatedStake, 1_000_000);
+    assert.equal(result.rewardDebt, 0n);
+  });
+
+  it('round-trips through computeLiveDelegationBalance to the expected live value', () => {
+    // 100 ARIO staked, last settled at reward_debt = 0.5 * REWARD_PRECISION.
+    // Gateway's accumulator is now at REWARD_PRECISION (1.0), so delta = 0.5
+    // → pending = 100 * 0.5 = 50 ARIO → live = 150 ARIO.
+    const buf = Buffer.alloc(DELEGATION_SIZE);
+    buf.writeBigUInt64LE(100_000_000n, 72); // 100 ARIO
+    buf.writeBigInt64LE(0n, 80);
+    writeU128LE(buf, 88, REWARD_PRECISION / 2n); // reward_debt = 0.5
+
+    const del = deserializeDelegation(buf);
+    const live = computeLiveDelegationBalance({
+      delegatedStake: del.delegatedStake,
+      rewardDebt: del.rewardDebt,
+      cumulativeRewardPerToken: REWARD_PRECISION, // gateway at 1.0
+    });
+
+    assert.equal(live, 150_000_000); // 150 ARIO in mARIO
+  });
+});
+
+describe('deserializeGateway (synthetic round-trip — cumulativeRewardPerToken)', () => {
+  /**
+   * Build a minimal but valid Gateway buffer. Uses 1-character placeholders
+   * for the variable-length strings so all subsequent offsets are computable.
+   * Caller passes the values for `cumulative_reward_per_token` (the field we
+   * care about validating) and any other fields they want to assert on.
+   */
+  function buildGatewayBuffer(opts: {
+    operatorStake: bigint;
+    totalDelegatedStake: bigint;
+    cumulativeRewardPerToken: bigint;
+  }): Buffer {
+    // We use 1-char placeholders ("a") for label/fqdn/properties/note to keep
+    // the math obvious. Each string contributes 4 (length prefix) + 1 (content).
+    const STRING_BYTES = 4 + 1; // 4 length prefix + 1 char
+    const SIZE =
+      8 + // disc
+      32 + // operator
+      STRING_BYTES + // label = "a"
+      STRING_BYTES + // fqdn = "a"
+      2 + // port
+      1 + // protocolIdx
+      STRING_BYTES + // properties = "a"
+      STRING_BYTES + // note = "a"
+      8 + // operator_stake
+      8 + // total_delegated_stake
+      1 + // status
+      8 + // start_timestamp
+      1 + // leave_timestamp Option discriminator (None = 0, no payload)
+      8 + // leave_epoch_duration
+      4 * 5 + // stats: passed/failed/total/prescribed/observed epoch counts (u32 each)
+      1 + // stats: failed_consecutive (u8)
+      1 + // stats: passed_consecutive (u8)
+      8 * 7 + // weights: 6 published u64 + weights_epoch u64
+      1 + // allow_delegated_staking
+      2 + // delegate_reward_share_ratio
+      8 + // min_delegated_stake
+      1 + // allowlist_enabled
+      4 + // registry_index.index
+      1 + // registry_index._reserved
+      32 + // observer_address
+      16 + // cumulative_reward_per_token
+      1; // bump
+
+    const buf = Buffer.alloc(SIZE);
+    let off = 8 + 32; // skip disc + operator
+
+    // label "a"
+    buf.writeUInt32LE(1, off);
+    off += 4;
+    buf.writeUInt8(0x61, off);
+    off += 1;
+    // fqdn "a"
+    buf.writeUInt32LE(1, off);
+    off += 4;
+    buf.writeUInt8(0x61, off);
+    off += 1;
+    // port (u16) + protocolIdx (u8)
+    buf.writeUInt16LE(443, off);
+    off += 2;
+    buf.writeUInt8(1, off);
+    off += 1; // https
+    // properties "a"
+    buf.writeUInt32LE(1, off);
+    off += 4;
+    buf.writeUInt8(0x61, off);
+    off += 1;
+    // note "a"
+    buf.writeUInt32LE(1, off);
+    off += 4;
+    buf.writeUInt8(0x61, off);
+    off += 1;
+    // operator_stake (u64)
+    buf.writeBigUInt64LE(opts.operatorStake, off);
+    off += 8;
+    // total_delegated_stake (u64)
+    buf.writeBigUInt64LE(opts.totalDelegatedStake, off);
+    off += 8;
+    // status (u8) — Joined = 0
+    buf.writeUInt8(0, off);
+    off += 1;
+    // start_timestamp (i64)
+    buf.writeBigInt64LE(0n, off);
+    off += 8;
+    // leave_timestamp Option<i64> — None
+    buf.writeUInt8(0, off);
+    off += 1;
+    // leave_epoch_duration (i64) — skipped by deserializer but layout still consumed
+    buf.writeBigInt64LE(0n, off);
+    off += 8;
+    // stats: 5 u32 + 2 u8 = 22 bytes — leave zeroes
+    off += 22;
+    // weights: 7 u64 = 56 bytes — leave zeroes
+    off += 56;
+    // allow_delegated_staking (bool)
+    buf.writeUInt8(1, off);
+    off += 1;
+    // delegate_reward_share_ratio (u16) — pre-scale value, e.g. 10 means 10*100=1000 in basis-of-RATE_SCALE
+    buf.writeUInt16LE(1000, off);
+    off += 2;
+    // min_delegated_stake (u64)
+    buf.writeBigUInt64LE(0n, off);
+    off += 8;
+    // allowlist_enabled (bool)
+    buf.writeUInt8(0, off);
+    off += 1;
+    // registry_index.index (u32) + _reserved (u8)
+    buf.writeUInt32LE(0, off);
+    off += 4;
+    buf.writeUInt8(0, off);
+    off += 1;
+    // observer_address (32 raw bytes) — leave zero
+    off += 32;
+    // cumulative_reward_per_token (u128 LE) — THE FIELD UNDER TEST
+    writeU128LE(buf, off, opts.cumulativeRewardPerToken);
+    off += 16;
+    // bump (u8)
+    buf.writeUInt8(255, off);
+    off += 1;
+
+    assert.equal(off, SIZE, 'buffer build size mismatch');
+    return buf;
+  }
+
+  it('extracts cumulativeRewardPerToken at the expected offset', () => {
+    const buf = buildGatewayBuffer({
+      operatorStake: 30_000_000_000n,
+      totalDelegatedStake: 5_000_000_000n,
+      cumulativeRewardPerToken: 750_000_000_000_000_000n, // 0.75 * REWARD_PRECISION
+    });
+    const gw = deserializeGateway(buf);
+
+    assert.equal(gw.operatorStake, 30_000_000_000);
+    assert.equal(gw.totalDelegatedStake, 5_000_000_000);
+    assert.equal(gw.cumulativeRewardPerToken, 750_000_000_000_000_000n);
+  });
+
+  it('handles a fresh gateway (zero accumulator)', () => {
+    const buf = buildGatewayBuffer({
+      operatorStake: 20_000_000_000n,
+      totalDelegatedStake: 0n,
+      cumulativeRewardPerToken: 0n,
+    });
+    const gw = deserializeGateway(buf);
+    assert.equal(gw.cumulativeRewardPerToken, 0n);
+  });
+
+  it('preserves large u128 accumulator values without truncation', () => {
+    // Pick a value with non-zero bits in both halves of the u128 — catches a
+    // little-endian half-swap bug if either reader/writer is wrong.
+    const big = (123n << 64n) | 456n;
+    const buf = buildGatewayBuffer({
+      operatorStake: 0n,
+      totalDelegatedStake: 0n,
+      cumulativeRewardPerToken: big,
+    });
+    const gw = deserializeGateway(buf);
+    assert.equal(gw.cumulativeRewardPerToken, big);
+  });
+});

--- a/src/solana/deserialize.ts
+++ b/src/solana/deserialize.ts
@@ -342,7 +342,7 @@ function scaleToFloat(value: number, scale: number = RATE_SCALE): number {
  */
 export function deserializeGateway(
   data: Buffer,
-): AoGateway & { operator: string } {
+): AoGateway & { operator: string; cumulativeRewardPerToken: bigint } {
   const r = new BorshReader(data, 8); // skip 8-byte discriminator
 
   const operator = r.readPubkey();
@@ -392,8 +392,12 @@ export function deserializeGateway(
   // observer_address
   const observerAddress = r.readPubkey();
 
-  // cumulative_reward_per_token (u128, not exposed in SDK type)
-  r.skip(16);
+  // cumulative_reward_per_token: u128 — per-share accumulator advanced by
+  // distribute_epoch. Combined with each Delegation.reward_debt, this lets
+  // off-chain readers compute the live delegate balance without an on-chain
+  // settlement call. Not part of the public AoGateway type but surfaced as
+  // an extra field on this function's return so internal readers can use it.
+  const cumulativeRewardPerToken = r.readU128();
 
   // bump
   r.skip(1);
@@ -446,6 +450,7 @@ export function deserializeGateway(
     operatorStake,
     status: statusIdx === 0 ? 'joined' : 'leaving',
     weights,
+    cumulativeRewardPerToken,
   };
 }
 
@@ -559,8 +564,19 @@ export function deserializeVault(
 export type DeserializedDelegation = {
   gateway: string;
   delegator: string;
+  /**
+   * Last-settled principal (raw `Delegation.amount` from on-chain state).
+   * This value is stale between epochs — see `INVARIANTS.md` in the contracts
+   * repo. Use `computeLiveDelegationBalance` (with the gateway's current
+   * `cumulativeRewardPerToken`) to get the actual current balance.
+   */
   delegatedStake: number;
   startTimestamp: number;
+  /**
+   * Snapshot of `gateway.cumulative_reward_per_token` at the last settlement.
+   * Required input to `computeLiveDelegationBalance`.
+   */
+  rewardDebt: bigint;
 };
 
 /**
@@ -574,14 +590,18 @@ export function deserializeDelegation(data: Buffer): DeserializedDelegation {
   const delegator = r.readPubkey();
   const amount = r.readU64AsNumber();
   const startTimestamp = r.readI64AsNumber();
-  // reward_debt: u128, bump: u8 — skip
-  r.skip(16 + 1);
+  // reward_debt: u128 — snapshot of gateway.cumulative_reward_per_token at last
+  // settlement. Needed (together with the gateway's current accumulator) to
+  // compute the live delegate balance via computeLiveDelegationBalance().
+  const rewardDebt = r.readU128();
+  r.skip(1); // bump
 
   return {
     gateway: gateway,
     delegator: delegator,
     delegatedStake: amount,
     startTimestamp,
+    rewardDebt,
   };
 }
 

--- a/src/solana/deserialize.ts
+++ b/src/solana/deserialize.ts
@@ -335,12 +335,18 @@ function scaleToFloat(value: number, scale: number = RATE_SCALE): number {
 // =========================================
 
 /**
- * Deserialize a Gateway account from raw bytes.
- * PDA: ["gateway", operator_pubkey] in ario-gar program.
+ * Internal variant of {@link deserializeGateway} that additionally surfaces
+ * the on-chain `cumulative_reward_per_token` u128 accumulator. Used by the
+ * live delegation balance pipeline ({@link computeLiveDelegationBalance} via
+ * `getGatewayAccumulators` in `io-readable.ts`).
  *
- * Returns the SDK-compatible AoGateway type.
+ * Not part of the public AoGateway shape — `bigint` is not JSON-serializable
+ * and would leak through `getGateway` / `getGateways`. Prefer
+ * {@link deserializeGateway} everywhere except inside live-balance plumbing.
+ *
+ * PDA: ["gateway", operator_pubkey] in ario-gar program.
  */
-export function deserializeGateway(
+export function deserializeGatewayWithAccumulator(
   data: Buffer,
 ): AoGateway & { operator: string; cumulativeRewardPerToken: bigint } {
   const r = new BorshReader(data, 8); // skip 8-byte discriminator
@@ -452,6 +458,25 @@ export function deserializeGateway(
     weights,
     cumulativeRewardPerToken,
   };
+}
+
+/**
+ * Deserialize a Gateway account from raw bytes.
+ *
+ * Returns the SDK-compatible AoGateway type (plus `operator: string`).
+ * The on-chain `cumulative_reward_per_token` u128 is intentionally NOT
+ * surfaced on the returned object — `bigint` is not JSON-serializable,
+ * and leaking it through `getGateway` / `getGateways` would break
+ * downstream consumers that call `JSON.stringify` on results. Use
+ * {@link deserializeGatewayWithAccumulator} from within the live-balance
+ * pipeline when the accumulator value is actually needed.
+ */
+export function deserializeGateway(
+  data: Buffer,
+): AoGateway & { operator: string } {
+  const { cumulativeRewardPerToken: _unused, ...publicShape } =
+    deserializeGatewayWithAccumulator(data);
+  return publicShape;
 }
 
 // =========================================

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -69,6 +69,7 @@ import {
   ARNS_RECORD_ANT_OFFSET,
   RATE_SCALE,
 } from './constants.js';
+import { computeLiveDelegationBalance } from './delegation-math.js';
 import {
   deserializeAllowlist,
   deserializeArioConfig,
@@ -343,6 +344,43 @@ export class SolanaARIOReadable {
       pubkey: entry.pubkey,
       data: Buffer.from(entry.account.data[0], 'base64'),
     }));
+  }
+
+  /**
+   * Batch-fetch the `cumulative_reward_per_token` accumulator for every gateway
+   * in `operatorAddresses`. Returns a Map keyed by base58 operator address.
+   * Used by the delegate readers below to compute the live delegation balance
+   * without an on-chain settlement call (see {@link computeLiveDelegationBalance}
+   * and `INVARIANTS.md` in the contracts repo). Missing gateways are silently
+   * skipped — callers fall back to the stale `Delegation.amount` for those
+   * (the accumulator delta is 0 and live == stored anyway when the gateway
+   * has no rewards to distribute).
+   */
+  protected async getGatewayAccumulators(
+    operatorAddresses: string[],
+  ): Promise<Map<string, bigint>> {
+    const unique = Array.from(new Set(operatorAddresses));
+    if (unique.length === 0) return new Map();
+    const pdas = await Promise.all(
+      unique.map(
+        async (op) => (await getGatewayPDA(address(op), this.garProgram))[0],
+      ),
+    );
+    const accounts = await fetchEncodedAccounts(this.rpc, pdas, {
+      commitment: this.commitment,
+    });
+    const out = new Map<string, bigint>();
+    for (let i = 0; i < accounts.length; i++) {
+      const acct = accounts[i];
+      if (!acct.exists) continue;
+      try {
+        const gw = deserializeGateway(Buffer.from(acct.data));
+        out.set(unique[i], gw.cumulativeRewardPerToken);
+      } catch {
+        // Skip malformed; the caller will fall back to the raw delegation amount.
+      }
+    }
+    return out;
   }
 
   /** Read the gateway registry and return addresses in registry index order */
@@ -713,13 +751,23 @@ export class SolanaARIOReadable {
       ],
     );
 
+    // Fetch this gateway's current reward accumulator so we can return live
+    // balances (raw `Delegation.amount` is stale between settlements — see
+    // INVARIANTS.md and `computeLiveDelegationBalance`).
+    const accumulators = await this.getGatewayAccumulators([gateway as string]);
+    const cumulative = accumulators.get(gateway as string) ?? 0n;
+
     const items: AoGatewayDelegateWithAddress[] = [];
     for (const { data } of accounts) {
       try {
         const del = deserializeDelegation(data);
         items.push({
           address: del.delegator,
-          delegatedStake: del.delegatedStake,
+          delegatedStake: computeLiveDelegationBalance({
+            delegatedStake: del.delegatedStake,
+            rewardDebt: del.rewardDebt,
+            cumulativeRewardPerToken: cumulative,
+          }),
           startTimestamp: secToMs(del.startTimestamp),
         });
       } catch {
@@ -777,21 +825,38 @@ export class SolanaARIOReadable {
       ],
     );
 
-    const items: AoDelegation[] = [];
+    const decoded: Array<{
+      pubkey: string;
+      del: ReturnType<typeof deserializeDelegation>;
+    }> = [];
     for (const { pubkey, data } of accounts) {
       try {
-        const del = deserializeDelegation(data);
-        items.push({
-          type: 'stake' as const,
-          gatewayAddress: del.gateway,
-          delegationId: pubkey as string,
-          startTimestamp: secToMs(del.startTimestamp),
-          balance: del.delegatedStake,
+        decoded.push({
+          pubkey: pubkey as string,
+          del: deserializeDelegation(data),
         });
       } catch {
         // Skip malformed
       }
     }
+
+    // Batch-fetch each referenced gateway's reward accumulator so we can
+    // return live balances. See INVARIANTS.md and `computeLiveDelegationBalance`.
+    const accumulators = await this.getGatewayAccumulators(
+      decoded.map(({ del }) => del.gateway),
+    );
+
+    const items: AoDelegation[] = decoded.map(({ pubkey, del }) => ({
+      type: 'stake' as const,
+      gatewayAddress: del.gateway,
+      delegationId: pubkey,
+      startTimestamp: secToMs(del.startTimestamp),
+      balance: computeLiveDelegationBalance({
+        delegatedStake: del.delegatedStake,
+        rewardDebt: del.rewardDebt,
+        cumulativeRewardPerToken: accumulators.get(del.gateway) ?? 0n,
+      }),
+    }));
 
     return paginate(items, params);
   }
@@ -1734,22 +1799,39 @@ export class SolanaARIOReadable {
       DELEGATION_DISCRIMINATOR,
     );
 
-    const items: AoAllDelegates[] = [];
+    const decoded: Array<{
+      pubkey: string;
+      del: ReturnType<typeof deserializeDelegation>;
+    }> = [];
     for (const { pubkey, data } of accounts) {
       try {
-        const del = deserializeDelegation(data);
-        items.push({
-          address: del.delegator,
-          gatewayAddress: del.gateway,
-          delegatedStake: del.delegatedStake,
-          startTimestamp: secToMs(del.startTimestamp),
-          vaultedStake: 0,
-          cursorId: pubkey as string,
+        decoded.push({
+          pubkey: pubkey as string,
+          del: deserializeDelegation(data),
         });
       } catch {
         // Skip malformed
       }
     }
+
+    // Batch-fetch each referenced gateway's reward accumulator so we can
+    // return live balances. See INVARIANTS.md and `computeLiveDelegationBalance`.
+    const accumulators = await this.getGatewayAccumulators(
+      decoded.map(({ del }) => del.gateway),
+    );
+
+    const items: AoAllDelegates[] = decoded.map(({ pubkey, del }) => ({
+      address: del.delegator,
+      gatewayAddress: del.gateway,
+      delegatedStake: computeLiveDelegationBalance({
+        delegatedStake: del.delegatedStake,
+        rewardDebt: del.rewardDebt,
+        cumulativeRewardPerToken: accumulators.get(del.gateway) ?? 0n,
+      }),
+      startTimestamp: secToMs(del.startTimestamp),
+      vaultedStake: 0,
+      cursorId: pubkey,
+    }));
 
     return paginate(items, params);
   }

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -82,6 +82,7 @@ import {
   deserializeGarSettings,
   deserializeGarSupplyCounters,
   deserializeGateway,
+  deserializeGatewayWithAccumulator,
   deserializeObservation,
   deserializePrimaryName,
   deserializePrimaryNameRequest,
@@ -374,7 +375,10 @@ export class SolanaARIOReadable {
       const acct = accounts[i];
       if (!acct.exists) continue;
       try {
-        const gw = deserializeGateway(Buffer.from(acct.data));
+        // Internal variant: surfaces the u128 accumulator that the public
+        // `deserializeGateway` deliberately drops (BigInt is not
+        // JSON-serializable and would leak through getGateway).
+        const gw = deserializeGatewayWithAccumulator(Buffer.from(acct.data));
         out.set(unique[i], gw.cumulativeRewardPerToken);
       } catch {
         // Skip malformed; the caller will fall back to the raw delegation amount.


### PR DESCRIPTION
## Summary

Makes `getGatewayDelegates`, `getDelegations`, and `getAllDelegates` return the **live** delegate balance (last-settled principal + accumulator-derived pending rewards) instead of the raw `Delegation.amount` field, which is stale-by-design between settlements.

## Why this matters

`distribute_epoch` advances the per-share accumulator `Gateway.cumulative_reward_per_token` and does **not** update every `Delegation.amount` (it would be O(delegates) per epoch — would blow the compute budget). `Delegation.amount` is only refreshed when the delegate next interacts (`increase`/`decrease`/`redelegate`/`claim_from_leaving`) or when someone calls the permissionless `compound_delegation_rewards`.

The network portal (and every downstream consumer of these SDK methods) was reading the raw field — so a delegate who stakes once and lets it sit sees their displayed balance **never grow between epochs**, even though they're earning rewards. It only jumps when something triggers settlement.

This is corrected on the SDK read side without any on-chain change (the on-chain accumulator pattern is canonical and correct — see `INVARIANTS.md` in the contracts repo).

## Changes

- **`constants.ts`**: add `REWARD_PRECISION = 1e18` (mirrors the on-chain constant in `programs/ario-gar/src/state/mod.rs`).
- **`deserialize.ts`**: stop skipping `reward_debt` in `deserializeDelegation` and `cumulative_reward_per_token` in `deserializeGateway`; surface both as `bigint` on the internal return types. The public `AoGateway` type is unchanged.
- **`delegation-math.ts`** (new): `computeLiveDelegationBalance` helper that ports the on-chain `settle_delegate_rewards` math to TypeScript bigint, including the overflow-safe quotient/remainder split and the `u64::MAX` saturation cap.
- **`io-readable.ts`**:
  - New private `getGatewayAccumulators(operatorAddresses[])` helper — batch-fetches gateways via `fetchEncodedAccounts`, returns `Map<address, bigint>` of per-gateway accumulators.
  - `getGatewayDelegates`: fetches the single referenced gateway, applies live math to each delegation's `delegatedStake`.
  - `getDelegations` and `getAllDelegates`: collect all referenced gateways, batch-fetch them once, apply live math.
- **`delegation-math.test.ts`** (new): 7 unit tests — zero principal, no-delta short-circuit, monotonic-accumulator guard, single-epoch reward (10% rate), non-zero `rewardDebt` snapshot, large multiplier precision, and `u64` saturation.

## API compatibility

Return shapes unchanged. Callers see strictly better numbers (live ≥ stored). No new methods exposed.

## Cost

One additional `getMultipleAccounts` per call when delegations span multiple gateways. Negligible for the per-gateway reader (single RPC); modest constant factor for the global reader.

## Test plan

- [x] `yarn build:esm` — clean
- [x] `yarn lint:check` — clean (biome formatting applied)
- [x] `yarn test:unit src/solana/delegation-math.test.ts` — 7 subtests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delegation balances now automatically account for earned rewards in real-time, providing accurate, up-to-date balance information.
  * Added reward accumulator tracking to support live balance calculations based on current gateway reward data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ar-io/ar-io-sdk/pull/628)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->