### PR TITLE
feat(solana/escrow): expose claimVaultArweaveIx for attested-claim composition

### DIFF
--- a/src/solana/escrow-token.test.ts
+++ b/src/solana/escrow-token.test.ts
@@ -383,3 +383,109 @@ describe('isVaultClaimable (non-throwing UI predicate)', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// claimVaultArweaveIx — low-level builder for the Arweave attested
+// vault-claim path. Integrators (e.g. the escrow-app frontend) compose:
+//   [createClaimantAtaIx?, ed25519SigverifyIx, claimVaultArweaveIx]
+// and submit. The high-level `claimVaultArweave` cannot work alone because
+// the SDK has no attestor URL; calling it must throw a clear migration error.
+// ---------------------------------------------------------------------------
+
+import { TokenEscrow } from './escrow.js';
+
+const FAKE_ADDR = '11111111111111111111111111111112' as unknown as Address;
+
+function makeTokenEscrow(): TokenEscrow {
+  return new TokenEscrow({
+    rpc: {} as never,
+    signer: createNoopSigner(address(FAKE_ADDR)),
+    programId: address(FAKE_ADDR),
+  });
+}
+
+describe('claimVaultArweaveIx', () => {
+  it('returns an Instruction whose accounts list matches the ADR-022 ABI', async () => {
+    const te = makeTokenEscrow();
+    const ix = await te.claimVaultArweaveIx({
+      depositor: address(FAKE_ADDR),
+      assetId: new Uint8Array(32),
+      claimant: address(FAKE_ADDR),
+      claimantTokenAccount: address(FAKE_ADDR),
+      escrowTokenAccount: address(FAKE_ADDR),
+      messageNonce: new Uint8Array(32),
+    });
+    // Post-ADR-022: payer_token_account dropped; ix has 9 accounts
+    // (escrow, escrow_token_account, claimant_token_account, claimant,
+    // depositor, payer, instructions_sysvar, token_program, system_program).
+    assert.equal(ix.accounts?.length, 9, 'expected 9 accounts post-ADR-022');
+    assert.equal(ix.programAddress, address(FAKE_ADDR));
+    // data = 8-byte disc + 32-byte messageNonce.
+    assert.equal(
+      ix.data?.length,
+      40,
+      'expected disc(8) + nonce(32) = 40 bytes',
+    );
+  });
+
+  it('rejects a non-32-byte messageNonce', async () => {
+    const te = makeTokenEscrow();
+    await assert.rejects(
+      () =>
+        te.claimVaultArweaveIx({
+          depositor: address(FAKE_ADDR),
+          assetId: new Uint8Array(32),
+          claimant: address(FAKE_ADDR),
+          claimantTokenAccount: address(FAKE_ADDR),
+          escrowTokenAccount: address(FAKE_ADDR),
+          messageNonce: new Uint8Array(31),
+        }),
+      /messageNonce must be 32 bytes/,
+    );
+  });
+
+  it('rejects when no signer is configured', async () => {
+    const te = new TokenEscrow({
+      rpc: {} as never,
+      programId: address(FAKE_ADDR),
+      // no signer
+    });
+    await assert.rejects(
+      () =>
+        te.claimVaultArweaveIx({
+          depositor: address(FAKE_ADDR),
+          assetId: new Uint8Array(32),
+          claimant: address(FAKE_ADDR),
+          claimantTokenAccount: address(FAKE_ADDR),
+          escrowTokenAccount: address(FAKE_ADDR),
+          messageNonce: new Uint8Array(32),
+        }),
+      /signer/i,
+    );
+  });
+});
+
+describe('claimVaultArweave (deprecated single-call wrapper)', () => {
+  it('throws with a clear migration message pointing at claimVaultArweaveIx', async () => {
+    const te = makeTokenEscrow();
+    await assert.rejects(
+      () =>
+        te.claimVaultArweave({
+          depositor: address(FAKE_ADDR),
+          assetId: new Uint8Array(32),
+          claimant: address(FAKE_ADDR),
+          claimantTokenAccount: address(FAKE_ADDR),
+          escrowTokenAccount: address(FAKE_ADDR),
+          signature: new Uint8Array(512),
+        }),
+      (err: unknown) => {
+        const msg = (err as Error).message;
+        return (
+          /claimVaultArweaveIx/.test(msg) &&
+          /Ed25519Program/.test(msg) &&
+          /ADR-017/.test(msg)
+        );
+      },
+    );
+  });
+});

--- a/src/solana/escrow.ts
+++ b/src/solana/escrow.ts
@@ -958,48 +958,100 @@ export class TokenEscrow {
   }
 
   /**
-   * Submit an Arweave attestor's Ed25519 signature to release escrowed vault
-   * tokens. The on-chain handler delivers liquid tokens directly to
-   * `claimantTokenAccount`.
+   * **Use {@link claimVaultArweaveIx} instead** — this single-send wrapper
+   * cannot work end-to-end for the Arweave attested vault-claim path,
+   * because the on-chain `claim_vault_arweave_attested` handler requires
+   * an Ed25519Program native sigverify ix at idx-1 of the claim ix
+   * (introspected via `instructions_sysvar`). That sigverify ix carries
+   * the attestor's Ed25519 signature over the canonical claim message
+   * and is built by the *integrator* (who calls the off-chain attestor
+   * service for the signature, per ADR-017) — the SDK has no attestor
+   * URL or client to do this for the caller.
    *
-   * **Vaults are only claimable after `vault_end_timestamp`.** Active
-   * (still-locked) vault claims are rejected on-chain with `VaultStillLocked`
-   * (ADR-022 / BD-107: the former active re-lock path was removed because its
-   * sibling-`vaulted_transfer` introspection had no 1:1 claim↔re-lock binding
-   * → reuse / relayer skim). This method pre-flights the same gate and throws
-   * a clear `vault still locked until <ISO>` error rather than building a tx
-   * that will fail on-chain. To revive "claim early, stay locked" see the
-   * restoration playbook in the contracts repo
-   * (`docs/RESTORE_ACTIVE_VAULT_RELOCK.md`).
+   * Calling this method instead of composing via
+   * {@link claimVaultArweaveIx} will hit `MissingAttestation` on-chain.
+   * It is kept only for ABI continuity; new code must use
+   * {@link claimVaultArweaveIx} and prepend the attestor sigverify ix.
+   *
+   * @deprecated cannot succeed alone — see {@link claimVaultArweaveIx}.
    */
-  async claimVaultArweave(args: {
+  async claimVaultArweave(_args: {
     depositor: Address;
     assetId: Uint8Array;
     claimant: Address;
     claimantTokenAccount: Address;
     escrowTokenAccount: Address;
-    signature: Uint8Array; // 512 bytes
+    signature: Uint8Array;
     saltLen?: number;
   }): Promise<string> {
-    const escrow = await this.requireVaultEscrow(args.depositor, args.assetId);
-    if (escrow.recipientProtocol !== 'arweave') {
-      throw new Error(
-        `escrow recipient is ${escrow.recipientProtocol}, not arweave`,
-      );
+    throw new Error(
+      'claimVaultArweave cannot complete the Arweave attested vault-claim ' +
+        'in a single SDK call: the on-chain handler requires an ' +
+        'Ed25519Program sigverify ix at idx-1 of the claim ix, which ' +
+        'must carry the attestor service’s signature over the canonical ' +
+        'claim message (ADR-017). The SDK does not know your attestor URL. ' +
+        'Use claimVaultArweaveIx() instead and bundle the sigverify ix ' +
+        'yourself: ' +
+        '[createAtaIx?, ed25519SigverifyIx, claimVaultArweaveIx, ...]. ' +
+        'See ar-io-solana-escrow-app/src/pages/ClaimPage.tsx for the ' +
+        'reference composition, and ADR-022 / VaultStillLocked for the ' +
+        'still-locked rejection (use isVaultClaimable() to pre-flight).',
+    );
+  }
+
+  /**
+   * Build a `claim_vault_arweave_attested` instruction (without sending).
+   * Mirror of {@link claimTokensArweaveIx} for the vault-claim path:
+   * returns the bare claim ix so the caller can prepend the attestor's
+   * Ed25519Program sigverify ix and submit the bundle in one tx.
+   *
+   * The on-chain handler:
+   * - Reads the preceding Ed25519Program native sigverify ix from
+   *   `instructions_sysvar` to confirm the attestor signed the canonical
+   *   claim message.
+   * - Rejects with `VaultStillLocked` if `clock < vault_end_timestamp`
+   *   (ADR-022). Callers should pre-flight with {@link isVaultClaimable}
+   *   (non-throwing) or {@link assertVaultClaimable} (throws with the
+   *   unlock timestamp) before composing the tx.
+   * - On the expired path, transfers the escrowed amount liquid to
+   *   `claimantTokenAccount` and closes the escrow PDA.
+   *
+   * Composition (frontend pattern):
+   *   ```ts
+   *   const escrow = await tokenEscrow.requireVaultEscrow(depositor, assetId);
+   *   assertVaultClaimable(escrow);                       // pre-flight
+   *   const canonical = canonicalMessage({ ... });        // build message
+   *   const attestation = await attestor.attest({ ... }); // attestor service
+   *   const ed25519Ix = buildEd25519SigverifyIx(
+   *     attestation.attestorPubkey, attestation.signature, canonical,
+   *   );
+   *   const claimIx = await tokenEscrow.claimVaultArweaveIx({
+   *     depositor, assetId, claimant, claimantTokenAccount,
+   *     escrowTokenAccount, messageNonce: escrow.nonce,
+   *   });
+   *   // Idempotent-create the claimant ATA if it's the canonical derivation.
+   *   await sendTx([createAtaIx?, ed25519Ix, claimIx]);
+   *   ```
+   */
+  async claimVaultArweaveIx(args: {
+    depositor: Address;
+    assetId: Uint8Array;
+    claimant: Address;
+    claimantTokenAccount: Address;
+    escrowTokenAccount: Address;
+    /** 32-byte nonce from the on-chain EscrowToken PDA (`escrow.nonce`). */
+    messageNonce: Uint8Array;
+  }): Promise<Instruction> {
+    if (args.messageNonce.length !== 32) {
+      throw new Error('messageNonce must be 32 bytes');
     }
-    // ADR-022 / VaultStillLocked: pre-flight the on-chain lock gate.
-    assertVaultClaimable(escrow);
-    const signer = this.requireSigner('claimVaultArweave');
+    const signer = this.requireSigner('claimVaultArweaveIx');
     const [escrowPda] = await getEscrowVaultPDA(
       args.depositor,
       args.assetId,
       this.programId,
     );
-    // `args.signature` and `args.saltLen` are no longer fed to the
-    // builder — the on-chain `claim_vault_arweave_attested` ix verifies
-    // the attestor's Ed25519 signature via instruction-introspection
-    // of a preceding sigverify ix. See doc on `claimArweaveIx`.
-    const claimIx = getClaimVaultArweaveAttestedInstruction(
+    return getClaimVaultArweaveAttestedInstruction(
       {
         escrow: escrowPda,
         escrowTokenAccount: args.escrowTokenAccount,
@@ -1007,19 +1059,10 @@ export class TokenEscrow {
         claimant: args.claimant,
         depositor: args.depositor,
         payer: signer,
-        messageNonce: escrow.nonce,
+        messageNonce: args.messageNonce,
       },
       { programAddress: this.programId },
     );
-    const createClaimantAtaIx = await this._createClaimantAtaIfCanonical(
-      args.claimant,
-      args.claimantTokenAccount,
-      escrow.arioMint,
-    );
-    const ixs = createClaimantAtaIx
-      ? [createClaimantAtaIx, claimIx]
-      : [claimIx];
-    return this.send(ixs, 400_000);
   }
 
   /**

--- a/src/solana/index.ts
+++ b/src/solana/index.ts
@@ -88,7 +88,18 @@ export type {
 } from '../types/ant-registry.js';
 
 // ANT-escrow client (trustless multi-protocol custody — Arweave RSA-PSS / Ethereum ECDSA)
-export { ANTEscrow, TokenEscrow } from './escrow.js';
+export {
+  ANTEscrow,
+  TokenEscrow,
+  // Vault-claim pre-flight helpers (ADR-022 / VaultStillLocked).
+  // Exported so downstream UIs can gate their Submit buttons using the
+  // SAME forward CLOCK_SKEW_TOLERANCE_SECONDS buffer the SDK's
+  // assertVaultClaimable throws use — keeping pre-flight and UI gates
+  // in lock-step so users never see a raw on-chain error.
+  assertVaultClaimable,
+  isVaultClaimable,
+  CLOCK_SKEW_TOLERANCE_SECONDS,
+} from './escrow.js';
 export type {
   ANTEscrowConfig,
   EscrowAntState,


### PR DESCRIPTION
Closes the **Arweave-vault claim gap** flagged by the verifier sweep: until now there was no way for an integrator to claim an Arweave-recipient vault escrow through the SDK. The escrow-app frontend captured this with a hard `throw new Error('Arweave vault claims are not yet supported')` and forced users onto an Ethereum recipient.

## The gap

The on-chain `claim_vault_arweave_attested` handler requires an **Ed25519Program native sigverify ix** at idx-1 of the claim ix (introspected via `instructions_sysvar`) carrying the off-chain attestor service's signature over the canonical claim message (ADR-017). The SDK doesn't own the attestor URL/client — that's an integrator concern — so the single-send `claimVaultArweave` wrapper has never been able to complete the flow alone (it would hit `MissingAttestation` on-chain).

## The fix

Adds **`claimVaultArweaveIx`** — the bare claim-ix builder, mirror of the existing `claimTokensArweaveIx`. Integrators now compose:

```
[createClaimantAtaIx?, ed25519SigverifyIx, claimVaultArweaveIx]
```

and submit. This is the same pattern the escrow-app already uses for token-claim Arweave; the frontend follow-up enables it for vaults.

Also: **`claimVaultArweave` (the single-send wrapper) now throws a clear migration error** pointing at `claimVaultArweaveIx` + the bundling requirement + ADR-017. Kept for ABI continuity; never functioned for attested claims, so no one's code regresses.

## Tests (244 → 248)

- `claimVaultArweaveIx` returns the right `Instruction` shape — 9 accounts post-ADR-022 (no `payer_token_account`); 40-byte data (disc + nonce).
- Rejects non-32-byte `messageNonce`.
- Rejects when no signer is configured.
- The deprecated `claimVaultArweave` throws with the migration message (must mention `claimVaultArweaveIx`, `Ed25519Program`, `ADR-017`).
- `tsc`, `lint`, `format`, `build` clean.

## Downstream

Once this publishes, the frontend follow-up (combined with the `isVaultClaimable` migration from #644) drops the Arweave-vault block in `ClaimPage.tsx`, calls the attestor service, builds the sigverify ix, and bundles with `claimVaultArweaveIx` — restoring full feature parity with the Ethereum vault claim path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)