### PR TITLE
fix: convert Solana delegate reward share from basis points to percent

### DIFF
--- a/src/solana/deserialize.test.ts
+++ b/src/solana/deserialize.test.ts
@@ -221,6 +221,7 @@ describe('deserializeGateway (synthetic round-trip — cumulativeRewardPerToken)
 
     assert.equal(gw.operatorStake, 30_000_000_000);
     assert.equal(gw.totalDelegatedStake, 5_000_000_000);
+    assert.equal(gw.settings.delegateRewardShareRatio, 10);
     assert.equal(gw.cumulativeRewardPerToken, 750_000_000_000_000_000n);
   });
 

--- a/src/solana/deserialize.ts
+++ b/src/solana/deserialize.ts
@@ -388,7 +388,7 @@ export function deserializeGatewayWithAccumulator(
 
   // GatewaySettings2 (auto_stake removed in cfc7a8b2 — never existed on Solana)
   const allowDelegatedStaking = r.readBool();
-  const delegateRewardShareRatio = r.readU16();
+  const delegateRewardShareRatio = r.readU16() / 100;
   const minDelegatedStake = r.readU64AsNumber();
   const allowlistEnabled = r.readBool();
 


### PR DESCRIPTION
The Solana gateway read path was returning delegateRewardShareRatio as raw basis points from on-chain storage, so gateways configured for 90% could appear as 9000% in the SDK/UI. The change converts the deserialized value back to percent so the SDK read path matches the write path and the public API.