### PR TITLE
fix(solana): don't sign ANT writes against an untrusted auto-detected program

### DIFF
--- a/src/common/ant.ts
+++ b/src/common/ant.ts
@@ -33,6 +33,13 @@ import type { ANTRead, ANTWrite } from '../types/ant.js';
  * (BYO-ANT) and falls back to the canonical default. Callers who already know
  * the program (e.g. immediately after `ANT.spawn`) can pass it explicitly to
  * skip the lookup.
+ *
+ * SECURITY: the `ANT Program` trait is untrusted asset/RPC data. For a
+ * read-only client it's used as-is, but a writeable client (signer present)
+ * will NOT sign against an auto-detected *non-canonical* program — it throws
+ * unless you opted in by passing `antProgramId` explicitly. This prevents a
+ * malicious asset or spoofed RPC response from redirecting your signed
+ * transaction to an attacker-controlled program.
  */
 export type ANTConfig = {
   processId: string;
@@ -58,24 +65,30 @@ export class ANT {
     return (async () => {
       const { SolanaANTReadable } = await import('../solana/ant-readable.js');
       const { SolanaANTWriteable } = await import('../solana/ant-writeable.js');
-      // ADR-016 / BD-100: when no explicit `antProgramId` is passed,
-      // resolve it from the asset's `ANT Program` Attributes-plugin entry.
-      // Without this auto-detection, third-party (BYO-ANT) assets would
-      // silently mis-derive PDAs through the canonical default.
-      let antProgramId = config.antProgramId;
-      if (!antProgramId) {
-        const { fetchAntProgramFromAsset } = await import(
-          '../solana/mpl-core.js'
-        );
-        const { ARIO_ANT_PROGRAM_ID } = await import('../solana/constants.js');
-        const { address } = await import('@solana/kit');
-        const detected = await fetchAntProgramFromAsset(
-          config.rpc,
-          address(config.processId),
-          { commitment: config.commitment ?? 'confirmed' },
-        );
-        antProgramId = detected ?? ARIO_ANT_PROGRAM_ID;
-      }
+      // ADR-016 / BD-100: when no explicit `antProgramId` is passed, resolve
+      // it from the asset's `ANT Program` Attributes-plugin entry so that
+      // third-party (BYO-ANT) assets derive PDAs through the right program.
+      //
+      // SECURITY: that trait is untrusted asset/RPC data. The *read* path may
+      // use it freely (it never signs). The *write* path runs it through
+      // `resolveWriteAntProgram`, which refuses to sign against a non-canonical
+      // detected value unless the caller opted in by passing `antProgramId`
+      // explicitly — otherwise a spoofed trait could route a signed tx to an
+      // attacker-controlled program.
+      const explicit = config.antProgramId;
+      const { fetchAntProgramFromAsset, resolveWriteAntProgram } = await import(
+        '../solana/mpl-core.js'
+      );
+      const { ARIO_ANT_PROGRAM_ID } = await import('../solana/constants.js');
+      const { address } = await import('@solana/kit');
+      const detected =
+        explicit !== undefined
+          ? null
+          : await fetchAntProgramFromAsset(
+              config.rpc,
+              address(config.processId),
+              { commitment: config.commitment ?? 'confirmed' },
+            );
       if (config.signer) {
         if (!config.rpcSubscriptions) {
           throw new Error(
@@ -88,14 +101,14 @@ export class ANT {
           processId: config.processId,
           signer: config.signer,
           commitment: config.commitment,
-          antProgramId,
+          antProgramId: resolveWriteAntProgram({ explicit, detected }),
         }) as unknown as ANTWrite;
       }
       return new SolanaANTReadable({
         rpc: config.rpc,
         processId: config.processId,
         commitment: config.commitment,
-        antProgramId,
+        antProgramId: explicit ?? detected ?? ARIO_ANT_PROGRAM_ID,
       }) as unknown as ANTRead;
     })();
   }

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -168,7 +168,7 @@ import {
   getUpdateGatewaySettingsInstructionAsync,
 } from '@ar.io/solana-contracts/gar';
 import { getTransferCheckedInstruction } from '@solana-program/token';
-import { TOKEN_DECIMALS } from './constants.js';
+import { ARIO_ANT_PROGRAM_ID, TOKEN_DECIMALS } from './constants.js';
 import { SolanaARIOReadable } from './io-readable.js';
 import {
   getAntRecordPDA,
@@ -2064,10 +2064,13 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
    *
    * `antProgram` honors ADR-016 / BD-100 pluggability: the asset's
    * `ANT Program` Attributes-plugin trait selects which program owns the
-   * AntRecord PDA. Absent / unparseable → canonical fallback. Both the
-   * PDA derivation here and the `ant_program_id` arg the caller passes
-   * to the on-chain ix MUST agree (the handler re-derives and rejects
-   * mismatches).
+   * AntRecord PDA. Absent / unparseable → canonical fallback. The detected
+   * trait is untrusted asset/RPC data, so it is honored only when it matches
+   * the canonical program or this client's explicitly-configured
+   * `this.antProgram`; any other value falls back to the configured program
+   * (see the SECURITY note in the body). Both the PDA derivation here and the
+   * `ant_program_id` arg the caller passes to the on-chain ix MUST agree (the
+   * handler re-derives and rejects mismatches).
    */
   private async _buildPrimaryNameValidationAccounts(
     name: string,
@@ -2102,10 +2105,26 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       const antMint = address(arnsRecord.processId);
 
       const { fetchAntProgramFromAsset } = await import('./mpl-core.js');
+      const detected = await fetchAntProgramFromAsset(this.rpc, antMint, {
+        commitment: this.commitment,
+      });
+      // SECURITY (BD-100 / SDK ANT-program auth finding): the asset's
+      // `ANT Program` trait is untrusted asset/RPC data. Only honor a detected
+      // value when it matches the canonical program or the program this client
+      // was explicitly configured with (`this.antProgram`); otherwise fall back
+      // to the configured program so a spoofed trait can't redirect the
+      // AntRecord PDA derivation. This path only derives a READONLY validation
+      // account (the instruction itself targets the canonical core program), so
+      // the fallback is silent rather than a throw — but the gate keeps an
+      // attacker from steering PDA derivation. Heterogeneous BYO-ANT primary
+      // names (an asset on a non-configured program) await the contract-side
+      // resolution of the `ant_program == ario_ant::ID` pin; see the
+      // accompanying security note.
       antProgram =
-        (await fetchAntProgramFromAsset(this.rpc, antMint, {
-          commitment: this.commitment,
-        })) ?? this.antProgram;
+        detected !== null &&
+        (detected === ARIO_ANT_PROGRAM_ID || detected === this.antProgram)
+          ? detected
+          : this.antProgram;
 
       // removeForBaseName always uses the "@" undername (the base-name
       // owner's record). The other ANT-auth variants use the undername

--- a/src/solana/mpl-core.test.ts
+++ b/src/solana/mpl-core.test.ts
@@ -1,10 +1,15 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
+import { type Address, address } from '@solana/kit';
+
+import { ANT } from '../common/ant.js';
+import { ARIO_ANT_PROGRAM_ID, ARIO_CORE_PROGRAM_ID } from './constants.js';
 import {
   TRAIT_KEY_ANT_PROGRAM,
   TRAIT_KEY_ARNS_NAME,
   readAttribute,
+  resolveWriteAntProgram,
 } from './mpl-core.js';
 
 const ATTRIBUTES_PLUGIN_TYPE = 6;
@@ -133,5 +138,125 @@ describe('readAttribute', () => {
     const buf = new Uint8Array(8);
     buf[0] = 1;
     assert.equal(readAttribute(buf, TRAIT_KEY_ANT_PROGRAM), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveWriteAntProgram — the trust gate for the SIGNING (write) path.
+// The `ANT Program` trait is untrusted asset/RPC data; a non-canonical
+// detected value must not be signed against without explicit opt-in, or a
+// spoofed trait could route a victim's signature to an attacker program.
+// ---------------------------------------------------------------------------
+
+describe('resolveWriteAntProgram', () => {
+  // A valid-but-non-canonical program id stands in for an attacker's program.
+  const NON_CANONICAL = ARIO_CORE_PROGRAM_ID;
+
+  it('falls back to canonical when no trait is detected', () => {
+    assert.equal(
+      resolveWriteAntProgram({ detected: null }),
+      ARIO_ANT_PROGRAM_ID,
+    );
+  });
+
+  it('accepts a detected value that equals the canonical program', () => {
+    assert.equal(
+      resolveWriteAntProgram({ detected: ARIO_ANT_PROGRAM_ID }),
+      ARIO_ANT_PROGRAM_ID,
+    );
+  });
+
+  it('THROWS on an auto-detected non-canonical program (no opt-in)', () => {
+    assert.throws(
+      () => resolveWriteAntProgram({ detected: NON_CANONICAL }),
+      /non-canonical ANT program/,
+    );
+  });
+
+  it('honors an explicit non-canonical program (BYO-ANT opt-in)', () => {
+    assert.equal(
+      resolveWriteAntProgram({ explicit: NON_CANONICAL, detected: null }),
+      NON_CANONICAL,
+    );
+  });
+
+  it('explicit opt-in wins even if a different value was detected', () => {
+    assert.equal(
+      resolveWriteAntProgram({
+        explicit: ARIO_ANT_PROGRAM_ID,
+        detected: NON_CANONICAL,
+      }),
+      ARIO_ANT_PROGRAM_ID,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ANT.init end-to-end: a spoofed `ANT Program` trait must NOT become the
+// signed-write program, but the read-only client may still auto-detect it.
+// Mirrors the security finding's PoC step.
+// ---------------------------------------------------------------------------
+
+/** A valid asset address to stand in as the ANT `processId`. */
+const ASSET_ADDRESS = address('So11111111111111111111111111111111111111112');
+
+/** Stub rpc whose getAccountInfo returns `bytes` for any pubkey. */
+function stubRpcReturningAsset(bytes: Uint8Array): unknown {
+  return {
+    getAccountInfo: () => ({
+      send: async () => ({
+        value: {
+          data: [Buffer.from(bytes).toString('base64'), 'base64'] as readonly [
+            string,
+            string,
+          ],
+          lamports: 1,
+          owner: '11111111111111111111111111111111',
+          executable: false,
+          rentEpoch: 0,
+        },
+      }),
+    }),
+  };
+}
+
+describe('ANT.init ANT-program trust', () => {
+  // Asset advertising an attacker-controlled `ANT Program` trait.
+  const spoofedAsset = makeAssetWithAttributes([
+    ['ANT Program', ARIO_CORE_PROGRAM_ID as string],
+  ]);
+
+  it('refuses to build a writeable client against a spoofed program', async () => {
+    const rpc = stubRpcReturningAsset(spoofedAsset);
+    await assert.rejects(
+      ANT.init({
+        processId: ASSET_ADDRESS,
+        rpc: rpc as never,
+        signer: {} as never,
+        rpcSubscriptions: {} as never,
+      }),
+      /non-canonical ANT program/,
+    );
+  });
+
+  it('allows a readable client to auto-detect (no signature at risk)', async () => {
+    const rpc = stubRpcReturningAsset(spoofedAsset);
+    const ant = await ANT.init({
+      processId: ASSET_ADDRESS,
+      rpc: rpc as never,
+    });
+    assert.ok(ant, 'read-only ANT.init should resolve without throwing');
+  });
+
+  it('builds a writeable client when the spoofed program is explicitly opted into', async () => {
+    const rpc = stubRpcReturningAsset(spoofedAsset);
+    const ant = await ANT.init({
+      processId: ASSET_ADDRESS,
+      rpc: rpc as never,
+      signer: {} as never,
+      rpcSubscriptions: {} as never,
+      antProgramId: ARIO_CORE_PROGRAM_ID as Address,
+    });
+    assert.ok(ant, 'explicit opt-in should bypass the auto-detect guard');
   });
 });

--- a/src/solana/mpl-core.ts
+++ b/src/solana/mpl-core.ts
@@ -33,6 +33,7 @@ import {
   fetchEncodedAccount,
 } from '@solana/kit';
 
+import { ARIO_ANT_PROGRAM_ID } from './constants.js';
 import { getAssetV1Decoder } from './generated/mpl-core/accounts/assetV1.js';
 import { getPluginHeaderV1Decoder } from './generated/mpl-core/accounts/pluginHeaderV1.js';
 import { getPluginRegistryV1Decoder } from './generated/mpl-core/accounts/pluginRegistryV1.js';
@@ -132,6 +133,49 @@ export async function fetchAntProgramFromAsset(
   // simple ("found a value or didn't"); a malformed value is a holder
   // self-grief that surfaces at the next PDA derivation.
   return value as Address;
+}
+
+/**
+ * Decide which ANT program id to trust for a SIGNING (write) transaction.
+ *
+ * The `ANT Program` trait returned by {@link fetchAntProgramFromAsset} is read
+ * from Metaplex Core asset / RPC data and is NOT authenticated — a malicious
+ * asset owner, or a spoofed/compromised RPC response, can set it to an
+ * attacker-controlled program. Write instructions use this value as the
+ * instruction `programAddress` while including the caller as a signer, so
+ * silently trusting a non-canonical detected value would let an attacker route
+ * a victim's signed transaction to their own program and inherit signer /
+ * writable privileges over the included accounts.
+ *
+ * Trust rules — BYO-ANT (ADR-016 / BD-100) stays supported, but only via
+ * explicit opt-in:
+ *   - An `explicit` program id (the caller passed `antProgramId`) is always
+ *     honored — the caller has taken responsibility for it.
+ *   - Otherwise a detected value is honored only when it is `null` (no trait)
+ *     or equals the canonical {@link ARIO_ANT_PROGRAM_ID}.
+ *   - A detected NON-canonical value with no explicit opt-in throws, rather
+ *     than silently signing against an untrusted program.
+ *
+ * Read-only paths never sign, so they may auto-detect freely; this guard is
+ * only for the write path.
+ */
+export function resolveWriteAntProgram(args: {
+  explicit?: Address;
+  detected: Address | null;
+  canonical?: Address;
+}): Address {
+  const canonical = args.canonical ?? ARIO_ANT_PROGRAM_ID;
+  if (args.explicit !== undefined) return args.explicit;
+  if (args.detected === null || args.detected === canonical) return canonical;
+  throw new Error(
+    `ANT.init auto-detected a non-canonical ANT program (${args.detected}) ` +
+      `from the asset's "${TRAIT_KEY_ANT_PROGRAM}" trait. That value is read ` +
+      `from asset/RPC data and is not authenticated, so the SDK refuses to ` +
+      `build a *signed* transaction against it implicitly (doing so could ` +
+      `route your signature to an attacker-controlled program). To use a ` +
+      `third-party (BYO-ANT) program for writes, pass it explicitly: ` +
+      `ANT.init({ ..., antProgramId }).`,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

**Security finding (Codex), client-side.** `ANT.init` auto-detects the ANT program id from the asset's `ANT Program` Attributes-plugin trait when `antProgramId` is omitted (BYO-ANT, ADR-016 / BD-100). That trait is read from Metaplex Core asset / RPC data and is **not authenticated**.

For a **writeable** client the detected value became the instruction `programAddress` across every write method (`setRecord`, `setController`, `transfer`, …) while the caller was included as a **signer**. So a malicious asset owner — or a spoofed/compromised RPC response — could route a victim's signed transaction to an attacker-controlled Solana program and inherit signer/writable privileges over the included accounts. The CLI/SDK write path hits this by default whenever `antProgramId` is omitted.

## Fix — harden the signing path, keep BYO-ANT

BYO-ANT stays supported, but only via **explicit opt-in** for non-canonical programs:

- **`resolveWriteAntProgram` (`mpl-core.ts`)** — the trust gate:
  - an explicit `antProgramId` (caller-supplied) is always honored;
  - an auto-detected value is trusted only when it's absent (`null`) or equals the canonical `ARIO_ANT_PROGRAM_ID`;
  - a detected **non-canonical** value with no explicit opt-in **throws** instead of silently signing against it.
- **`ANT.init`** — the **read** path still auto-detects freely (it never signs); the **write** path runs the detected value through `resolveWriteAntProgram`.
- **`io-writeable.ts` primary-name path** — only honor a detected program when it equals canonical or this client's explicitly-configured `this.antProgram`, else fall back to the configured program. (This path only derives a READONLY validation account — the instruction targets the canonical core program — so it's lower risk, but gated for defense in depth.)

## Tests

`src/solana/mpl-core.test.ts` (8 new):
- pure `resolveWriteAntProgram` cases (canonical / null / non-canonical-throws / explicit-opt-in / explicit-wins);
- `ANT.init` end-to-end against a spoofed `ANT Program` trait: **rejected for writes**, **allowed for reads**, **bypassed by explicit opt-in**.

All four CI gates pass locally: `lint:check`, `format:check`, `build` (tsc), `test:unit` (236 pass).

## Drive-by: pre-existing tsc break fixed

`EscrowAntState` / `EscrowTokenState` typed `version` as `{ major, minor, patch }`, but the generated decoder (and the on-chain account) expose a `u8` schema-version `number`. This broke `yarn build` on `solana` already (the `solana` branch is excluded from push-triggered CI, so it went unnoticed). Corrected to `number`. Unrelated to the security fix but required for a green build.

## Contracts-side follow-up (separate repo)

The on-chain `ant_program == ario_ant::ID` pin (ario-core primary-name path, from the on-chain half of the same Codex report) currently blocks heterogeneous BYO-ANT end-to-end. Whether to relax it is a separate `ar-io-solana-contracts` decision (flagged with the team) and is **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)