### PR TITLE
feat(cli): add claim-withdrawal command

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -47,6 +47,7 @@ import {
 } from './commands/escrowCommands.js';
 import {
   cancelWithdrawal,
+  claimWithdrawal,
   decreaseDelegateStake,
   decreaseOperatorStake,
   delegateStake,
@@ -613,6 +614,14 @@ makeCommand({
   description: 'Cancel a pending gateway withdrawal vault',
   options: addressAndVaultIdOptions,
   action: cancelWithdrawal,
+});
+
+makeCommand({
+  name: 'claim-withdrawal',
+  description:
+    'Claim tokens from a matured withdrawal vault (after the lock period has elapsed)',
+  options: [...writeActionOptions, optionMap.vaultId],
+  action: claimWithdrawal,
 });
 
 makeCommand({

--- a/src/cli/commands/gatewayWriteCommands.ts
+++ b/src/cli/commands/gatewayWriteCommands.ts
@@ -16,6 +16,7 @@
 import prompts from 'prompts';
 
 import { mARIOToken } from '../../node/index.js';
+import type { SolanaARIOWriteable } from '../../solana/io-writeable.js';
 import type { AoStakeDelegation } from '../../types/io.js';
 import {
   AddressAndVaultIdCLIWriteOptions,
@@ -235,6 +236,11 @@ export async function decreaseOperatorStake(o: OperatorStakeCLIOptions) {
 }
 
 export async function claimWithdrawal(o: AddressAndVaultIdCLIWriteOptions) {
+  if (o.ao) {
+    throw new Error(
+      'claim-withdrawal is only supported on the Solana backend (drop --ao).',
+    );
+  }
   const vaultId = requiredStringFromOptions(o, 'vaultId');
 
   await assertConfirmationPrompt(
@@ -242,10 +248,12 @@ export async function claimWithdrawal(o: AddressAndVaultIdCLIWriteOptions) {
     o,
   );
 
-  return (await writeARIOFromOptions(o)).ario.claimWithdrawal(
-    {
-      withdrawalId: vaultId,
-    },
+  // claimWithdrawal is Solana-only — no AO equivalent exists (see the comment
+  // block in src/types/io.ts above syncAttributes). The `--ao` guard above
+  // narrows us to the Solana path, so the cast is safe at runtime.
+  const { ario } = await writeARIOFromOptions(o);
+  return (ario as unknown as SolanaARIOWriteable).claimWithdrawal(
+    { withdrawalId: vaultId },
     customTagsFromOptions(o),
   );
 }

--- a/src/cli/commands/gatewayWriteCommands.ts
+++ b/src/cli/commands/gatewayWriteCommands.ts
@@ -234,6 +234,22 @@ export async function decreaseOperatorStake(o: OperatorStakeCLIOptions) {
   );
 }
 
+export async function claimWithdrawal(o: AddressAndVaultIdCLIWriteOptions) {
+  const vaultId = requiredStringFromOptions(o, 'vaultId');
+
+  await assertConfirmationPrompt(
+    `You are about to claim matured withdrawal vault ${vaultId}. Tokens will be transferred to your wallet.\nAre you sure?`,
+    o,
+  );
+
+  return (await writeARIOFromOptions(o)).ario.claimWithdrawal(
+    {
+      withdrawalId: vaultId,
+    },
+    customTagsFromOptions(o),
+  );
+}
+
 export async function instantWithdrawal(o: AddressAndVaultIdCLIWriteOptions) {
   const vaultId = requiredStringFromOptions(o, 'vaultId');
   const gatewayAddress = requiredAddressFromOptions(o);


### PR DESCRIPTION
## Summary

- The SDK has `claimWithdrawal({ withdrawalId })` as a writeable method but it was missing from the CLI
- Users had no CLI path to claim matured withdrawal vaults after the lock period elapses
- Adds `claim-withdrawal --vault-id <id>` alongside existing `instant-withdrawal` and `cancel-withdrawal` commands

## Changes

- `src/cli/commands/gatewayWriteCommands.ts`: Add `claimWithdrawal` CLI function
- `src/cli/cli.ts`: Import + wire `claim-withdrawal` command with `writeActionOptions` + `optionMap.vaultId`

## Test plan

- [ ] `ario claim-withdrawal --vault-id <id>` works with a matured withdrawal on localnet/devnet
- [ ] Rejects with `WithdrawalNotReady` when called before lock period elapses
- [ ] Confirmation prompt displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)