### PR TITLE
fix(solana): finalize_gone discovers Leaving gateways + supplies swapped-slot PDA

### DIFF
--- a/src/solana/finalize-gone-swap.test.ts
+++ b/src/solana/finalize-gone-swap.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for `selectFinalizeGoneSwapOperator` — the index math that
+ * decides which swapped Gateway PDA `finalizeGone` must pass as writable
+ * `remaining_accounts[0]`.
+ *
+ * Mirrors `programs/ario-gar/src/instructions/gateway.rs::finalize_gone`:
+ *   - `index = gateway.registry_index.index`
+ *   - `last_index = registry.count - 1`
+ *   - swap only when `index != last_index`; the swapped gateway is the one at
+ *     the last active slot (`registry.gateways[last_index].address`).
+ * `registryAddresses` is slot-ordered with length === `registry.count`, so the
+ * last element is exactly that swap source.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { selectFinalizeGoneSwapOperator } from './io-writeable.js';
+
+const REG = ['op0', 'op1', 'op2', 'op3']; // count = 4, last slot index = 3
+
+describe('selectFinalizeGoneSwapOperator', () => {
+  it('returns null when the gateway is already the last active slot', () => {
+    assert.equal(selectFinalizeGoneSwapOperator(3, REG), null);
+  });
+
+  it('returns null for a single-gateway registry (index 0, count 1)', () => {
+    assert.equal(selectFinalizeGoneSwapOperator(0, ['only']), null);
+  });
+
+  it('returns the last-slot operator when finalizing the first slot', () => {
+    assert.equal(selectFinalizeGoneSwapOperator(0, REG), 'op3');
+  });
+
+  it('returns the last-slot operator when finalizing a middle slot', () => {
+    assert.equal(selectFinalizeGoneSwapOperator(2, REG), 'op3');
+  });
+
+  it('throws when the index equals the active count (off-by-one / stale index)', () => {
+    assert.throws(
+      () => selectFinalizeGoneSwapOperator(4, REG),
+      /outside the active registry count/i,
+    );
+  });
+
+  it('throws when the index exceeds the active count', () => {
+    assert.throws(
+      () => selectFinalizeGoneSwapOperator(99, REG),
+      /outside the active registry count/i,
+    );
+  });
+
+  it('throws on a negative index', () => {
+    assert.throws(
+      () => selectFinalizeGoneSwapOperator(-1, REG),
+      /outside the active registry count/i,
+    );
+  });
+
+  it('throws on an empty registry', () => {
+    assert.throws(
+      () => selectFinalizeGoneSwapOperator(0, []),
+      /outside the active registry count/i,
+    );
+  });
+});

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -2294,8 +2294,21 @@ export class SolanaARIOReadable {
   }
 
   /**
-   * Enumerate Gateway PDAs whose `status == Gone` (already left the
-   * network but PDA not yet GC'd). Eligible for `finalizeGone`.
+   * Enumerate Gateway PDAs that are candidates for `finalizeGone` GC — i.e.
+   * those whose `status == Leaving`.
+   *
+   * NOTE: despite the historical name, this returns `Leaving` (not `Gone`)
+   * gateways. `Gone` is NOT a persistent discovery state: the on-chain
+   * `finalize_gone` instruction accepts a `Leaving` gateway, flips it to
+   * `Gone`, and closes the Gateway PDA in the *same* instruction
+   * (programs/ario-gar/src/instructions/gateway.rs::finalize_gone), so a
+   * gateway is never observably parked at `Gone`. Filtering on `Gone` matched
+   * nothing and left Leaving gateways un-GC'd. Time/delegation eligibility is
+   * still enforced on-chain (`finalize_gone` reverts early if the leave window
+   * hasn't elapsed or delegations remain), so over-returning not-yet-eligible
+   * Leaving gateways is safe — the tx just no-ops/reverts.
+   *
+   * @deprecated Prefer {@link getLeavingGateways} — same result, accurate name.
    */
   async getGoneGateways(): Promise<
     Array<{ pubkey: Address; operator: Address }>
@@ -2309,7 +2322,7 @@ export class SolanaARIOReadable {
     for (const { pubkey, data } of accounts) {
       try {
         const g = decoder.decode(data);
-        if (g.status === GatewayStatus.Gone) {
+        if (g.status === GatewayStatus.Leaving) {
           out.push({ pubkey, operator: g.operator });
         }
       } catch {
@@ -2317,6 +2330,17 @@ export class SolanaARIOReadable {
       }
     }
     return out;
+  }
+
+  /**
+   * Enumerate Gateway PDAs whose `status == Leaving` — the persistent
+   * pre-finalization state that `finalizeGone` GC's. Alias for
+   * {@link getGoneGateways} with a name that matches the on-chain state.
+   */
+  async getLeavingGateways(): Promise<
+    Array<{ pubkey: Address; operator: Address }>
+  > {
+    return this.getGoneGateways();
   }
 
   /**

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -245,6 +245,42 @@ function withRemainingAccounts<I extends Instruction>(
 }
 
 /**
+ * Pick the swapped-gateway operator that `finalize_gone` needs as a writable
+ * `remaining_accounts[0]`.
+ *
+ * `finalize_gone` reclaims a gateway's slot from the compact GatewayRegistry by
+ * moving the LAST active slot into it and rewriting that swapped gateway's
+ * stored `registry_index`. When the finalized gateway is NOT already the last
+ * slot, the on-chain handler requires the swapped Gateway PDA (writable) at
+ * `remaining_accounts[0]`; when it IS the last slot, no swap occurs and no
+ * extra account is needed. See
+ * `programs/ario-gar/src/instructions/gateway.rs::finalize_gone`.
+ *
+ * `registryAddresses` MUST be the active registry operator addresses in slot
+ * order (`getRegistryGatewayAddresses()` — length === on-chain
+ * `registry.count`), so `registryAddresses[length - 1]` is exactly the
+ * `registry.gateways[count - 1].address` the on-chain swap reads.
+ *
+ * @returns the swapped gateway's operator address, or `null` when the finalized
+ *   gateway already occupies the last slot.
+ * @throws if `registryIndex` is outside the active registry count (mirrors the
+ *   on-chain `index < registry.count` guard, surfacing a stale index early).
+ */
+export function selectFinalizeGoneSwapOperator(
+  registryIndex: number,
+  registryAddresses: string[],
+): string | null {
+  if (registryIndex < 0 || registryIndex >= registryAddresses.length) {
+    throw new Error(
+      `finalizeGone: registry index ${registryIndex} is outside the active ` +
+        `registry count ${registryAddresses.length}`,
+    );
+  }
+  const lastIndex = registryAddresses.length - 1;
+  return registryIndex === lastIndex ? null : registryAddresses[lastIndex];
+}
+
+/**
  * Split a primary name into its undername + base parts using the same rule
  * as the on-chain `splitn(2, '_')` in `programs/ario-core/src/instructions/primary_name.rs`:
  * everything before the first '_' is the undername, the rest is the base.
@@ -4010,6 +4046,26 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     const gatewayAddr = address(params.gateway);
     const [gatewayPda] = await getGatewayPDA(gatewayAddr, this.garProgram);
 
+    // `finalize_gone` reclaims this gateway's compact-registry slot by
+    // swap-removing the LAST active slot into it. When this gateway is not the
+    // last slot, the on-chain handler rewrites the swapped gateway's stored
+    // registry_index and therefore requires that swapped Gateway PDA as
+    // writable remaining_accounts[0]
+    // (programs/ario-gar/src/instructions/gateway.rs::finalize_gone). Read the
+    // gateway's slot index + the active registry to decide.
+    const gatewayAccount = await fetchEncodedAccount(this.rpc, gatewayPda, {
+      commitment: this.commitment,
+    });
+    if (!gatewayAccount.exists) {
+      throw new Error(`Gateway not found for operator ${params.gateway}`);
+    }
+    const gateway = getGatewayDecoder().decode(gatewayAccount.data);
+    const registryAddresses = await this.getRegistryGatewayAddresses();
+    const swappedOperator = selectFinalizeGoneSwapOperator(
+      gateway.registryIndex.index,
+      registryAddresses,
+    );
+
     const ix = await getFinalizeGoneInstructionAsync(
       await this.withGarDefaults({
         gateway: gatewayPda,
@@ -4018,7 +4074,18 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       { programAddress: this.garProgram },
     );
 
-    const sig = await this.sendTransaction([ix]);
+    let finalIx = ix;
+    if (swappedOperator !== null) {
+      const [swappedGatewayPda] = await getGatewayPDA(
+        address(swappedOperator),
+        this.garProgram,
+      );
+      finalIx = withRemainingAccounts(ix, [
+        { address: swappedGatewayPda, role: AccountRole.WRITABLE },
+      ]);
+    }
+
+    const sig = await this.sendTransaction([finalIx]);
     return { id: sig };
   }
 

--- a/src/solana/prune-discovery.test.ts
+++ b/src/solana/prune-discovery.test.ts
@@ -386,7 +386,7 @@ describe('SolanaARIOReadable.getDeficientGateways', () => {
 });
 
 describe('SolanaARIOReadable.getGoneGateways', () => {
-  it('returns only gateways with status === Gone', async () => {
+  it('returns only gateways with status === Leaving (Gone never persists)', async () => {
     const joined = makeGatewayBytes(PUBKEY_1, GatewayStatus.Joined, 0);
     const leaving = makeGatewayBytes(PUBKEY_2, GatewayStatus.Leaving, 0);
     const gone = makeGatewayBytes(PUBKEY_3, GatewayStatus.Gone, 0);
@@ -401,10 +401,29 @@ describe('SolanaARIOReadable.getGoneGateways', () => {
     assert.equal(
       out.length,
       1,
-      'only Gone gateways are eligible for finalize_gone GC',
+      'Leaving is the finalize_gone-eligible state; Gone is set+closed in one ix and never observed',
     );
-    assert.equal(out[0].pubkey, ADDR_C);
-    assert.equal(out[0].operator, PUBKEY_3);
+    assert.equal(out[0].pubkey, ADDR_B);
+    assert.equal(out[0].operator, PUBKEY_2);
+  });
+});
+
+describe('SolanaARIOReadable.getLeavingGateways', () => {
+  it('is an alias for getGoneGateways — returns only Leaving gateways', async () => {
+    const joined = makeGatewayBytes(PUBKEY_1, GatewayStatus.Joined, 0);
+    const leaving = makeGatewayBytes(PUBKEY_2, GatewayStatus.Leaving, 0);
+    const gone = makeGatewayBytes(PUBKEY_3, GatewayStatus.Gone, 0);
+    const rpc = stubRpcReturning([
+      { pubkey: ADDR_A, bytes: joined },
+      { pubkey: ADDR_B, bytes: leaving },
+      { pubkey: ADDR_C, bytes: gone },
+    ]);
+    const r = buildReadable(rpc);
+
+    const out = await r.getLeavingGateways();
+    assert.equal(out.length, 1);
+    assert.equal(out[0].pubkey, ADDR_B);
+    assert.equal(out[0].operator, PUBKEY_2);
   });
 });
 


### PR DESCRIPTION
## Problem

Gateway garbage collection via `finalizeGone` was broken on two fronts, so `Leaving` gateways were **never finalized** — the GatewayRegistry never shrinks and their rent is never reclaimed.

**1. Discovery scanned for the wrong status.** `getGoneGateways()` filtered `status == Gone`, but **`Gone` never persists**: the on-chain `finalize_gone` instruction accepts a `Leaving` gateway, flips it to `Gone`, and closes the Gateway PDA in the *same* instruction (`programs/ario-gar/src/instructions/gateway.rs::finalize_gone`). The scan therefore always returned empty.

**2. `finalizeGone()` omitted the swap-remove account.** The registry is a compact array; `finalize_gone` reclaims a slot by **swap-removing the last active slot** into it and rewriting that swapped gateway's stored `registry_index`. For any gateway that isn't already the last slot, the handler **requires the swapped Gateway PDA as writable `remaining_accounts[0]`** — without it the instruction reverts.

## Fix

- `getGoneGateways()` now filters `status == Leaving` (the real pre-finalize state); added **`getLeavingGateways()`** as the accurately-named alias. Eligibility (leave-window elapsed, zero outstanding delegations) is still enforced on-chain, so over-returning not-yet-eligible `Leaving` gateways is safe — the tx just no-ops/reverts.
- `finalizeGone()` reads the gateway's slot index + the active registry and appends the last-slot gateway PDA as writable `remaining_accounts[0]` when (and only when) the finalized gateway isn't already last. The index math is extracted into the pure, unit-tested `selectFinalizeGoneSwapOperator`.

## Verification

Logic checked line-by-line against `programs/ario-gar/src/instructions/gateway.rs::finalize_gone`: the swap source is `registry.gateways[registry.count - 1].address`, and `getRegistryGatewayAddresses()` returns slot-ordered active operators with `length === registry.count`, so `addresses[length - 1]` is exactly that source.

## Tests

- `prune-discovery.test.ts`: updated `getGoneGateways` (now asserts `Leaving`) + new `getLeavingGateways` alias test.
- `finalize-gone-swap.test.ts` (new): `selectFinalizeGoneSwapOperator` boundaries — last slot → none, single-gateway, first/middle slot → last operator, out-of-range/negative/empty → throws.
- Full Solana unit suite green: **331/331**.

## Downstream follow-up

This ships in `@ar.io/sdk@solana`. The standalone cranker (`ar-io/ar-io-cranker`) and the observer-embedded cranker (`ar-io/ar-io-observer@solana`, `src/epoch/`) both call `getGoneGateways()` → `finalizeGone()`. The public API is preserved, so **after this publishes they only need a `@ar.io/sdk` version bump** (no code changes) to pick up the fix; an optional cleanup can switch call sites/logs to `getLeavingGateways()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)