### PR TITLE
fix(package): add default export conditions for sdk entrypoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,23 +27,28 @@
   "exports": {
     ".": {
       "types": "./lib/types/node/index.d.ts",
-      "import": "./lib/esm/node/index.js"
+      "import": "./lib/esm/node/index.js",
+      "default": "./lib/esm/node/index.js"
     },
     "./node": {
       "types": "./lib/types/node/index.d.ts",
-      "import": "./lib/esm/node/index.js"
+      "import": "./lib/esm/node/index.js",
+      "default": "./lib/esm/node/index.js"
     },
     "./web": {
       "types": "./lib/types/web/index.d.ts",
-      "import": "./lib/esm/web/index.js"
+      "import": "./lib/esm/web/index.js",
+      "default": "./lib/esm/web/index.js"
     },
     "./solana": {
       "types": "./lib/types/solana/index.d.ts",
-      "import": "./lib/esm/solana/index.js"
+      "import": "./lib/esm/solana/index.js",
+      "default": "./lib/esm/solana/index.js"
     },
     "./solana/generated": {
       "types": "./lib/types/solana/generated/index.d.ts",
-      "import": "./lib/esm/solana/generated/index.js"
+      "import": "./lib/esm/solana/generated/index.js",
+      "default": "./lib/esm/solana/generated/index.js"
     }
   },
   "bin": {


### PR DESCRIPTION
This updates the package export map to include default conditions for all public entrypoints so non-ESM-first resolvers can resolve the SDK without failing with ERR_PACKAGE_PATH_NOT_EXPORTED.

What changed:

Added default export conditions for:
.
./node
./web
./solana
./solana/generated
Each default condition points to the existing ESM output path.
Why:
Some downstream runtime setups (for example ts-node/nodemon startup paths using require semantics) do not match import-only export maps and fail during package resolution before load.

Validation:

require.resolve('@ar.io/sdk') resolves successfully.
A direct require('@ar.io/sdk') sanity check succeeds.
package.json validation reports no errors.
Impact:

No API surface changes.
No runtime behavior changes for ESM consumers.
Improves compatibility for CommonJS and mixed-resolution environments.