### PR TITLE
fix(solana): primary-name deserializer + approvePrimaryName config + test 9 hermeticity

### DIFF
--- a/src/solana/deserialize.ts
+++ b/src/solana/deserialize.ts
@@ -1483,25 +1483,31 @@ export function deserializeAclPage(data: Buffer): {
 /**
  * Deserialize a PrimaryName account from raw bytes.
  * PDA: ["primary_name", owner] in ario-core program.
+ *
+ * The on-chain `PrimaryName` (programs/ario-core/src/state/mod.rs) has
+ * **no** `processId` field — only `{owner, name, set_at, bump}`. The ANT
+ * mint that a primary name resolves to lives on the matching `ArnsRecord`
+ * (looked up by `name`), and callers wanting an `AoPrimaryName`-shaped
+ * result MUST enrich this output with that lookup. The previous
+ * implementation read 32 bytes from where `set_at` (i64) + part of `bump`
+ * actually sit and returned a fake `processId` pubkey, which broke every
+ * `assert.equal(pn.processId, antMint)` check downstream.
  */
 export function deserializePrimaryName(data: Buffer): {
   owner: string;
   name: string;
-  processId: string;
   startTimestamp: number;
 } {
   const r = new BorshReader(data, 8); // skip discriminator
 
   const owner = r.readPubkey();
   const name = r.readString();
-  const processId = r.readPubkey();
   const startTimestamp = r.readI64AsNumber();
   // bump: u8 — skip
 
   return {
-    owner: owner,
+    owner,
     name,
-    processId: processId,
     startTimestamp,
   };
 }

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -1661,6 +1661,23 @@ export class SolanaARIOReadable {
   async getPrimaryName(
     params: { address: WalletAddress } | { name: string },
   ): Promise<AoPrimaryName> {
+    // On-chain `PrimaryName` stores only {owner, name, set_at}. The ANT mint
+    // that AoPrimaryName.processId expects lives on the matching ArnsRecord
+    // (looked up by the base name). Both lookup paths below deserialize the
+    // on-chain account and then enrich with the ArnsRecord lookup.
+    const baseNameOf = (n: string): string => {
+      const parts = n.toLowerCase().split('_');
+      return parts.length === 2 ? parts[1] : parts[0];
+    };
+    const enrich = async (pn: {
+      owner: string;
+      name: string;
+      startTimestamp: number;
+    }): Promise<AoPrimaryName> => {
+      const rec = await this.getArNSRecord({ name: baseNameOf(pn.name) });
+      return { ...pn, processId: rec.processId };
+    };
+
     if ('address' in params) {
       const [pda] = await getPrimaryNamePDA(
         address(params.address),
@@ -1670,7 +1687,7 @@ export class SolanaARIOReadable {
       if (!account.exists) {
         throw new Error(`Primary name not found for address ${params.address}`);
       }
-      return deserializePrimaryName(Buffer.from(account.data));
+      return enrich(deserializePrimaryName(Buffer.from(account.data)));
     }
 
     // Lookup by name — scan all primary name accounts
@@ -1683,7 +1700,7 @@ export class SolanaARIOReadable {
       try {
         const pn = deserializePrimaryName(data);
         if (pn.name === params.name) {
-          return pn;
+          return enrich(pn);
         }
       } catch {
         // Skip malformed
@@ -1735,12 +1752,22 @@ export class SolanaARIOReadable {
       PRIMARY_NAME_DISCRIMINATOR,
     );
 
+    // Enrich each on-chain PrimaryName with its ArnsRecord.processId (the
+    // on-chain account doesn't store it; see deserializePrimaryName).
+    // Records that no longer have a matching ArnsRecord are silently
+    // skipped — same forgiveness the per-name lookup already applies.
+    const baseNameOf = (n: string): string => {
+      const parts = n.toLowerCase().split('_');
+      return parts.length === 2 ? parts[1] : parts[0];
+    };
     const items: AoPrimaryName[] = [];
     for (const { data } of accounts) {
       try {
-        items.push(deserializePrimaryName(data));
+        const pn = deserializePrimaryName(data);
+        const rec = await this.getArNSRecord({ name: baseNameOf(pn.name) });
+        items.push({ ...pn, processId: rec.processId });
       } catch {
-        // Skip malformed
+        // Skip malformed or orphaned (ArnsRecord missing).
       }
     }
 

--- a/src/solana/io-writeable.localnet.test.ts
+++ b/src/solana/io-writeable.localnet.test.ts
@@ -741,11 +741,22 @@ describe(
     });
 
     it('requestPrimaryName + approvePrimaryName two-step flow sets primary name', async () => {
+      // Hermeticity: use a fresh signer rather than the shared `operator`.
+      // The prior test (`setPrimaryName calls request_and_set ...`) sets a
+      // primary name on `operator`, so reusing it here trips
+      // `MustRemoveExistingPrimaryName` on the approve step. ARIO-core's
+      // `approve_primary_name` enforces a "remove first" rule when the
+      // signer already has a primary name pointing at a different name.
+      const fresh = await freshSigner(scratch, 'pn2-signer');
+      await airdrop(fresh.keypairPath, 5);
+      mintArio(fresh.signer.address, 100_000_000_000n); // 100k ARIO
+
+      const freshArio = buildArio(fresh.signer, RPC_URL!, WS_URL!);
       const rpc = createSolanaRpc(RPC_URL!);
       const antResult = await spawnSolanaANT({
         rpc,
         rpcSubscriptions: createSolanaRpcSubscriptions(WS_URL!),
-        signer: operator.signer,
+        signer: fresh.signer,
         antProgramId: address(ANT_ID!),
         state: {
           name: 'Primary approve smoke ANT',
@@ -755,7 +766,7 @@ describe(
         },
       });
       const name = `prreq${Date.now().toString(36).slice(-8)}`;
-      const buy = await ario.buyRecord({
+      const buy = await freshArio.buyRecord({
         name,
         type: 'lease',
         years: 1,
@@ -763,22 +774,22 @@ describe(
       });
       assert.ok(buy.id, 'buyRecord must succeed before primary name request');
 
-      const reqRes = await ario.requestPrimaryName({ name });
+      const reqRes = await freshArio.requestPrimaryName({ name });
       assert.ok(reqRes.id, 'requestPrimaryName must return a tx id');
 
-      const pending = await ario.getPrimaryNameRequest({
-        initiator: operator.signer.address as string,
+      const pending = await freshArio.getPrimaryNameRequest({
+        initiator: fresh.signer.address as string,
       });
       assert.equal(pending.name.toLowerCase(), name.toLowerCase());
 
-      const appRes = await ario.approvePrimaryName({
-        initiator: operator.signer.address as string,
+      const appRes = await freshArio.approvePrimaryName({
+        initiator: fresh.signer.address as string,
         name,
       });
       assert.ok(appRes.id, 'approvePrimaryName must return a tx id');
 
-      const pn = await ario.getPrimaryName({
-        address: operator.signer.address as string,
+      const pn = await freshArio.getPrimaryName({
+        address: fresh.signer.address as string,
       });
       assert.equal(pn.name.toLowerCase(), name.toLowerCase());
       assert.equal(pn.processId, antResult.processId);

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -2369,9 +2369,17 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     const { remaining, antProgram } =
       await this._buildPrimaryNameValidationAccounts(params.name, 'approve');
 
+    // withCoreDefaults injects `config` as the ArioConfig PDA derived against
+    // *this.coreProgram*. Without it, Codama's `findConfigPda()` fallback
+    // resolves to the source-pinned `ARioCoreProgramXXXX...` placeholder
+    // program id (declare_id! literal pre-anchor-keys-sync), which on any
+    // non-mainnet deployment produces an unallocated PDA → Anchor #3012
+    // AccountNotInitialized on `config`. requestPrimaryName /
+    // requestAndSetPrimaryName already use withCoreDefaults; this was the
+    // last setPrimaryName-family entrypoint missing it.
     const ix = withRemainingAccounts(
       await getApprovePrimaryNameInstructionAsync(
-        {
+        await this.withCoreDefaults({
           request: requestPda,
           initiator: params.initiator,
           primaryName: primaryNamePda,
@@ -2379,7 +2387,7 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
           nameOwner: this.signer,
           reverseLookupHash: hashName(params.name),
           antProgramId: antProgram,
-        },
+        }),
         { programAddress: this.coreProgram },
       ),
       remaining,


### PR DESCRIPTION
## Summary
Three SDK-side fixes that get the primary-name flow green against localnet (\`yarn test:localnet:io-write\` **9/9**, \`yarn test:sdk-e2e\` **4/4** — was 7/9 + 3/4).

1. **`deserializePrimaryName`** stops returning a non-existent \`processId\`. On-chain \`PrimaryName\` is \`{owner, name, set_at, bump}\` — no \`processId\` field. The previous implementation read 32 bytes from where \`set_at\` (i64) + part of \`bump\` sit and returned a fake Pubkey, breaking every \`assert.equal(pn.processId, antMint)\` check. \`getPrimaryName\` / \`getPrimaryNames\` now enrich the payload with \`processId\` via an ArnsRecord lookup keyed on the primary name's base portion.

2. **`approvePrimaryName`** wraps input in \`withCoreDefaults\`. Codama-generated \`getApprovePrimaryNameInstructionAsync\` falls back to the placeholder program id \`ARioCoreProgramXXXX...\` inside \`findConfigPda()\` when the caller doesn't pass \`config\` explicitly. Every other primary-name entrypoint (\`requestPrimaryName\`, \`requestAndSetPrimaryName\`) already wraps via \`withCoreDefaults\`; this was the last missing one. Without the wrap, approve fired \`AccountNotInitialized #3012\` on \`config\` against any non-mainnet deployment.

3. **`io-writeable.localnet.test.ts` test 9** uses a fresh signer. Test 8 sets a primary name on the shared \`operator\`, and \`approve_primary_name\` enforces a "remove first" rule (\`MustRemoveExistingPrimaryName #6022\`) when the signer already has one pointing at a different name. Hermeticity restored via a per-test signer.

## Paired with contracts PR
This SDK fix and the on-chain \`NotAntHolder\` fix are independent of each other but must land together for the SDK tests to go full green. The contracts PR (\`fix/primary-name-implicit-owner-from-last-reconciled\` against ar-io-solana-contracts \`develop\`) fixes \`read_ant_record_owner\` to fall back to \`AntRecord.last_reconciled_owner\` when \`owner = None\` — without it, tests 8/9 in io-write and test 3 in sdk-e2e still hit NotAntHolder.

## Test plan
- [x] \`yarn test:unit\` — 249/249.
- [x] \`yarn test:e2e\` (ESM + web AO bundling) — 77/77 + 5 intentional skips, no fails.
- [x] \`yarn sdk-e2e:up && yarn test:localnet:io-write\` — 9/9.
- [x] \`yarn test:sdk-e2e\` — 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)