### PR TITLE
feat(solana): add getWithdrawals per-owner read

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -104,6 +104,7 @@ Commands:
   get-gateway [options]                   Get the gateway of an address
   get-gateway-delegates [options]         Get the delegates of a gateway
   get-gateway-vaults [options]            Get the vaults of a gateway
+  get-withdrawals [options]               Get all pending stake withdrawals (operator + delegate) owned by an address (Solana-only)
   get-delegations [options]               Get all stake delegated to gateways from this address
   get-allowed-delegates [options]         Get the allow list of a gateway delegate
   get-arns-record [options]               Get an ArNS record by name
@@ -153,6 +154,7 @@ Commands:
   decrease-operator-stake [options]       Decrease operator stake
   instant-withdrawal [options]            Instantly withdraw stake from an existing gateway withdrawal vault
   cancel-withdrawal [options]             Cancel a pending gateway withdrawal vault
+  claim-withdrawal [options]              Claim a matured stake withdrawal vault (Solana-only)
   delegate-stake [options]                Delegate stake to a gateway
   decrease-delegate-stake [options]       Decrease delegated stake
   redelegate-stake [options]              Redelegate stake to another gateway

--- a/README.md
+++ b/README.md
@@ -1043,6 +1043,57 @@ const vaults = await ario.getAllGatewayVaults({
 
 </details>
 
+#### `getWithdrawals({ address, cursor, limit, sortBy, sortOrder })`
+
+**Solana-only.** Returns every pending stake withdrawal owned by `address` — covering both operator-stake decreases (`isDelegate: false`) and delegate-stake decreases (`isDelegate: true`). A withdrawal is claimable when `Date.now() >= endTimestamp`; call `claimWithdrawal({ withdrawalId: item.vaultId })` to release the tokens.
+
+This is the per-owner read needed to drive "you have X claimable withdrawals" UIs without fanning out across every gateway the wallet has interacted with. Throws on the AO backend.
+
+```typescript
+const ario = ARIO.init({ backend: "solana", rpc, rpcSubscriptions, signer });
+
+const withdrawals = await ario.getWithdrawals({
+  address: "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+});
+
+const claimable = withdrawals.items.filter(
+  (w) => Date.now() >= w.endTimestamp,
+);
+```
+
+<details>
+  <summary>Output</summary>
+
+```json
+{
+  "hasMore": false,
+  "totalItems": 2,
+  "limit": 100,
+  "items": [
+    {
+      "cursorId": "8CSdSjf7gXqQ5p1U2qfdwHzVw9sZRYHJpDpV87dnvb4d",
+      "vaultId": "0",
+      "gatewayAddress": "Bxz7Q2tWfqr9Q5T6cZjUnVxRk9CnHwShfgUaW5fY1Mvr",
+      "balance": 50000000000,
+      "startTimestamp": 1735843635857,
+      "endTimestamp": 1738435635857,
+      "isDelegate": true
+    },
+    {
+      "cursorId": "FmWUz4w7vSdLcz1nN8H1n2KkjJgrQQXR1n4kV3WqJ7Hf",
+      "vaultId": "1",
+      "gatewayAddress": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+      "balance": 10000000000,
+      "startTimestamp": 1735843835857,
+      "endTimestamp": 1738435835857,
+      "isDelegate": false
+    }
+  ]
+}
+```
+
+</details>
+
 #### `increaseOperatorStake({ qty })`
 
 Increases the callers operator stake. Must be executed with a wallet registered as a gateway operator.

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -89,6 +89,7 @@ import {
   getPrimaryName,
   getTokenCost,
   getVault,
+  getWithdrawals,
   listAllDelegatesCLICommand,
   listAntsForAddress,
   listArNSRecords,
@@ -511,6 +512,14 @@ makeCommand({
   description: 'List vaults from all gateways',
   options: paginationAddressOptions,
   action: getAllGatewayVaults,
+});
+
+makeCommand({
+  name: 'get-withdrawals',
+  description:
+    'Get all pending stake withdrawals (operator + delegate) owned by an address (Solana-only)',
+  options: paginationAddressOptions,
+  action: getWithdrawals,
 });
 
 // # Actions

--- a/src/cli/commands/readCommands.ts
+++ b/src/cli/commands/readCommands.ts
@@ -19,6 +19,7 @@ import {
   AoGatewayDelegateWithAddress,
   AoGatewayVault,
   AoGetCostDetailsParams,
+  AoUserWithdrawal,
 } from '../../types/io.js';
 import { mARIOToken } from '../../types/token.js';
 import {
@@ -283,6 +284,23 @@ export async function getAllGatewayVaults(o: PaginationCLIOptions) {
     ? result
     : {
         message: `No vaults found`,
+      };
+}
+
+export async function getWithdrawals(o: PaginationAddressCLIOptions) {
+  const address = requiredAddressFromOptions(o);
+  const result = await readARIOFromOptions(o).getWithdrawals({
+    address,
+    ...paginationParamsFromOptions<
+      PaginationAddressCLIOptions,
+      AoUserWithdrawal
+    >(o),
+  });
+
+  return result.items?.length
+    ? result
+    : {
+        message: `No pending withdrawals found for address ${address}`,
       };
 }
 

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -69,6 +69,7 @@ import {
   AoTokenCostParams,
   AoTokenSupplyData,
   AoUpdateGatewaySettingsParams,
+  AoUserWithdrawal,
   AoVaultData,
   AoVaultedTransferParams,
   AoWalletVault,
@@ -1146,6 +1147,21 @@ export class ARIOReadable implements AoARIORead, ArNSNameResolver {
         ...paginationParamsToTags<AoAllGatewayVaults>(params),
       ],
     });
+  }
+
+  /**
+   * AO backend stub — `getWithdrawals` is a Solana-only per-owner read that
+   * aggregates operator-stake and delegate-stake withdrawals for a wallet.
+   * On AO, withdrawals auto-distribute at maturity; use `getDelegations`
+   * (vault-typed entries) and `getGatewayVaults` instead.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getWithdrawals(
+    _params: PaginationParams<AoUserWithdrawal> & { address: WalletAddress },
+  ): Promise<PaginationResult<AoUserWithdrawal>> {
+    throw new Error(
+      'getWithdrawals is only supported on the Solana backend (use ARIO.init({ backend: "solana", ... })).',
+    );
   }
 
   async resolveArNSName({

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -78,6 +78,7 @@ import type {
   AoReturnedName,
   AoTokenCostParams,
   AoTokenSupplyData,
+  AoUserWithdrawal,
   AoVaultData,
   AoWalletVault,
   AoWeightedObserver,
@@ -891,6 +892,44 @@ export class SolanaARIOReadable {
             endTimestamp: secToMs(w.endTimestamp),
           });
         }
+      } catch {
+        // Skip malformed
+      }
+    }
+
+    return paginate(items, params);
+  }
+
+  async getWithdrawals(
+    params: PaginationParams<AoUserWithdrawal> & { address: WalletAddress },
+  ): Promise<PaginationResult<AoUserWithdrawal>> {
+    const owner = address(params.address);
+    // Withdrawal layout: disc(8) + owner(32) + withdrawal_id(8) + gateway(32).
+    // Filter by owner at offset 8 — returns both operator-stake (isDelegate=false)
+    // and delegate-stake (isDelegate=true) withdrawals for this wallet.
+    const accounts = await this.getAccountsByDiscriminator(
+      this.garProgram,
+      WITHDRAWAL_DISCRIMINATOR,
+      [
+        {
+          memcmp: { offset: 8n, bytes: owner as string, encoding: 'base58' },
+        },
+      ],
+    );
+
+    const items: AoUserWithdrawal[] = [];
+    for (const { pubkey, data } of accounts) {
+      try {
+        const w = deserializeWithdrawal(data);
+        items.push({
+          cursorId: pubkey as string,
+          vaultId: w.vaultId,
+          balance: w.balance,
+          startTimestamp: secToMs(w.startTimestamp),
+          endTimestamp: secToMs(w.endTimestamp),
+          gatewayAddress: w.gateway,
+          isDelegate: w.isDelegate,
+        });
       } catch {
         // Skip malformed
       }

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -900,6 +900,16 @@ export class SolanaARIOReadable {
     return paginate(items, params);
   }
 
+  /**
+   * Return every pending stake withdrawal owned by `address` — operator-stake
+   * decreases (`isDelegate: false`) and delegate-stake decreases
+   * (`isDelegate: true`) in one paginated result. A withdrawal is claimable
+   * when `Date.now() >= endTimestamp`; release the funds via
+   * `claimWithdrawal({ withdrawalId: item.vaultId })`.
+   *
+   * Solana-only: AO releases withdrawals automatically at maturity and has no
+   * equivalent per-owner read; the AO backend throws.
+   */
   async getWithdrawals(
     params: PaginationParams<AoUserWithdrawal> & { address: WalletAddress },
   ): Promise<PaginationResult<AoUserWithdrawal>> {

--- a/src/solana/io-writeable.localnet.test.ts
+++ b/src/solana/io-writeable.localnet.test.ts
@@ -511,6 +511,89 @@ describe(
       );
     });
 
+    it('getWithdrawals({ address }) returns per-wallet operator + delegate withdrawals', async () => {
+      // Fresh operator + fresh delegator so the assertion counts are exact
+      // and the shared `operator` state isn't perturbed.
+      const wdOp = await freshSigner(scratch, 'wd-list-operator');
+      await airdrop(wdOp.keypairPath, 5);
+      mintArio(wdOp.signer.address, OPERATOR_STAKE * 2n);
+      const wdOpArio = buildArio(wdOp.signer, RPC_URL!, WS_URL!);
+
+      await wdOpArio.joinNetwork({
+        operatorStake: Number(OPERATOR_STAKE),
+        label: 'wd-list-gw',
+        fqdn: 'wd-list.example.com',
+        port: 443,
+        protocol: 'https',
+        autoStake: false,
+        allowDelegatedStaking: true,
+        delegateRewardShareRatio: 10,
+        observerAddress: wdOp.signer.address as string,
+      });
+
+      // Operator-stake withdrawal. OPERATOR_STAKE (50k) - 10k = 40k, still
+      // above the 10k floor, so the decrease is accepted.
+      await wdOpArio.decreaseOperatorStake({
+        decreaseQty: 10_000_000_000,
+      });
+
+      // Delegate-stake withdrawal from a fresh delegator targeting wdOp.
+      const wdDel = await freshSigner(scratch, 'wd-list-delegator');
+      await airdrop(wdDel.keypairPath, 5);
+      mintArio(wdDel.signer.address, 100_000_000_000n);
+      const wdDelArio = buildArio(wdDel.signer, RPC_URL!, WS_URL!);
+
+      const delegateAmount = 50_000_000_000n;
+      await wdDelArio.delegateStake({
+        target: wdOp.signer.address as string,
+        stakeQty: Number(delegateAmount),
+      });
+      await wdDelArio.decreaseDelegateStake({
+        target: wdOp.signer.address as string,
+        decreaseQty: Number(delegateAmount),
+      });
+
+      const opResult = await wdOpArio.getWithdrawals({
+        address: wdOp.signer.address as string,
+      });
+      assert.equal(
+        opResult.items.length,
+        1,
+        'operator must surface exactly one withdrawal (its own decrease)',
+      );
+      assert.equal(opResult.items[0].isDelegate, false);
+      assert.equal(
+        opResult.items[0].gatewayAddress,
+        wdOp.signer.address as string,
+      );
+      assert.ok(
+        opResult.items[0].endTimestamp > opResult.items[0].startTimestamp,
+        'endTimestamp must be after startTimestamp',
+      );
+
+      const delResult = await wdDelArio.getWithdrawals({
+        address: wdDel.signer.address as string,
+      });
+      assert.equal(
+        delResult.items.length,
+        1,
+        'delegator must surface exactly one withdrawal (its delegate decrease)',
+      );
+      assert.equal(delResult.items[0].isDelegate, true);
+      assert.equal(
+        delResult.items[0].gatewayAddress,
+        wdOp.signer.address as string,
+      );
+
+      // Cross-check: operator's getWithdrawals does NOT include the delegate
+      // withdrawal that landed on its gateway (delegate withdrawal is owned
+      // by the delegator, not by the gateway).
+      assert.ok(
+        opResult.items.every((w) => !w.isDelegate),
+        'operator getWithdrawals must not surface delegate-owned withdrawals',
+      );
+    });
+
     it('buyRecord({ fundFrom: "plan", sources: [...] }) draws from a caller-supplied balance + delegation plan', async () => {
       // Fresh delegator → mint balance → delegate so the plan has both a
       // wallet ATA source and a delegation source. Pre-compute cost via

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -373,6 +373,18 @@ export type AoAllGatewayVaults = AoGatewayVault & {
   gatewayAddress: WalletAddress;
 };
 
+/**
+ * A pending or matured stake withdrawal owned by a wallet. Covers both
+ * operator-stake decreases and delegate-stake decreases — discriminate with
+ * `isDelegate`. A withdrawal is claimable when `Date.now() >= endTimestamp`.
+ *
+ * Solana-only: AO releases withdrawals automatically at maturity and has no
+ * equivalent per-owner read.
+ */
+export type AoUserWithdrawal = AoAllGatewayVaults & {
+  isDelegate: boolean;
+};
+
 // Input types
 export type AoJoinNetworkParams = Pick<AoGateway, 'operatorStake'> &
   Partial<AoGatewaySettings> & {
@@ -762,6 +774,9 @@ export interface AoARIORead extends ArNSNameResolver {
   getAllGatewayVaults(
     params?: PaginationParams<AoAllGatewayVaults>,
   ): Promise<PaginationResult<AoAllGatewayVaults>>;
+  getWithdrawals(
+    params: PaginationParams<AoUserWithdrawal> & { address: WalletAddress },
+  ): Promise<PaginationResult<AoUserWithdrawal>>;
 }
 
 export interface AoARIOWrite extends AoARIORead {


### PR DESCRIPTION
## Summary

- Adds `ario.getWithdrawals({ address })` on the Solana backend — a single per-owner read that returns both operator-stake and delegate-stake withdrawal vaults for a wallet, each carrying `isDelegate`, `gatewayAddress`, `balance`, `startTimestamp`, and `endTimestamp`.
- Closes the gap where portal/UX code had to fan out across every gateway a wallet has touched (and still missed delegate-stake withdrawals — `getGatewayVaults` filters `isDelegate` out) just to render "you have N claimable withdrawals."
- Pairs with the existing `claimWithdrawal({ withdrawalId })` write path so a UI can drive: list → flag rows where `Date.now() >= endTimestamp` → claim per row.

## Implementation notes

- No IDL / codegen / contract change. Uses the existing `Withdrawal` account layout (`disc(8) + owner(32) + withdrawal_id(8) + gateway(32) + ...`) and the existing `deserializeWithdrawal` decoder. Filtering is a `memcmp` at offset 8 on owner.
- AO backend throws (Solana-only), matching the `syncAttributes` / `claimWithdrawal` precedent. The user explicitly does not want an AO implementation.
- CLI: `ar.io get-withdrawals --address <wallet>` registered with `paginationAddressOptions`.

## Test plan

- [x] `yarn build:esm` clean
- [x] `yarn lint:check` clean
- [x] `yarn test:unit` — 249/249 pass
- [ ] `yarn sdk-e2e:up` + `yarn test:localnet:io-write` — added a focused localnet test that:
  - Spins up a fresh operator + delegator
  - Creates one operator-stake withdrawal (`decreaseOperatorStake`) and one delegate-stake withdrawal (`delegateStake` → `decreaseDelegateStake`)
  - Asserts each wallet's `getWithdrawals` returns exactly its own withdrawal with the correct `isDelegate` and `gatewayAddress`
- [ ] Smoke against the network portal: render banner from `items.filter(w => Date.now() >= w.endTimestamp)` and confirm row counts match expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)