### PR TITLE
feat(solana): compound + demand-factor crank steps in crankEpochStep

### DIFF
--- a/src/solana/compound-crank.test.ts
+++ b/src/solana/compound-crank.test.ts
@@ -1,0 +1,150 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { type Address, type Instruction, getAddressDecoder } from '@solana/kit';
+
+import { selectCompoundableDelegations } from './delegation-math.js';
+import { SolanaARIOWriteable } from './io-writeable.js';
+
+const dec = getAddressDecoder();
+function pk(tag: number): Address {
+  const u = new Uint8Array(32);
+  u[0] = tag & 0xff;
+  u[31] = 0x2a;
+  return dec.decode(u);
+}
+
+// REWARD_PRECISION = 1e18: pending = stake * (cum - debt) / 1e18.
+const PREC = 10n ** 18n;
+const joined = (cum: bigint) => ({
+  cumulativeRewardPerToken: cum,
+  status: 'joined',
+});
+const leaving = (cum: bigint) => ({
+  cumulativeRewardPerToken: cum,
+  status: 'leaving',
+});
+const del = (
+  gateway: string,
+  delegator: string,
+  stake: number,
+  debt: bigint,
+) => ({
+  gateway,
+  delegator,
+  delegatedStake: stake,
+  rewardDebt: debt,
+});
+
+describe('selectCompoundableDelegations', () => {
+  it('includes pending delegations and computes the pending amount', () => {
+    const gateways = new Map([['gwA', joined(PREC / 100n)]]); // 0.01 reward-per-token
+    const out = selectCompoundableDelegations(
+      [del('gwA', 'd1', 1_000_000, 0n)],
+      gateways,
+    );
+    assert.equal(out.length, 1);
+    assert.deepEqual(
+      { g: out[0].gatewayAddress, d: out[0].delegatorAddress },
+      { g: 'gwA', d: 'd1' },
+    );
+    // pending = 1_000_000 * (1e16) / 1e18 = 10_000
+    assert.equal(out[0].pendingRewards, 10_000);
+  });
+
+  it('skips delegations whose gateway is LEAVING (claim path, not compound)', () => {
+    const out = selectCompoundableDelegations(
+      [del('gwA', 'd1', 1_000_000, 0n)],
+      new Map([['gwA', leaving(PREC)]]),
+    );
+    assert.equal(out.length, 0);
+  });
+
+  it('skips delegations whose gateway is missing/unreadable', () => {
+    const out = selectCompoundableDelegations(
+      [del('ghost', 'd1', 1_000_000, 0n)],
+      new Map(),
+    );
+    assert.equal(out.length, 0);
+  });
+
+  it('skips already-settled delegations (reward_debt == accumulator)', () => {
+    const out = selectCompoundableDelegations(
+      [del('gwA', 'd1', 1_000_000, PREC)],
+      new Map([['gwA', joined(PREC)]]),
+    );
+    assert.equal(out.length, 0);
+  });
+
+  it('respects minPendingRewards (filters dust that would only bump reward_debt)', () => {
+    const gateways = new Map([['gwA', joined(PREC / 1_000_000n)]]); // pending = 1 mARIO
+    const dels = [del('gwA', 'd1', 1_000_000, 0n)];
+    assert.equal(selectCompoundableDelegations(dels, gateways, 0).length, 1);
+    assert.equal(selectCompoundableDelegations(dels, gateways, 1).length, 0); // 1 is not > 1
+  });
+});
+
+/**
+ * Captures the instructions handed to `sendTransaction` instead of sending —
+ * the compound/demand-factor instruction builders are pure (PDA derivation +
+ * encoding, no RPC), so we can assert their shape without a cluster.
+ */
+class TestWriteable extends SolanaARIOWriteable {
+  sent: Array<{ ixs: Instruction[]; cu?: number }> = [];
+  constructor() {
+    super({
+      rpc: {} as never,
+      rpcSubscriptions: {} as never,
+      signer: { address: pk(99) } as never,
+    } as never);
+  }
+  protected async sendTransaction(
+    instructions: Instruction[],
+    computeUnitLimit?: number,
+  ): Promise<string> {
+    this.sent.push({ ixs: instructions, cu: computeUnitLimit });
+    return 'tx-stub';
+  }
+}
+
+describe('compoundDelegationRewards', () => {
+  it('builds a single compound instruction and sends one tx', async () => {
+    const w = new TestWriteable();
+    const r = await w.compoundDelegationRewards({
+      gateway: pk(1),
+      delegator: pk(2),
+    });
+    assert.equal(r.id, 'tx-stub');
+    assert.equal(w.sent.length, 1);
+    assert.equal(w.sent[0].ixs.length, 1);
+  });
+});
+
+describe('compoundDelegationRewardsBatch', () => {
+  it('throws on an empty delegation list', async () => {
+    const w = new TestWriteable();
+    await assert.rejects(() => w.compoundDelegationRewardsBatch([]), /empty/);
+  });
+
+  it('builds one instruction per delegation in a SINGLE transaction', async () => {
+    const w = new TestWriteable();
+    const r = await w.compoundDelegationRewardsBatch([
+      { gateway: pk(1), delegator: pk(2) },
+      { gateway: pk(1), delegator: pk(3) }, // same gateway, different delegate
+      { gateway: pk(4), delegator: pk(5) },
+    ]);
+    assert.equal(r.id, 'tx-stub');
+    assert.equal(w.sent.length, 1, 'a single transaction');
+    assert.equal(w.sent[0].ixs.length, 3, 'one instruction per delegation');
+  });
+});
+
+describe('updateDemandFactor', () => {
+  it('builds an update_demand_factor instruction and sends one tx', async () => {
+    const w = new TestWriteable();
+    const r = await w.updateDemandFactor();
+    assert.equal(r.id, 'tx-stub');
+    assert.equal(w.sent.length, 1);
+    assert.equal(w.sent[0].ixs.length, 1);
+  });
+});

--- a/src/solana/crank-epoch-step.test.ts
+++ b/src/solana/crank-epoch-step.test.ts
@@ -108,6 +108,38 @@ class TestCranker extends SolanaARIOWriteable {
     if (e) throw e;
     return { id: 'tx-prescribe' };
   }
+
+  // --- Lazy-state maintenance stubs (compound + demand factor). Defaults make
+  // the idle tail a no-op so the lifecycle tests above are unaffected. ---
+  compoundable: Array<{
+    gatewayAddress: Address;
+    delegatorAddress: Address;
+    pendingRewards: number;
+  }> = [];
+  // biome-ignore lint/suspicious/noExplicitAny: test stubs
+  async getDelegationsToCompound(): Promise<any> {
+    this.calls.push('getCompoundable');
+    return this.compoundable;
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: test stubs
+  async compoundDelegationRewardsBatch(b: any[]): Promise<any> {
+    this.calls.push(`compound:${b.length}`);
+    return { id: 'tx-compound' };
+  }
+  dfPeriod: { currentPeriod: number; periodZeroStartTimestamp: number } | null =
+    null;
+  async getDemandFactorPeriodState(): Promise<{
+    currentPeriod: number;
+    periodZeroStartTimestamp: number;
+  } | null> {
+    this.calls.push('dfState');
+    return this.dfPeriod;
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: test stubs
+  async updateDemandFactor(): Promise<any> {
+    this.calls.push('updateDemandFactor');
+    return { id: 'tx-df' };
+  }
 }
 
 const baseSettings: Settings = {
@@ -318,5 +350,72 @@ describe('crankEpochStep', () => {
     const r = await c.crankEpochStep({ now: 1200 }); // < nextEpochStart 1300
     assert.equal(r.action, 'idle');
     assert.equal(r.reason, 'epoch_complete');
+  });
+
+  // --- Lazy-state maintenance steps in the idle tail ---
+
+  it('compounds pending delegate rewards in the idle tail', async () => {
+    const c = new TestCranker();
+    c.settings = { ...baseSettings, currentEpochIndex: 3 };
+    c.epochs[2] = { ...liveEpoch, endTimestamp: 1000 };
+    c.compoundable = [
+      { gatewayAddress: pk(1), delegatorAddress: pk(2), pendingRewards: 100 },
+    ];
+    const r = await c.crankEpochStep({ now: 1200 }); // epoch_complete window
+    assert.equal(r.action, 'compound');
+    assert.equal(r.txId, 'tx-compound');
+    assert.ok(c.calls.includes('compound:1'));
+  });
+
+  it('skips compounding when enableCompound is false', async () => {
+    const c = new TestCranker();
+    c.settings = { ...baseSettings, currentEpochIndex: 3 };
+    c.epochs[2] = { ...liveEpoch, endTimestamp: 1000 };
+    c.compoundable = [
+      { gatewayAddress: pk(1), delegatorAddress: pk(2), pendingRewards: 100 },
+    ];
+    const r = await c.crankEpochStep({ now: 1200, enableCompound: false });
+    assert.equal(r.action, 'idle');
+    assert.equal(r.reason, 'epoch_complete');
+    assert.ok(!c.calls.some((x) => x.startsWith('compound:')));
+  });
+
+  it('rolls the demand factor in the idle tail when its period elapsed (preempts create)', async () => {
+    const c = new TestCranker();
+    c.settings = { ...baseSettings, currentEpochIndex: 3 };
+    c.epochs[2] = { ...liveEpoch, endTimestamp: 1000 };
+    c.compoundable = []; // nothing to compound
+    c.dfPeriod = { currentPeriod: 1, periodZeroStartTimestamp: 0 };
+    // now in demand-factor period 2 (>= 86400) — also >= nextEpochStart, so this
+    // proves the roll preempts create-next.
+    const r = await c.crankEpochStep({ now: 90_000 });
+    assert.equal(r.action, 'update_demand_factor');
+    assert.equal(r.txId, 'tx-df');
+    assert.ok(!c.calls.includes('createEpoch'));
+  });
+
+  it('does not roll the demand factor within the same period', async () => {
+    const c = new TestCranker();
+    c.settings = { ...baseSettings, currentEpochIndex: 3 };
+    c.epochs[2] = { ...liveEpoch, endTimestamp: 1000 };
+    c.compoundable = [];
+    c.dfPeriod = { currentPeriod: 2, periodZeroStartTimestamp: 0 }; // already period 2
+    const r = await c.crankEpochStep({ now: 90_000 }); // still period 2
+    assert.notEqual(r.action, 'update_demand_factor');
+    assert.ok(!c.calls.includes('updateDemandFactor'));
+  });
+
+  it('compound takes precedence over demand-factor roll and create-next', async () => {
+    const c = new TestCranker();
+    c.settings = { ...baseSettings, currentEpochIndex: 3 };
+    c.epochs[2] = { ...liveEpoch, endTimestamp: 1000 };
+    c.compoundable = [
+      { gatewayAddress: pk(1), delegatorAddress: pk(2), pendingRewards: 5 },
+    ];
+    c.dfPeriod = { currentPeriod: 1, periodZeroStartTimestamp: 0 }; // also due
+    const r = await c.crankEpochStep({ now: 90_000 }); // create + df also due
+    assert.equal(r.action, 'compound');
+    assert.ok(!c.calls.includes('updateDemandFactor'));
+    assert.ok(!c.calls.includes('createEpoch'));
   });
 });

--- a/src/solana/delegation-math.ts
+++ b/src/solana/delegation-math.ts
@@ -89,3 +89,56 @@ export function computeLiveDelegationBalance({
   const capped = live > U64_MAX ? U64_MAX : live;
   return Number(capped);
 }
+
+/**
+ * Select the delegations worth compounding, from decoded delegations + a map
+ * of their gateways' reward accumulators. Pure (no I/O) so it's unit-testable
+ * independently of RPC; `SolanaARIOReadable.getDelegationsToCompound` is just
+ * fetch+decode wrapped around this.
+ *
+ * A delegation is included when its pending reward (live balance − settled
+ * principal) exceeds `minPendingRewards`, EXCEPT when its gateway is `leaving`
+ * (those settle via `claim_delegate_from_leaving_gateway`, not compounding) or
+ * its gateway is missing/unreadable. Compounding sub-threshold dust only
+ * advances `reward_debt` for no balance gain, so it's filtered out.
+ */
+export function selectCompoundableDelegations(
+  delegations: Array<{
+    gateway: string;
+    delegator: string;
+    delegatedStake: number;
+    rewardDebt: bigint;
+  }>,
+  gatewaysByOperator: Map<
+    string,
+    { cumulativeRewardPerToken: bigint; status: string }
+  >,
+  minPendingRewards = 0,
+): Array<{
+  gatewayAddress: string;
+  delegatorAddress: string;
+  pendingRewards: number;
+}> {
+  const out: Array<{
+    gatewayAddress: string;
+    delegatorAddress: string;
+    pendingRewards: number;
+  }> = [];
+  for (const del of delegations) {
+    const gw = gatewaysByOperator.get(del.gateway);
+    if (!gw || gw.status === 'leaving') continue;
+    const live = computeLiveDelegationBalance({
+      delegatedStake: del.delegatedStake,
+      rewardDebt: del.rewardDebt,
+      cumulativeRewardPerToken: gw.cumulativeRewardPerToken,
+    });
+    const pendingRewards = live - del.delegatedStake;
+    if (pendingRewards <= minPendingRewards) continue;
+    out.push({
+      gatewayAddress: del.gateway,
+      delegatorAddress: del.delegator,
+      pendingRewards,
+    });
+  }
+  return out;
+}

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -115,7 +115,10 @@ import {
   ARNS_RECORD_ANT_OFFSET,
   RATE_SCALE,
 } from './constants.js';
-import { computeLiveDelegationBalance } from './delegation-math.js';
+import {
+  computeLiveDelegationBalance,
+  selectCompoundableDelegations,
+} from './delegation-math.js';
 import {
   deserializeAllowlist,
   deserializeArioConfig,
@@ -2168,6 +2171,80 @@ export class SolanaARIOReadable {
     }));
 
     return paginate(items, params);
+  }
+
+  /**
+   * Enumerate every delegation that has pending (unsettled) rewards — the work
+   * list for the permissionless `compound_delegation_rewards` crank. Pending is
+   * computed from the gateway's reward-per-share accumulator (mirrors
+   * {@link computeLiveDelegationBalance}); the crank only changes balances, so
+   * rewards already accrue correctly without it.
+   *
+   * Skips delegations whose gateway is `Leaving` (those settle through
+   * `claim_delegate_from_leaving_gateway`, not compounding) and any below
+   * `minPendingRewards` — compounding sub-threshold dust just advances
+   * `reward_debt` for no balance gain. Feed the result, chunked, to
+   * `SolanaARIOWriteable.compoundDelegationRewardsBatch`.
+   */
+  async getDelegationsToCompound(params?: {
+    minPendingRewards?: number;
+  }): Promise<
+    Array<{
+      gatewayAddress: string;
+      delegatorAddress: string;
+      pendingRewards: number;
+    }>
+  > {
+    const minPending = params?.minPendingRewards ?? 0;
+
+    // One scan for gateways → accumulator + status.
+    const gatewayAccounts = await this.getAccountsByDiscriminator(
+      this.garProgram,
+      GATEWAY_DISCRIMINATOR,
+    );
+    const gateways = new Map<
+      string,
+      { cumulativeRewardPerToken: bigint; status: string }
+    >();
+    for (const { data } of gatewayAccounts) {
+      try {
+        const gw = deserializeGatewayWithAccumulator(data);
+        gateways.set(gw.operator, {
+          cumulativeRewardPerToken: gw.cumulativeRewardPerToken,
+          status: gw.status,
+        });
+      } catch {
+        // Skip malformed.
+      }
+    }
+
+    // One scan for delegations; decode then delegate the selection logic to the
+    // pure `selectCompoundableDelegations` (unit-tested in delegation-math).
+    const delegationAccounts = await this.getAccountsByDiscriminator(
+      this.garProgram,
+      DELEGATION_DISCRIMINATOR,
+    );
+    const delegations: Array<{
+      gateway: string;
+      delegator: string;
+      delegatedStake: number;
+      rewardDebt: bigint;
+    }> = [];
+    for (const { data } of delegationAccounts) {
+      try {
+        const del = deserializeDelegation(data);
+        delegations.push({
+          gateway: del.gateway,
+          delegator: del.delegator,
+          delegatedStake: del.delegatedStake,
+          rewardDebt: del.rewardDebt,
+        });
+      } catch {
+        // Skip malformed.
+      }
+    }
+
+    return selectCompoundableDelegations(delegations, gateways, minPending);
   }
 
   async getAllGatewayVaults(

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -81,6 +81,7 @@ import {
   getPruneReturnedNamesInstructionAsync,
   getReassignNameInstructionAsync,
   getReleaseNameInstructionAsync,
+  getUpdateDemandFactorInstruction,
   getUpgradeNameFromDelegationInstructionAsync,
   getUpgradeNameFromFundingPlanInstructionAsync,
   getUpgradeNameFromOperatorStakeInstructionAsync,
@@ -117,6 +118,7 @@ import {
 } from './ata.js';
 import {
   deserializeArnsRecord,
+  deserializeDemandFactor,
   deserializeEpochSettingsFull,
   deserializePrimaryName,
 } from './deserialize.js';
@@ -176,6 +178,7 @@ import {
   getCloseEmptyDelegationInstruction,
   getCloseEpochInstructionAsync,
   getCloseObservationInstructionAsync,
+  getCompoundDelegationRewardsInstruction,
   getCreateEpochInstructionAsync,
   getDecreaseDelegateStakeInstructionAsync,
   getDecreaseOperatorStakeInstructionAsync,
@@ -433,12 +436,23 @@ export function encodeReportTxId(reportTxId: string | undefined): Buffer {
   return out;
 }
 
+/**
+ * Max `compound_delegation_rewards` instructions packed into one batched tx.
+ * Each carries a gateway + delegation + delegator account; 12 stays well within
+ * the per-tx account/1232-byte budget even when none share a gateway.
+ */
+const MAX_COMPOUND_BATCH = 12;
+/** Demand-factor period length (seconds) — mirrors `PERIOD_LENGTH_SECONDS` in ario-arns. */
+const DEMAND_FACTOR_PERIOD_SECONDS = 86_400;
+
 /** The single on-chain action a {@link SolanaARIOWriteable.crankEpochStep} call performed. */
 export type CrankAction =
   | 'create'
   | 'tally'
   | 'prescribe'
   | 'distribute'
+  | 'compound'
+  | 'update_demand_factor'
   | 'close'
   | 'idle';
 
@@ -456,6 +470,27 @@ export interface CrankEpochStepOptions {
   enableClose?: boolean;
   /** Epochs of retention before an epoch may be closed (GAR-006). Default 7. */
   epochRetention?: number;
+  /**
+   * Compound pending delegate rewards (settle the reward-per-share accumulator
+   * into delegated stake) once the live epoch is fully distributed, so the next
+   * epoch's tally weights the compounded stake. Default true. The delegate
+   * rewards are correct in the accumulator regardless — this only materializes
+   * them on-chain. Each step compounds one batch; runs only in the otherwise-
+   * idle tail (never during tally/distribute).
+   */
+  enableCompound?: boolean;
+  /**
+   * Skip compounding delegations whose pending reward is at/below this (mARIO).
+   * Avoids dust compounds that only advance `reward_debt`. Default 0.
+   */
+  compoundMinPendingRewards?: number;
+  /**
+   * Roll the demand factor forward when its (wall-clock) period has elapsed.
+   * Idempotent — only sends a tx when the stored period is behind. Pricing is
+   * always lazily correct without this; it keeps the STORED factor (and reads
+   * between buys) current. Default true. Runs only in the idle tail.
+   */
+  enableDemandFactorRoll?: boolean;
   /** Unix seconds; defaults to the wall clock. Injectable for testing. */
   now?: number;
 }
@@ -3331,6 +3366,94 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
   }
 
   // =========================================
+  // Lazy-state crank steps — materialize accumulator/period state.
+  // Both are permissionless + idempotent (safe to crank on a schedule).
+  // =========================================
+
+  /**
+   * Roll the demand factor forward to the current period. Permissionless and
+   * idempotent — a no-op within the same period. Pricing already rolls the
+   * factor inline on every buy/extend, so this only refreshes the STORED
+   * factor that `getDemandFactor` and between-buy price previews read; a
+   * periodic crank (~once per 24h `PERIOD_LENGTH_SECONDS`) keeps it current.
+   */
+  async updateDemandFactor(_options?: WriteOptions): Promise<MessageResult> {
+    const [demandFactorPda] = await getDemandFactorPDA(this.arnsProgram);
+    const ix = getUpdateDemandFactorInstruction(
+      { demandFactor: demandFactorPda, payer: this.signer },
+      { programAddress: this.arnsProgram },
+    );
+    const sig = await this.sendTransaction([ix]);
+    return { id: sig };
+  }
+
+  /**
+   * Materialize a single delegate's pending rewards into their delegated
+   * stake by settling the gateway's reward-per-share accumulator.
+   * Permissionless — there is no signer beyond the fee payer; `delegator` is
+   * only a PDA-derivation seed. Rewards always accrue correctly in the
+   * accumulator regardless of this call; compounding makes the on-chain
+   * `delegatedStake` reflect them (and earn compound interest in the next
+   * epoch's weighting). Idempotent — a no-op once already settled.
+   */
+  async compoundDelegationRewards(
+    params: { gateway: string; delegator: string },
+    _options?: WriteOptions,
+  ): Promise<MessageResult> {
+    const ix = await this.buildCompoundDelegationRewardsInstruction(params);
+    const sig = await this.sendTransaction([ix]);
+    return { id: sig };
+  }
+
+  /**
+   * Compound many delegates' rewards in a SINGLE transaction — one
+   * `compound_delegation_rewards` instruction per entry. Idempotent and
+   * permissionless, so partial batches are safe to retry. Keep each batch
+   * within the per-tx account/CU budget; grouping entries that share a gateway
+   * lowers the unique-account count (the gateway account is reused across
+   * instructions). Typical cranker usage: enumerate with
+   * `SolanaARIOReadable.getDelegationsToCompound`, chunk, then call this.
+   */
+  async compoundDelegationRewardsBatch(
+    delegations: Array<{ gateway: string; delegator: string }>,
+    _options?: WriteOptions,
+  ): Promise<MessageResult> {
+    if (delegations.length === 0) {
+      throw new Error(
+        'compoundDelegationRewardsBatch: delegations list is empty',
+      );
+    }
+    const ixs = await Promise.all(
+      delegations.map((d) => this.buildCompoundDelegationRewardsInstruction(d)),
+    );
+    const sig = await this.sendTransaction(ixs, 1_400_000);
+    return { id: sig };
+  }
+
+  /**
+   * Build a single `compound_delegation_rewards` instruction (shared by the
+   * single + batch methods). PDAs are derived under the configured gar program
+   * so the program-id override always targets the right cluster.
+   */
+  private async buildCompoundDelegationRewardsInstruction(params: {
+    gateway: string;
+    delegator: string;
+  }) {
+    const gateway = address(params.gateway);
+    const delegator = address(params.delegator);
+    const [gatewayPda] = await getGatewayPDA(gateway, this.garProgram);
+    const [delegationPda] = await getDelegationPDA(
+      gateway,
+      delegator,
+      this.garProgram,
+    );
+    return getCompoundDelegationRewardsInstruction(
+      { gateway: gatewayPda, delegation: delegationPda, delegator },
+      { programAddress: this.garProgram },
+    );
+  }
+
+  // =========================================
   // Epoch cranking (ario-gar) — permissionless
   // =========================================
 
@@ -3793,6 +3916,9 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     );
     const enableClose = opts.enableClose ?? true;
     const retention = opts.epochRetention ?? 7;
+    const enableCompound = opts.enableCompound ?? true;
+    const compoundMinPending = opts.compoundMinPendingRewards ?? 0;
+    const enableDemandFactorRoll = opts.enableDemandFactorRoll ?? true;
     const now = opts.now ?? Math.floor(Date.now() / 1000);
 
     const settings = await this.getEpochSettingsFull();
@@ -3897,6 +4023,21 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       }
     }
 
+    // Lazy-state maintenance — lower urgency than the lifecycle, reached only
+    // once the live epoch is fully distributed (rewardsDistributed === 1 here).
+    // Compound FIRST so delegated stake reflects the just-distributed rewards
+    // before the next epoch's tally weights it; then roll the demand factor if
+    // its period elapsed. Both are permissionless + idempotent, and run BEFORE
+    // creating the next epoch so the compounded stake is in place for its tally.
+    if (enableCompound) {
+      const compounded = await this.maybeCompoundStep(compoundMinPending);
+      if (compounded) return compounded;
+    }
+    if (enableDemandFactorRoll) {
+      const rolled = await this.maybeRollDemandFactorStep(now);
+      if (rolled) return rolled;
+    }
+
     // Current epoch fully processed — create the next once its start arrives.
     if (now >= nextEpochStart) {
       const { id } = await this.createEpoch();
@@ -3904,6 +4045,68 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     }
 
     return { action: 'idle', reason: 'epoch_complete' };
+  }
+
+  /**
+   * One compound batch over delegations with pending rewards (≤
+   * {@link MAX_COMPOUND_BATCH} per tx), or `null` when none are due. Settling
+   * is idempotent, so this converges over a few crank steps then no-ops until
+   * the next epoch's distribution advances the accumulator again.
+   */
+  private async maybeCompoundStep(
+    minPendingRewards: number,
+  ): Promise<CrankEpochStepResult | null> {
+    const pending = await this.getDelegationsToCompound({ minPendingRewards });
+    if (pending.length === 0) return null;
+    const batch = pending.slice(0, MAX_COMPOUND_BATCH).map((p) => ({
+      gateway: p.gatewayAddress,
+      delegator: p.delegatorAddress,
+    }));
+    const { id } = await this.compoundDelegationRewardsBatch(batch);
+    return {
+      action: 'compound',
+      txId: id,
+      progress: { index: batch.length, total: pending.length },
+    };
+  }
+
+  /**
+   * Roll the demand factor forward if its (wall-clock) period elapsed since the
+   * last stored roll, else `null`. Mirrors the on-chain period math; the roll
+   * itself is idempotent.
+   */
+  private async maybeRollDemandFactorStep(
+    now: number,
+  ): Promise<CrankEpochStepResult | null> {
+    const state = await this.getDemandFactorPeriodState();
+    if (!state) return null;
+    const elapsed = now - state.periodZeroStartTimestamp;
+    const periodForNow =
+      elapsed < 0 ? 1 : Math.floor(elapsed / DEMAND_FACTOR_PERIOD_SECONDS) + 1;
+    if (periodForNow <= state.currentPeriod) return null; // same period — no-op
+    const { id } = await this.updateDemandFactor();
+    return { action: 'update_demand_factor', txId: id };
+  }
+
+  /**
+   * The DemandFactor account's stored period + period-zero start (seconds) —
+   * the gate for {@link maybeRollDemandFactorStep}. `null` if the account
+   * doesn't exist (pre-genesis).
+   */
+  async getDemandFactorPeriodState(): Promise<{
+    currentPeriod: number;
+    periodZeroStartTimestamp: number;
+  } | null> {
+    const [pda] = await getDemandFactorPDA(this.arnsProgram);
+    const account = await fetchEncodedAccount(this.rpc, pda, {
+      commitment: this.commitment,
+    });
+    if (!account.exists) return null;
+    const df = deserializeDemandFactor(Buffer.from(account.data));
+    return {
+      currentPeriod: df.currentPeriod,
+      periodZeroStartTimestamp: df.periodZeroStartTimestamp,
+    };
   }
 
   /**


### PR DESCRIPTION
Materializes the two **lazy on-chain states the epoch cranker currently leaves behind** on Solana. Both new steps are **permissionless + idempotent**, and both are integrated into the existing **`crankEpochStep`** orchestrator so the cranker/observer pick them up without new loops.

## Why
- **Delegate rewards**: `distribute_epoch` advances the gateway reward-per-share accumulator (`cumulative_reward_per_token`) but never touches `Delegation.amount`. So a *passive* delegator's stake looks flat even though rewards are accruing correctly. `compound_delegation_rewards` settles the accumulator into their stake (and lets it earn compound interest in the next epoch's tally weighting). Verified on staging: 435 delegations had ~6,602 ARIO accrued-but-unmaterialized.
- **Demand factor**: rolls lazily — on each buy inline, or via `update_demand_factor`. With no buys and no crank, the *stored* factor (and `getDemandFactor` reads) sits stale even after the 24h period elapses.

## What
**`SolanaARIOWriteable`**
- `compoundDelegationRewards({ gateway, delegator })` and `compoundDelegationRewardsBatch([...])` (one tx, ≤12 ix).
- `updateDemandFactor()`.
- **`crankEpochStep`** now runs both in its **idle tail** — compound **after distribute and before creating the next epoch** (so compounded stake is weighted), then the demand-factor roll. New `CrankAction`s `'compound'` / `'update_demand_factor'`; gated by `enableCompound` / `compoundMinPendingRewards` / `enableDemandFactorRoll` (all default on). Skips **Leaving** gateways (those use the claim path) and sub-threshold dust.
- `getDemandFactorPeriodState()` helper for the period gate.

**`SolanaARIOReadable`**
- `getDelegationsToCompound({ minPendingRewards })` — enumerates delegations with pending rewards for the crank, via the pure, unit-tested `selectCompoundableDelegations` (in `delegation-math`).

## Behavior / cost notes
- Compound runs only in the otherwise-idle tail (never during tally/distribute), one batch per step, converging then no-op until the next distribution advances the accumulator. Compounding *less* frequently is also fairer on rounding dust (sub-1-unit pending truncates while `reward_debt` advances).
- `update_demand_factor` only sends a tx when the stored period is behind (no-op spam avoided).

## Tests
Pure selection logic; write-method instruction shape + batching; and `crankEpochStep`'s new tail steps (precedence: compound > demand-factor > create-next; period gate; enable flags). Full unit suite green.

## Follow-up (separate PRs)
- `ar-io-cranker` + `ar-io-observer`: map the two new `CrankAction`s onto metrics/logging (they already call `crankEpochStep`, so no new phases). Gated on this releasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)