### PR TITLE
fix(solana): crankEpochStep handles AO-continuity cold start (currentIndex>0)

### DIFF
--- a/src/solana/crank-epoch-step.test.ts
+++ b/src/solana/crank-epoch-step.test.ts
@@ -154,10 +154,23 @@ describe('crankEpochStep', () => {
     assert.equal(r.txId, 'tx-create');
   });
 
-  it('idle waiting_for_epoch when the current epoch account is missing', async () => {
+  it('creates epoch[currentIndex] on a continuity cold start (live epoch missing, started)', async () => {
+    // AO→Solana cutover: admin_set_current_epoch_index jumped currentIndex to
+    // N>0 with NO prior epochs on-chain, so the "live" epoch (currentIndex-1)
+    // was never created. Create epoch[currentIndex] directly once its start has
+    // passed — the old code idled 'waiting_for_epoch' here forever (deadlock).
     const c = new TestCranker();
-    c.settings = { ...baseSettings, currentEpochIndex: 1 }; // target 0, not present
+    c.settings = { ...baseSettings, currentEpochIndex: 1 }; // target 0 absent; epoch 1 start = 1100
     const r = await c.crankEpochStep({ now: 1500 });
+    assert.equal(r.action, 'create');
+    assert.equal(r.epochIndex, 1);
+    assert.equal(r.txId, 'tx-create');
+  });
+
+  it('idle waiting_for_epoch on a cold start before the epoch start arrives', async () => {
+    const c = new TestCranker();
+    c.settings = { ...baseSettings, currentEpochIndex: 1 }; // epoch 1 start = 1100
+    const r = await c.crankEpochStep({ now: 1050 }); // before 1100
     assert.equal(r.action, 'idle');
     assert.equal(r.reason, 'waiting_for_epoch');
   });

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -3697,16 +3697,28 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     const nextEpochStart =
       settings.genesisTimestamp + currentIndex * settings.epochDuration;
 
-    // Bootstrap: no epochs yet.
-    if (currentIndex === 0) {
-      if (now < nextEpochStart)
-        return { action: 'idle', reason: 'waiting_for_genesis' };
-      const { id } = await this.createEpoch();
-      return { action: 'create', epochIndex: 0, txId: id };
-    }
-
     const epoch = await this.getEpochRaw(targetEpochIndex);
-    if (!epoch) return { action: 'idle', reason: 'waiting_for_epoch' };
+
+    // Cold start: the live epoch (targetEpochIndex) doesn't exist yet. Two cases,
+    // handled identically — `create_epoch` always creates epoch[currentIndex] and
+    // then increments the counter, so the NEXT crank finds it live at currentIndex-1:
+    //   1. Genesis: currentIndex === 0 → create epoch 0.
+    //   2. AO→Solana continuity cold start: `admin_set_current_epoch_index` jumped
+    //      currentIndex to e.g. 454 with NO prior epochs on-chain (the AO-side
+    //      epochs were never created on Solana). targetEpochIndex (453) points at
+    //      an epoch that will never exist, so the old `currentIndex === 0`-only
+    //      bootstrap deadlocked here ('waiting_for_epoch' forever). Create
+    //      epoch[currentIndex] (454) directly — its start was re-anchored to ≈now.
+    if (!epoch) {
+      if (now < nextEpochStart)
+        return {
+          action: 'idle',
+          reason:
+            currentIndex === 0 ? 'waiting_for_genesis' : 'waiting_for_epoch',
+        };
+      const { id } = await this.createEpoch();
+      return { action: 'create', epochIndex: currentIndex, txId: id };
+    }
 
     // Tally (batched). activeGatewayCount===0 still needs one tx to flip the flag.
     if (epoch.weightsTallied === 0) {


### PR DESCRIPTION
## Problem

At AO→Solana cutover the epoch cranker **deadlocks**. `admin_set_current_epoch_index` jumps `current_epoch_index` to the AO continuity value (e.g. **454**) with no prior epochs on-chain. `crankEpochStep` only had a `currentIndex === 0` bootstrap; for `currentIndex > 0` it computed the "live" epoch as `currentIndex - 1` (453), called `getEpochRaw(453)` → `null` → returned `idle / waiting_for_epoch` **forever**. No epoch is ever created, so every operator's cranker (and the observer-embedded cranker — both just call `crankEpochStep`) deadlocks.

Observed on staging-v2: `enabled=true, currentEpochIndex=454`, zero Epoch accounts, all crankers idle.

## Fix

`ario-gar::create_epoch` is permissionless, creates `epoch[current_epoch_index]` directly (no dependency on the previous epoch), and increments the counter — it was designed for exactly this jump. Generalize the cold-start branch: when the live epoch doesn't exist (genesis **or** continuity cold start), create `epoch[currentIndex]` once its re-anchored start has arrived. The next crank then finds it live at `currentIndex-1` and proceeds through tally → prescribe → distribute → close as normal.

## Not a valid workaround

Resetting `current_epoch_index` to 0 resets the index-based reward-decay schedule and breaks AO continuity — and isn't even reachable once enabled (`admin_set_current_epoch_index` requires `enabled==false && index==0`; disabling is a 7-day timelock).

## Scope

SDK-only (`crankEpochStep`). `ar-io-cranker` and `ar-io-observer` delegate the whole lifecycle to this method, so they need no code change — just an `@ar.io/sdk` version bump. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)