### PR TITLE
feat(solana): disabled-gateway delegate claim + deferred reward-share ratio (GAR 1.1.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@ar.io/solana-contracts": "0.4.0",
+    "@ar.io/solana-contracts": "0.5.0-staging.15",
     "@solana-program/address-lookup-table": "^0.11.0",
     "@solana-program/compute-budget": "^0.15.0",
     "@solana-program/token": "^0.13.0",

--- a/src/solana/deserialize.test.ts
+++ b/src/solana/deserialize.test.ts
@@ -98,7 +98,14 @@ describe('deserializeGateway (synthetic round-trip — cumulativeRewardPerToken)
     operatorStake: bigint;
     totalDelegatedStake: bigint;
     cumulativeRewardPerToken: bigint;
+    // GATEWAY_VERSION 1.1.0 GatewaySettings2 additions (Fix #6/#7). Omitted = None.
+    pendingDelegateRewardShareRatio?: number; // raw u16 (e.g. 5000 = 50%)
+    delegationDisabledAt?: bigint; // unix seconds
   }): Buffer {
+    // Option<u16> = 1 tag (+2 if Some); Option<i64> = 1 tag (+8 if Some)
+    const pendingBytes =
+      opts.pendingDelegateRewardShareRatio === undefined ? 1 : 3;
+    const disabledBytes = opts.delegationDisabledAt === undefined ? 1 : 9;
     // We use 1-char placeholders ("a") for label/fqdn/properties/note to keep
     // the math obvious. Each string contributes 4 (length prefix) + 1 (content).
     const STRING_BYTES = 4 + 1; // 4 length prefix + 1 char
@@ -125,6 +132,8 @@ describe('deserializeGateway (synthetic round-trip — cumulativeRewardPerToken)
       2 + // delegate_reward_share_ratio
       8 + // min_delegated_stake
       1 + // allowlist_enabled
+      pendingBytes + // pending_delegate_reward_share_ratio: Option<u16> (Fix #7)
+      disabledBytes + // delegation_disabled_at: Option<i64> (Fix #6)
       4 + // registry_index.index
       1 + // registry_index._reserved
       32 + // observer_address
@@ -193,6 +202,26 @@ describe('deserializeGateway (synthetic round-trip — cumulativeRewardPerToken)
     // allowlist_enabled (bool)
     buf.writeUInt8(0, off);
     off += 1;
+    // pending_delegate_reward_share_ratio: Option<u16> (Fix #7)
+    if (opts.pendingDelegateRewardShareRatio === undefined) {
+      buf.writeUInt8(0, off);
+      off += 1;
+    } else {
+      buf.writeUInt8(1, off);
+      off += 1;
+      buf.writeUInt16LE(opts.pendingDelegateRewardShareRatio, off);
+      off += 2;
+    }
+    // delegation_disabled_at: Option<i64> (Fix #6)
+    if (opts.delegationDisabledAt === undefined) {
+      buf.writeUInt8(0, off);
+      off += 1;
+    } else {
+      buf.writeUInt8(1, off);
+      off += 1;
+      buf.writeBigInt64LE(opts.delegationDisabledAt, off);
+      off += 8;
+    }
     // registry_index.index (u32) + _reserved (u8)
     buf.writeUInt32LE(0, off);
     off += 4;
@@ -246,6 +275,38 @@ describe('deserializeGateway (synthetic round-trip — cumulativeRewardPerToken)
     });
     const gw = deserializeGatewayWithAccumulator(buf);
     assert.equal(gw.cumulativeRewardPerToken, big);
+  });
+
+  it('reads GatewaySettings2 1.1.0 fields (None) and keeps later offsets aligned', () => {
+    // Both Option fields absent (the common case). The layout grew by 2 bytes
+    // (two None tags), so cumulativeRewardPerToken must still land correctly.
+    const buf = buildGatewayBuffer({
+      operatorStake: 20_000_000_000n,
+      totalDelegatedStake: 7_000_000_000n,
+      cumulativeRewardPerToken: 500_000_000_000_000_000n,
+    });
+    const gw = deserializeGatewayWithAccumulator(buf);
+    assert.equal(gw.cumulativeRewardPerToken, 500_000_000_000_000_000n);
+    assert.equal(gw.settings.pendingDelegateRewardShareRatio, undefined);
+    assert.equal(gw.settings.delegationDisabledAt, undefined);
+  });
+
+  it('surfaces pending ratio + disabled timestamp (Some) without shifting later fields', () => {
+    // Fix #6/#7: a staged reward-share change (5000 bp = 50%) and a disable
+    // timestamp. The Some payloads widen GatewaySettings2 by 10 bytes; the
+    // accumulator after `settings` must still decode correctly.
+    const buf = buildGatewayBuffer({
+      operatorStake: 20_000_000_000n,
+      totalDelegatedStake: 9_000_000_000n,
+      cumulativeRewardPerToken: 750_000_000_000_000_000n,
+      pendingDelegateRewardShareRatio: 5000, // 50% in basis points
+      delegationDisabledAt: 1_700_000_000n,
+    });
+    const gw = deserializeGatewayWithAccumulator(buf);
+    assert.equal(gw.settings.pendingDelegateRewardShareRatio, 50); // 5000 / 100
+    assert.equal(gw.settings.delegationDisabledAt, 1_700_000_000);
+    // Critical: the layout after `settings` stays aligned.
+    assert.equal(gw.cumulativeRewardPerToken, 750_000_000_000_000_000n);
   });
 
   it('public deserializeGateway does NOT expose cumulativeRewardPerToken', () => {

--- a/src/solana/deserialize.ts
+++ b/src/solana/deserialize.ts
@@ -140,6 +140,12 @@ class BorshReader {
     return this.readU32();
   }
 
+  readOptionU16(): number | undefined {
+    const tag = this.readU8();
+    if (tag === 0) return undefined;
+    return this.readU16();
+  }
+
   skip(bytes: number): void {
     this.offset += bytes;
   }
@@ -393,6 +399,16 @@ export function deserializeGatewayWithAccumulator(
   const delegateRewardShareRatio = r.readU16() / 100;
   const minDelegatedStake = r.readU64AsNumber();
   const allowlistEnabled = r.readBool();
+  // GATEWAY_VERSION 1.1.0 added two fields to GatewaySettings2 — MUST read them
+  // here to keep the byte stream aligned for every field after `settings`.
+  //   - pending_delegate_reward_share_ratio: Option<u16> (Fix #7) — basis points
+  //     of a deferred reward-share change applied at the next epoch's tally.
+  //   - delegation_disabled_at: Option<i64> (Fix #6) — unix seconds the operator
+  //     disabled delegation; starts the re-enable cooldown.
+  const pendingRatioRaw = r.readOptionU16();
+  const pendingDelegateRewardShareRatio =
+    pendingRatioRaw === undefined ? undefined : pendingRatioRaw / 100;
+  const delegationDisabledAt = r.readOptionI64();
 
   // RegistryIndex (index: u32, _reserved: u8 — was is_registered:bool)
   r.readU32(); // registryIndex
@@ -446,6 +462,8 @@ export function deserializeGatewayWithAccumulator(
     fqdn,
     port,
     protocol: 'https', // protocolIdx: 0=Http, 1=Https — only HTTPS in practice
+    pendingDelegateRewardShareRatio, // Fix #7: undefined when no change is queued
+    delegationDisabledAt, // Fix #6: undefined when delegation is enabled
   };
 
   return {

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -2305,6 +2305,47 @@ export class SolanaARIOReadable {
   }
 
   /**
+   * Enumerate Joined Gateway PDAs whose delegation has been DISABLED
+   * (`allow_delegated_staking == false`) yet still hold delegated stake
+   * (`total_delegated_stake > 0`) — i.e. delegates that an operator's disable
+   * left stranded (WP §6.3 / Fix #6). Each such gateway's delegates must be
+   * cranked out via
+   * {@link SolanaARIOWriteable.claimDelegateFromDisabledGateway} (enumerate
+   * them with {@link getGatewayDelegates}) before the operator can re-enable
+   * delegation. This is the discovery primitive a cranker uses to sweep them.
+   */
+  async getDisabledGatewaysWithDelegatedStake(): Promise<
+    Array<{ pubkey: Address; operator: Address; totalDelegatedStake: bigint }>
+  > {
+    const accounts = await this.getAccountsByDiscriminator(
+      this.garProgram,
+      GATEWAY_DISCRIMINATOR,
+    );
+    const decoder = getGatewayDecoder();
+    const out: Array<{
+      pubkey: Address;
+      operator: Address;
+      totalDelegatedStake: bigint;
+    }> = [];
+    for (const { pubkey, data } of accounts) {
+      try {
+        const g = decoder.decode(data);
+        if (g.status !== GatewayStatus.Joined) continue;
+        if (!g.settings.allowDelegatedStaking && g.totalDelegatedStake > 0n) {
+          out.push({
+            pubkey,
+            operator: g.operator,
+            totalDelegatedStake: g.totalDelegatedStake,
+          });
+        }
+      } catch {
+        // skip malformed
+      }
+    }
+    return out;
+  }
+
+  /**
    * Enumerate Delegation PDAs with `amount == 0`. Eligible for
    * `closeEmptyDelegation` (rent refund to the original delegator).
    */

--- a/src/solana/io-writeable.localnet.test.ts
+++ b/src/solana/io-writeable.localnet.test.ts
@@ -606,6 +606,137 @@ describe(
       );
     });
 
+    it('Fix #7: updateGatewaySettings defers delegate_reward_share_ratio to pending (active unchanged)', async () => {
+      // Fresh operator so we don't perturb shared `operator` state.
+      const op = await freshSigner(scratch, 'defer-ratio-operator');
+      await airdrop(op.keypairPath, 5);
+      mintArio(op.signer.address, OPERATOR_STAKE * 2n);
+      const opArio = buildArio(op.signer, RPC_URL!, WS_URL!);
+
+      await opArio.joinNetwork({
+        operatorStake: Number(OPERATOR_STAKE),
+        label: 'defer-ratio-gw',
+        fqdn: 'defer-ratio.example.com',
+        port: 443,
+        protocol: 'https',
+        autoStake: false,
+        allowDelegatedStaking: true,
+        delegateRewardShareRatio: 10, // active = 10%
+        observerAddress: op.signer.address as string,
+      });
+
+      // Request a change to 50%. Per WP §6.3 / Fix #7 this is DEFERRED: the
+      // active value stays 10% and the request is staged in `pending`.
+      await opArio.updateGatewaySettings({ delegateRewardShareRatio: 50 });
+
+      const gw = await opArio.getGateway({
+        address: op.signer.address as string,
+      });
+      assert.equal(
+        gw.settings.delegateRewardShareRatio,
+        10,
+        'active delegate_reward_share_ratio must be unchanged until next epoch tally',
+      );
+      assert.equal(
+        gw.settings.pendingDelegateRewardShareRatio,
+        50,
+        'the requested ratio must be staged in pendingDelegateRewardShareRatio',
+      );
+    });
+
+    it('Fix #6: disable delegation → cranker claims delegate → re-enable blocked by cooldown', async () => {
+      // Fresh operator with delegation enabled.
+      const op = await freshSigner(scratch, 'disable-deleg-operator');
+      await airdrop(op.keypairPath, 5);
+      mintArio(op.signer.address, OPERATOR_STAKE * 2n);
+      const opArio = buildArio(op.signer, RPC_URL!, WS_URL!);
+      await opArio.joinNetwork({
+        operatorStake: Number(OPERATOR_STAKE),
+        label: 'disable-deleg-gw',
+        fqdn: 'disable-deleg.example.com',
+        port: 443,
+        protocol: 'https',
+        autoStake: false,
+        allowDelegatedStaking: true,
+        delegateRewardShareRatio: 10,
+        observerAddress: op.signer.address as string,
+      });
+
+      // Fresh delegator delegates 50k ARIO.
+      const del = await freshSigner(scratch, 'disable-deleg-delegator');
+      await airdrop(del.keypairPath, 5);
+      mintArio(del.signer.address, 100_000_000_000n);
+      const delArio = buildArio(del.signer, RPC_URL!, WS_URL!);
+      const delegateAmount = 50_000_000_000n;
+      await delArio.delegateStake({
+        target: op.signer.address as string,
+        stakeQty: Number(delegateAmount),
+      });
+
+      // Operator DISABLES delegation. Records delegation_disabled_at; existing
+      // delegates are NOT auto-withdrawn (must be cranked out).
+      await opArio.updateGatewaySettings({ allowDelegatedStaking: false });
+      const gwDisabled = await opArio.getGateway({
+        address: op.signer.address as string,
+      });
+      assert.equal(
+        gwDisabled.settings.allowDelegatedStaking,
+        false,
+        'allowDelegatedStaking must be false after disable',
+      );
+      assert.ok(
+        typeof gwDisabled.settings.delegationDisabledAt === 'number' &&
+          gwDisabled.settings.delegationDisabledAt > 0,
+        'delegationDisabledAt must be recorded on disable',
+      );
+
+      // A THIRD-PARTY CRANKER (not the operator, not the delegate) cranks the
+      // delegate out — the permissionless Fix #6 sweep primitive. Stake routes
+      // to the delegate's own withdrawal vault regardless of who pays.
+      const cranker = await freshSigner(scratch, 'disable-deleg-cranker');
+      await airdrop(cranker.keypairPath, 5);
+      const crankerArio = buildArio(cranker.signer, RPC_URL!, WS_URL!);
+      const claim = await crankerArio.claimDelegateFromDisabledGateway({
+        gatewayAddress: op.signer.address as string,
+        delegatorAddress: del.signer.address as string,
+      });
+      assert.ok(
+        claim.id,
+        'claimDelegateFromDisabledGateway must return a tx id',
+      );
+
+      // The delegate now has a delegate-owned withdrawal vault (30-day lock),
+      // and the gateway's total delegated stake is zero.
+      const delWithdrawals = await delArio.getWithdrawals({
+        address: del.signer.address as string,
+      });
+      assert.equal(
+        delWithdrawals.items.length,
+        1,
+        'delegate must have exactly one withdrawal after the cranked claim',
+      );
+      assert.equal(delWithdrawals.items[0].isDelegate, true);
+      assert.equal(
+        delWithdrawals.items[0].gatewayAddress,
+        op.signer.address as string,
+      );
+      const gwAfterClaim = await opArio.getGateway({
+        address: op.signer.address as string,
+      });
+      assert.equal(
+        gwAfterClaim.totalDelegatedStake,
+        0,
+        'gateway total delegated stake must be 0 after the delegate is cranked out',
+      );
+
+      // Re-enabling is still blocked by the withdrawal-period cooldown even
+      // though stake is now zero (WP §6.3: no toggle-churn).
+      await assert.rejects(
+        opArio.updateGatewaySettings({ allowDelegatedStaking: true }),
+        're-enabling delegation before the cooldown elapses must be rejected',
+      );
+    });
+
     it('buyRecord({ fundFrom: "plan", sources: [...] }) draws from a caller-supplied balance + delegation plan', async () => {
       // Fresh delegator → mint balance → delegate so the plan has both a
       // wallet ATA source and a delegation source. Pre-compute cost via

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -145,6 +145,7 @@ import {
   Protocol,
   getAllowDelegateInstructionAsync,
   getCancelWithdrawalInstruction,
+  getClaimDelegateFromDisabledGatewayInstructionAsync,
   getClaimDelegateFromLeavingGatewayInstructionAsync,
   getClaimWithdrawalInstructionAsync,
   getCloseDrainedWithdrawalInstruction,
@@ -2777,6 +2778,65 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
         delegation: delegationPda,
         withdrawal: withdrawalPda,
         delegator: this.signer.address,
+        payer: this.signer,
+      },
+      { programAddress: this.garProgram },
+    );
+
+    const sig = await this.sendTransaction([ix], 1_000_000);
+    return { id: sig };
+  }
+
+  // =========================================
+  // Claim delegation from gateway with delegation DISABLED (ario-gar, Fix #6)
+  // =========================================
+
+  /**
+   * Claim a delegate's stake out of a gateway that has DISABLED delegation
+   * (`allow_delegated_staking == false`), moving it into the delegate's own
+   * withdrawal vault (WP §6.3 / Fix #6). This is the disabled-gateway analog of
+   * {@link claimDelegateFromLeavingGateway}: the on-chain instruction is
+   * permissionless, so a cranker can sweep delegates out (the operator cannot
+   * re-enable delegation until `total_delegated_stake == 0` and the cooldown
+   * elapses). The withdrawal-counter and withdrawal PDAs are seeded by the
+   * DELEGATOR, so a cranker must pass that delegate's `delegatorAddress`.
+   *
+   * @param params.gatewayAddress  The gateway whose delegation was disabled.
+   * @param params.delegatorAddress  The delegate to claim for. Defaults to the
+   *   signer (self-claim). Pass another address to crank on a delegate's behalf;
+   *   the signer covers rent (`payer`) but stake still routes to the delegate's
+   *   own vault (the delegator key is bound by the delegation PDA seeds).
+   */
+  async claimDelegateFromDisabledGateway(
+    params: { gatewayAddress: string; delegatorAddress?: string },
+    _options?: WriteOptions,
+  ): Promise<MessageResult> {
+    const gateway = address(params.gatewayAddress);
+    const delegator = params.delegatorAddress
+      ? address(params.delegatorAddress)
+      : this.signer.address;
+    const [gatewayPda] = await getGatewayPDA(gateway, this.garProgram);
+    const [delegationPda] = await getDelegationPDA(
+      gateway,
+      delegator,
+      this.garProgram,
+    );
+    // Withdrawal counter + vault are PDA-seeded by the delegator, not the payer.
+    const nextId = await this.getNextWithdrawalId(delegator);
+    const [withdrawalPda] = await getWithdrawalPDA(
+      delegator,
+      nextId,
+      this.garProgram,
+    );
+
+    const ix = await getClaimDelegateFromDisabledGatewayInstructionAsync(
+      {
+        gateway: gatewayPda,
+        delegation: delegationPda,
+        withdrawal: withdrawalPda,
+        // `delegator` is an unsigned seeds-derivation key; `payer` (the signer)
+        // covers rent on the init_if_needed counter + the new withdrawal.
+        delegator,
         payer: this.signer,
       },
       { programAddress: this.garProgram },

--- a/src/solana/prune-discovery.test.ts
+++ b/src/solana/prune-discovery.test.ts
@@ -295,6 +295,7 @@ function makeGatewayBytes(
   operator: Address,
   status: GatewayStatus,
   failedConsecutive: number,
+  opts: { allowDelegatedStaking?: boolean; totalDelegatedStake?: bigint } = {},
 ): Uint8Array {
   const enc = getGatewayEncoder();
   return enc.encode({
@@ -306,7 +307,7 @@ function makeGatewayBytes(
     properties: '',
     note: '',
     operatorStake: 1_000n,
-    totalDelegatedStake: 0n,
+    totalDelegatedStake: opts.totalDelegatedStake ?? 0n,
     status,
     startTimestamp: 0n,
     leaveTimestamp: null,
@@ -330,7 +331,7 @@ function makeGatewayBytes(
       weightsEpoch: 0n,
     },
     settings: {
-      allowDelegatedStaking: false,
+      allowDelegatedStaking: opts.allowDelegatedStaking ?? false,
       delegateRewardShareRatio: 0,
       minDelegationAmount: 0n,
       allowlistEnabled: false,
@@ -404,6 +405,68 @@ describe('SolanaARIOReadable.getGoneGateways', () => {
     );
     assert.equal(out[0].pubkey, ADDR_C);
     assert.equal(out[0].operator, PUBKEY_3);
+  });
+});
+
+describe('SolanaARIOReadable.getDisabledGatewaysWithDelegatedStake', () => {
+  it('returns only Joined gateways with delegation disabled AND stake > 0', async () => {
+    // Disabled + has stake → eligible for the cranker sweep.
+    const disabledWithStake = makeGatewayBytes(
+      PUBKEY_1,
+      GatewayStatus.Joined,
+      0,
+      {
+        allowDelegatedStaking: false,
+        totalDelegatedStake: 5_000_000_000n,
+      },
+    );
+    // Disabled but already drained → nothing to crank.
+    const disabledNoStake = makeGatewayBytes(
+      PUBKEY_2,
+      GatewayStatus.Joined,
+      0,
+      {
+        allowDelegatedStaking: false,
+        totalDelegatedStake: 0n,
+      },
+    );
+    // Enabled with stake → not a target (delegation still allowed).
+    const enabledWithStake = makeGatewayBytes(
+      PUBKEY_3,
+      GatewayStatus.Joined,
+      0,
+      {
+        allowDelegatedStaking: true,
+        totalDelegatedStake: 9_000_000_000n,
+      },
+    );
+    // Leaving with disabled+stake → handled by the leaving-gateway sweep, not here.
+    const leavingDisabled = makeGatewayBytes(
+      PUBKEY_1,
+      GatewayStatus.Leaving,
+      0,
+      {
+        allowDelegatedStaking: false,
+        totalDelegatedStake: 1_000_000_000n,
+      },
+    );
+    const rpc = stubRpcReturning([
+      { pubkey: ADDR_A, bytes: disabledWithStake },
+      { pubkey: ADDR_B, bytes: disabledNoStake },
+      { pubkey: ADDR_C, bytes: enabledWithStake },
+      { pubkey: ADDR_A, bytes: leavingDisabled },
+    ]);
+    const r = buildReadable(rpc);
+
+    const out = await r.getDisabledGatewaysWithDelegatedStake();
+    assert.equal(
+      out.length,
+      1,
+      'only Joined + delegation-disabled + stake>0 gateways need the disabled sweep',
+    );
+    assert.equal(out[0].pubkey, ADDR_A);
+    assert.equal(out[0].operator, PUBKEY_1);
+    assert.equal(out[0].totalDelegatedStake, 5_000_000_000n);
   });
 });
 

--- a/src/solana/prune-discovery.test.ts
+++ b/src/solana/prune-discovery.test.ts
@@ -334,6 +334,9 @@ function makeGatewayBytes(
       delegateRewardShareRatio: 0,
       minDelegationAmount: 0n,
       allowlistEnabled: false,
+      // GATEWAY_VERSION 1.1.0 GatewaySettings2 additions (Fix #6/#7); None.
+      pendingDelegateRewardShareRatio: null,
+      delegationDisabledAt: null,
     },
     registryIndex: { index: 0, _reserved: 0 },
     observerAddress: operator,

--- a/src/solana/save-observations.test.ts
+++ b/src/solana/save-observations.test.ts
@@ -23,6 +23,7 @@ import {
 import bs58 from 'bs58';
 
 import { getEpochEncoder } from '@ar.io/solana-contracts/gar';
+import { MAX_GATEWAYS } from './constants.js';
 import { SolanaARIOReadable } from './io-readable.js';
 import { buildObservationBitmap, encodeReportTxId } from './io-writeable.js';
 
@@ -283,7 +284,10 @@ function buildEpochBuffer(opts: {
     prescriptionsDone: 0,
     bump: 0,
     observationsClosed: 0,
-    failureCounts: new Array(30).fill(0),
+    // Epoch.failure_counts is a fixed [u16; MAX_GATEWAYS] array — the
+    // encoder rejects any other length. Full-size on every cluster since
+    // devnet-shrunk was retired (contracts ADR-024).
+    failureCounts: new Array(MAX_GATEWAYS).fill(0),
     prescribedObservers: observers,
     prescribedObserverGateways: observerGateways,
     prescribedNames: [new Uint8Array(32), new Uint8Array(32)],

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -316,6 +316,22 @@ export type GatewaySettings = {
   fqdn: string;
   port: number;
   protocol: 'https';
+  /**
+   * Solana only (GATEWAY_VERSION 1.1.0+). A `delegateRewardShareRatio` change
+   * requested mid-epoch is staged here and applied at the next epoch's
+   * `tally_weights` (WP §6.3 / Fix #7), so the active value stays epoch-stable.
+   * When set, render the active `delegateRewardShareRatio` as the current rate
+   * and this as "pending until next epoch". Percent (0-95), same scale as
+   * `delegateRewardShareRatio`. Undefined when no change is queued.
+   */
+  pendingDelegateRewardShareRatio?: number;
+  /**
+   * Solana only (GATEWAY_VERSION 1.1.0+). Unix seconds when the operator
+   * disabled delegation (WP §6.3 / Fix #6). Re-enabling is blocked until every
+   * delegate has been withdrawn AND the withdrawal-period cooldown has elapsed
+   * since this time. Undefined when delegation is enabled.
+   */
+  delegationDisabledAt?: number;
 };
 
 export type BalanceWithAddress = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,10 @@
   resolved "https://registry.yarnpkg.com/@actions/io/-/io-3.0.2.tgz#6f89b27a159d109836d983efa283997c23b92284"
   integrity sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==
 
-"@ar.io/solana-contracts@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.npmjs.org/@ar.io/solana-contracts/-/solana-contracts-0.4.0.tgz#f658a2bcb926451188302cbbcc4a1d1f49f875ee"
-  integrity sha512-rLQVlNS1YBJq2cG5xu9qOmWF0qOPiLXD0AGVlW2WFeNxIXLvDYiARXLJXQ26kvnfIED/Fx3X5cg7Y4m4L1ZF4A==
+"@ar.io/solana-contracts@0.5.0-staging.15":
+  version "0.5.0-staging.15"
+  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-0.5.0-staging.15.tgz#42dbf0e5703598eb8b8c02affdc5731e914fdd0c"
+  integrity sha512-8sgIr+9e+L08PXTOoNXMzRJLfiERP/fycEP3tVmZYESbGdA85VUHpmiCuUr86m3ZEhwNM035/9g4bkcg6pCKlw==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
Adds SDK support for the ario-gar **GATEWAY_VERSION 1.1.0** changes (whitepaper §6.3 — Fix #6/#7), part of the cross-repo rollout alongside `ar-io-solana-contracts` PR #88 and `ar-io-cranker`.

## Changes
- **`deserialize.ts` (correctness fix):** `GatewaySettings2` gained two fields — `pending_delegate_reward_share_ratio: Option<u16>` (Fix #7) and `delegation_disabled_at: Option<i64>` (Fix #6). The hand-written `Gateway` reader now consumes **both**; without this, every field after `settings` (including `cumulative_reward_per_token`, which drives live delegation balances) was misread. Adds `readOptionU16()`.
- **`types/io.ts`:** surfaces `pendingDelegateRewardShareRatio` + `delegationDisabledAt` as optional (Solana-only) fields on `GatewaySettings`. Consumers should render the active `delegateRewardShareRatio` as current and the pending value as "effective next epoch".
- **`io-writeable.ts`:** `claimDelegateFromDisabledGateway({ gatewayAddress, delegatorAddress? })` — mirrors the leaving-gateway claim but supports the **permissionless cranker path** (a third party can claim on behalf of any delegator; signer pays rent, stake routes to the delegate).
- **`io-readable.ts`:** `getDisabledGatewaysWithDelegatedStake()` — discovery helper for the cranker sweep (Joined gateways with delegation disabled that still hold stake).

## Tests
- `deserialize.test.ts`: `buildGatewayBuffer` writes the new Option fields; +2 cases (None keeps later offsets aligned; Some surfaces values AND keeps `cumulativeRewardPerToken` aligned).
- `prune-discovery.test.ts`: fixture supplies the new fields; +1 test for `getDisabledGatewaysWithDelegatedStake` (disabled+stake matches; disabled-no-stake / enabled / leaving excluded).
- `io-writeable.localnet.test.ts`: +2 e2e — Fix #7 (ratio staged in pending, active unchanged) and Fix #6 (disable → third-party cranker claim → withdrawal vault, total stake 0 → re-enable blocked by cooldown).

Full unit suite green (293), `tsc` + biome clean.

> Depends on a republished `@ar.io/solana-contracts` carrying the new instruction + `GatewaySettings2` fields (bump the dep when it publishes). Validated locally against a synced build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)