### PR TITLE
fix(solana): correct EscrowAntState/EscrowTokenState version field type

### DIFF
--- a/src/solana/escrow.ts
+++ b/src/solana/escrow.ts
@@ -71,7 +71,8 @@ import type { SolanaRpc, SolanaRpcSubscriptions } from './types.js';
 export type EscrowProtocol = 'arweave' | 'ethereum';
 
 export interface EscrowAntState {
-  version: { major: number; minor: number; patch: number };
+  /** On-chain schema version, as decoded by the generated client. */
+  version: EscrowAnt['version'];
   bump: number;
   depositor: Address;
   antMint: Address;
@@ -466,7 +467,8 @@ export class ANTEscrow {
 export type EscrowAssetType = 'token' | 'vault';
 
 export interface EscrowTokenState {
-  version: { major: number; minor: number; patch: number };
+  /** On-chain schema version, as decoded by the generated client. */
+  version: EscrowToken['version'];
   bump: number;
   depositor: Address;
   assetType: EscrowAssetType;


### PR DESCRIPTION
## Surfaced by 4.0.0-solana.17

Tiny coupled fix to unblock [`ar-io-solana-escrow-app` #2](https://github.com/ar-io/ar-io-solana-escrow-app/pull/2) (frontend escrow-disable PR).

## The bug

`EscrowAntState.version` and `EscrowTokenState.version` are hand-annotated as `{ major: number; minor: number; patch: number }` — a stale semver shape that has **never matched the on-chain layout**. On-chain the field is a u8 schema version, exposed by the generated client as `ArioAntEscrowStateSchemaVersion`. The `toEscrow*State` mappers already assign `version: raw.version`, so the SDK's published types only matched reality when the build happened to widen them.

That widening apparently happened in `4.0.0-solana.14` (its published `.d.ts` declared `version: number`), but `4.0.0-solana.17` emitted the literal source shape — exposing the mismatch and breaking every consumer that constructs a `number`-shaped version against the SDK's interface. `ar-io-solana-escrow-app`'s `escrow-client.ts` deserializers (which read the u8 directly off the raw bytes) hit this immediately on the dep bump.

## The fix

Type the field as `EscrowAnt['version']` / `EscrowToken['version']` so it tracks the generated client regardless of how that client declares it. Mirrors the same fix style as [#639](https://github.com/ar-io/ar-io-sdk/pull/639) (still open, broader scope).

## Validation

`tsc`, `lint:check`, `format:check`, `build` all clean. **232/232 unit tests pass.**

Once merged + auto-published, I bump frontend #2's `@ar.io/sdk` dep + un-draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)