### PR TITLE
perf(solana): batch and parallelize gateway, balance, and epoch reads

### DIFF
--- a/src/solana/concurrency.test.ts
+++ b/src/solana/concurrency.test.ts
@@ -1,0 +1,83 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { mapWithConcurrency } from './concurrency.js';
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('mapWithConcurrency', () => {
+  it('returns an empty array for empty input without invoking fn', async () => {
+    let calls = 0;
+    const result = await mapWithConcurrency([], 4, async (x) => {
+      calls++;
+      return x;
+    });
+    assert.deepEqual(result, []);
+    assert.equal(calls, 0);
+  });
+
+  it('preserves input order regardless of completion order', async () => {
+    const items = [0, 1, 2, 3, 4, 5];
+    // Earlier items resolve LATER so completion order is reversed.
+    const result = await mapWithConcurrency(items, 3, async (x) => {
+      await delay((items.length - x) * 5);
+      return x * 10;
+    });
+    assert.deepEqual(result, [0, 10, 20, 30, 40, 50]);
+  });
+
+  it('respects the concurrency cap', async () => {
+    const limit = 3;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = Array.from({ length: 12 }, (_, i) => i);
+
+    await mapWithConcurrency(items, limit, async (x) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await delay(10);
+      inFlight--;
+      return x;
+    });
+
+    assert.ok(
+      maxInFlight <= limit,
+      `expected at most ${limit} in flight, saw ${maxInFlight}`,
+    );
+    // Sanity: with enough work the pool should actually saturate the cap.
+    assert.equal(maxInFlight, limit);
+  });
+
+  it('clamps limit to at least 1', async () => {
+    const order: number[] = [];
+    const result = await mapWithConcurrency([1, 2, 3], 0, async (x) => {
+      order.push(x);
+      return x;
+    });
+    assert.deepEqual(result, [1, 2, 3]);
+    assert.deepEqual(order, [1, 2, 3]);
+  });
+
+  it('does not spawn more workers than items', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const result = await mapWithConcurrency([1, 2], 100, async (x) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await delay(5);
+      inFlight--;
+      return x;
+    });
+    assert.deepEqual(result, [1, 2]);
+    assert.ok(maxInFlight <= 2);
+  });
+
+  it('passes the correct index to fn', async () => {
+    const result = await mapWithConcurrency(
+      ['a', 'b', 'c'],
+      2,
+      async (item, index) => `${index}:${item}`,
+    );
+    assert.deepEqual(result, ['0:a', '1:b', '2:c']);
+  });
+});

--- a/src/solana/concurrency.ts
+++ b/src/solana/concurrency.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Map `items` through async `fn` with at most `limit` invocations in flight at
+ * once, preserving INPUT ORDER in the returned array regardless of completion
+ * order. Used to fan out batched RPC reads (e.g. chunked `fetchEncodedAccounts`
+ * calls) without flooding the endpoint with unbounded concurrency.
+ *
+ * `limit` is clamped to at least 1; an empty `items` resolves to `[]` without
+ * invoking `fn`.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const effectiveLimit = Math.max(1, Math.min(limit, items.length));
+  const results: R[] = new Array(items.length);
+  let next = 0;
+
+  // Spin up `effectiveLimit` workers that pull the next index off a shared
+  // cursor until the input is exhausted. Results are written by index so the
+  // output order matches the input order, not the completion order.
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const index = next++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index], index);
+    }
+  };
+
+  await Promise.all(Array.from({ length: effectiveLimit }, () => worker()));
+
+  return results;
+}

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -107,6 +107,7 @@ import type {
 } from '../types/io.js';
 import { SolanaANTRegistryReadable } from './ant-registry-readable.js';
 import { getAssociatedTokenAddressKit } from './ata.js';
+import { mapWithConcurrency } from './concurrency.js';
 import {
   ARIO_ANT_PROGRAM_ID,
   ARIO_ARNS_PROGRAM_ID,
@@ -678,8 +679,11 @@ export class SolanaARIOReadable {
    * Enumerate liquid ARIO balances by querying the SPL Token program for
    * every initialized token account on the ARIO mint.
    *
-   * Filters: token-account size = 165, mint at offset 0. We then decode
-   * `owner` (offset 32) and `amount` (offset 64) from each.
+   * Filters: token-account size = 165, mint at offset 0 — these apply to the
+   * full on-chain account. We then `dataSlice` the response down to the 40
+   * bytes spanning `owner` (offset 32) and `amount` (offset 64), cutting the
+   * returned payload by ~75%, and decode `owner` (sliced bytes 0..32) and
+   * `amount` (sliced bytes 32..40) from each.
    */
   async getBalances(
     params?: PaginationParams<BalanceWithAddress>,
@@ -702,6 +706,9 @@ export class SolanaARIOReadable {
           .getProgramAccounts(TOKEN_PROGRAM_ADDRESS, {
             commitment: this.commitment,
             encoding: 'base64',
+            // Filters above match the full 165-byte account; dataSlice only
+            // trims the RETURNED bytes to owner(32) + amount(8) = 40 bytes.
+            dataSlice: { offset: 32, length: 40 },
             filters,
           })
           .send() as Promise<
@@ -715,10 +722,20 @@ export class SolanaARIOReadable {
     const items: BalanceWithAddress[] = [];
     for (const entry of result) {
       try {
+        // With the dataSlice above the returned buffer is 40 bytes:
+        // [0..32]=owner, [32..40]=amount(u64 LE).
         const data = Buffer.from(entry.account.data[0], 'base64');
-        if (data.length < 72) continue;
-        const ownerAddress = addressDecoder.decode(data.subarray(32, 64));
-        const amount = Number(data.readBigUInt64LE(64));
+        if (data.length < 40) continue;
+        const ownerAddress = addressDecoder.decode(data.subarray(0, 32));
+        // NOTE: avoid `Buffer.readBigUInt64LE` — some browser bundlers (notably
+        // arns-react's Vite output) strip the BigInt readers from the
+        // `buffer@6.0.3` shim's prototype. Manual little-endian u64 decode is
+        // portable across every JS runtime (matches getBalance above).
+        let amountBig = 0n;
+        for (let i = 7; i >= 0; i--) {
+          amountBig = (amountBig << 8n) | BigInt(data[32 + i]);
+        }
+        const amount = Number(amountBig);
         if (amount > 0) {
           items.push({ address: ownerAddress, balance: amount });
         }
@@ -728,6 +745,70 @@ export class SolanaARIOReadable {
     }
 
     return paginate(items, params);
+  }
+
+  /**
+   * Batch-load liquid ARIO balances for a specific set of owner addresses in a
+   * single fan-out of `getMultipleAccounts` reads (O(1) RPC round-trips per
+   * 100-ATA chunk, fetched concurrently) rather than one `getBalance` call per
+   * address.
+   *
+   * Each owner's balance lives on its Associated Token Account for the ARIO
+   * mint (see {@link getBalance} for why the ATA — not the Balance PDA — is the
+   * canonical liquid balance). Returns one `{ address, balance }` per input
+   * address in INPUT ORDER; `balance` is 0 when the ATA is not yet initialized.
+   */
+  async getBalancesForAddresses({
+    addresses,
+  }: {
+    addresses: string[];
+  }): Promise<BalanceWithAddress[]> {
+    if (addresses.length === 0) return [];
+
+    const mint = await this.getArioMint();
+    const atas = await Promise.all(
+      addresses.map((owner) =>
+        getAssociatedTokenAddressKit(mint, address(owner)),
+      ),
+    );
+    const chunks: Address[][] = [];
+    for (let i = 0; i < atas.length; i += 100) {
+      chunks.push(atas.slice(i, i + 100));
+    }
+    const BALANCE_FETCH_CONCURRENCY = 8;
+    const chunkResults = await mapWithConcurrency(
+      chunks,
+      BALANCE_FETCH_CONCURRENCY,
+      async (chunk) =>
+        withRetry(() =>
+          fetchEncodedAccounts(this.rpc, chunk, {
+            commitment: this.commitment,
+          }),
+        ),
+    );
+    const accounts = chunkResults.flat();
+
+    const items: BalanceWithAddress[] = [];
+    for (let i = 0; i < addresses.length; i++) {
+      const acct = accounts[i];
+      let balance = 0;
+      // SPL Token Account layout: [0..32]=mint, [32..64]=owner,
+      // [64..72]=amount(u64 LE). Decode amount with a manual little-endian
+      // loop (avoid `Buffer.readBigUInt64LE` — see getBalance for rationale).
+      if (acct?.exists) {
+        const data = Buffer.from(acct.data);
+        if (data.length >= 72) {
+          let amount = 0n;
+          for (let b = 7; b >= 0; b--) {
+            amount = (amount << 8n) | BigInt(data[64 + b]);
+          }
+          balance = Number(amount);
+        }
+      }
+      items.push({ address: addresses[i], balance });
+    }
+
+    return items;
   }
 
   // =========================================
@@ -832,32 +913,100 @@ export class SolanaARIOReadable {
       }
     }
 
-    // Batch fetch gateway PDAs (kit has no hard limit but keep 100-at-a-time
-    // for sensible RPC request sizes).
-    const allItems: GatewayWithAddress[] = [];
-    for (let i = 0; i < gatewayAddresses.length; i += 100) {
-      const batch = gatewayAddresses.slice(i, i + 100);
-      const pdas = await Promise.all(
-        batch.map(
-          async (addr) => (await getGatewayPDA(addr, this.garProgram))[0],
-        ),
-      );
-      const accounts = await fetchEncodedAccounts(this.rpc, pdas, {
-        commitment: this.commitment,
-      });
-
-      for (const acct of accounts) {
-        if (!acct.exists) continue;
-        try {
-          const gw = deserializeGateway(Buffer.from(acct.data));
-          allItems.push(toMsTimestamps({ ...gw, gatewayAddress: gw.operator }));
-        } catch {
-          // Skip malformed
-        }
-      }
+    // Derive every gateway PDA up front, then fetch them in 100-at-a-time
+    // chunks (kit has no hard limit but smaller `getMultipleAccounts` requests
+    // stay RPC-friendly). The chunks are fetched CONCURRENTLY with a bounded
+    // worker pool — previously this was a sequential loop, which serialized one
+    // round-trip per chunk. `mapWithConcurrency` preserves chunk order so the
+    // flattened result still comes back in registry order.
+    const pdas = await Promise.all(
+      gatewayAddresses.map(
+        async (addr) => (await getGatewayPDA(addr, this.garProgram))[0],
+      ),
+    );
+    const chunks: Address[][] = [];
+    for (let i = 0; i < pdas.length; i += 100) {
+      chunks.push(pdas.slice(i, i + 100));
     }
+    const GATEWAY_FETCH_CONCURRENCY = 8;
+    const chunkResults = await mapWithConcurrency(
+      chunks,
+      GATEWAY_FETCH_CONCURRENCY,
+      async (chunk) => {
+        const accounts = await withRetry(() =>
+          fetchEncodedAccounts(this.rpc, chunk, {
+            commitment: this.commitment,
+          }),
+        );
+        const items: GatewayWithAddress[] = [];
+        for (const acct of accounts) {
+          if (!acct.exists) continue;
+          try {
+            const gw = deserializeGateway(Buffer.from(acct.data));
+            items.push(toMsTimestamps({ ...gw, gatewayAddress: gw.operator }));
+          } catch {
+            // Skip malformed
+          }
+        }
+        return items;
+      },
+    );
+    const allItems: GatewayWithAddress[] = chunkResults.flat();
 
     return paginate(allItems, params);
+  }
+
+  /**
+   * Batch-load gateways for a specific set of operator addresses in a single
+   * fan-out of `getMultipleAccounts` reads (O(1) RPC round-trips per 100-PDA
+   * chunk, fetched concurrently) rather than one `getGateway` call per address.
+   *
+   * Returns items in INPUT ORDER, shaped like {@link getGateways} entries.
+   * Addresses whose gateway PDA does not exist (or fails to deserialize) are
+   * OMITTED from the result.
+   */
+  async getGatewaysByAddresses({
+    addresses,
+  }: {
+    addresses: string[];
+  }): Promise<GatewayWithAddress[]> {
+    if (addresses.length === 0) return [];
+
+    const pdas = await Promise.all(
+      addresses.map(
+        async (addr) =>
+          (await getGatewayPDA(address(addr), this.garProgram))[0],
+      ),
+    );
+    const chunks: Address[][] = [];
+    for (let i = 0; i < pdas.length; i += 100) {
+      chunks.push(pdas.slice(i, i + 100));
+    }
+    const GATEWAY_FETCH_CONCURRENCY = 8;
+    const chunkResults = await mapWithConcurrency(
+      chunks,
+      GATEWAY_FETCH_CONCURRENCY,
+      async (chunk) => {
+        const accounts = await withRetry(() =>
+          fetchEncodedAccounts(this.rpc, chunk, {
+            commitment: this.commitment,
+          }),
+        );
+        const items: GatewayWithAddress[] = [];
+        for (const acct of accounts) {
+          if (!acct.exists) continue;
+          try {
+            const gw = deserializeGateway(Buffer.from(acct.data));
+            items.push(toMsTimestamps({ ...gw, gatewayAddress: gw.operator }));
+          } catch {
+            // Skip malformed
+          }
+        }
+        return items;
+      },
+    );
+
+    return chunkResults.flat();
   }
 
   async getGatewayDelegates(
@@ -1432,44 +1581,83 @@ export class SolanaARIOReadable {
     const epochIndex = await this.resolveEpochIndex(epoch);
     const epochData = await this.fetchEpoch(epochIndex);
 
-    // Build prescribed observers list (only up to observerCount)
-    const prescribedObservers: WeightedObserver[] = [];
+    // Build prescribed observers list (only up to observerCount).
+    //
+    // Previously this fetched each observer's gateway with a separate
+    // sequential `getGateway` call (up to ~50 round-trips). Instead, collect
+    // every valid (observer, gateway) pair first, then batch-fetch all gateway
+    // accounts in ONE getMultipleAccounts pass (same mechanism as
+    // getGatewayAccumulators). Order and the zero-default fallback for
+    // missing/malformed gateways are preserved exactly.
+    const DEFAULT_WEIGHTS: GatewayWeights = {
+      stakeWeight: 0,
+      tenureWeight: 0,
+      gatewayRewardRatioWeight: 0,
+      observerRewardRatioWeight: 0,
+      gatewayPerformanceRatio: 0,
+      observerPerformanceRatio: 0,
+      compositeWeight: 0,
+      normalizedCompositeWeight: 0,
+    };
+
+    const observerPairs: { observerAddress: string; gatewayAddress: string }[] =
+      [];
     for (let i = 0; i < epochData.observerCount; i++) {
       const observerAddress = epochData.prescribedObservers[i];
       const gatewayAddress = epochData.prescribedObserverGateways[i];
       if (observerAddress === DEFAULT_ADDRESS) continue;
-
-      // Try to fetch gateway data for weights
-      let weights: GatewayWeights = {
-        stakeWeight: 0,
-        tenureWeight: 0,
-        gatewayRewardRatioWeight: 0,
-        observerRewardRatioWeight: 0,
-        gatewayPerformanceRatio: 0,
-        observerPerformanceRatio: 0,
-        compositeWeight: 0,
-        normalizedCompositeWeight: 0,
-      };
-      let stake = 0;
-      let startTimestamp = 0;
-
-      try {
-        const gw = await this.getGateway({ address: gatewayAddress as string });
-        weights = gw.weights;
-        stake = gw.operatorStake;
-        // gw.startTimestamp is already converted to ms by getGateway.
-        startTimestamp = gw.startTimestamp;
-      } catch {
-        // Gateway may no longer exist
-      }
-
-      prescribedObservers.push({
-        gatewayAddress: gatewayAddress as string,
+      observerPairs.push({
         observerAddress: observerAddress as string,
-        stake,
-        startTimestamp,
-        ...weights,
+        gatewayAddress: gatewayAddress as string,
       });
+    }
+
+    const prescribedObservers: WeightedObserver[] = [];
+    if (observerPairs.length > 0) {
+      const observerGatewayPdas = await Promise.all(
+        observerPairs.map(
+          async (pair) =>
+            (
+              await getGatewayPDA(address(pair.gatewayAddress), this.garProgram)
+            )[0],
+        ),
+      );
+      const observerGatewayAccounts = await withRetry(() =>
+        fetchEncodedAccounts(this.rpc, observerGatewayPdas, {
+          commitment: this.commitment,
+        }),
+      );
+
+      for (let i = 0; i < observerPairs.length; i++) {
+        const { observerAddress, gatewayAddress } = observerPairs[i];
+        let weights: GatewayWeights = DEFAULT_WEIGHTS;
+        let stake = 0;
+        let startTimestamp = 0;
+
+        const acct = observerGatewayAccounts[i];
+        if (acct?.exists) {
+          try {
+            // Mirror getGateway's projection: deserialize then toMsTimestamps
+            // so startTimestamp is in ms, matching the pre-batch behavior.
+            const gw = toMsTimestamps(
+              deserializeGateway(Buffer.from(acct.data)),
+            );
+            weights = gw.weights;
+            stake = gw.operatorStake;
+            startTimestamp = gw.startTimestamp;
+          } catch {
+            // Gateway data malformed — keep zero defaults.
+          }
+        }
+
+        prescribedObservers.push({
+          gatewayAddress,
+          observerAddress,
+          stake,
+          startTimestamp,
+          ...weights,
+        });
+      }
     }
 
     // Build prescribed names list by resolving hashes → ArnsRecord PDAs


### PR DESCRIPTION
## Summary

Reduces RPC load and latency in the Solana read client (`SolanaARIOReadable`) by batching/parallelizing on-chain reads that were previously serial. All changes are internal and API-compatible except two additive methods.

## Changes

- **`getGateways` — parallelize PDA batches.** The gateway-PDA chunks were fetched 100-at-a-time **sequentially** (one `getMultipleAccounts` round-trip per chunk). They're now fetched concurrently through a bounded worker pool (cap 8), with registry order preserved via `mapWithConcurrency`. For ~2,500 gateways this turns ~25 serial round-trips into a few concurrent waves.
- **`getBalances` — `dataSlice` the response.** The `getProgramAccounts` scan returned full 165-byte token accounts but only `owner`+`amount` are decoded. Added `dataSlice: { offset: 32, length: 40 }` so the RPC returns only those 40 bytes (~75% smaller payload). Filters (dataSize 165 + mint memcmp) are unchanged — they apply to the full account. Amount is now decoded with the browser-safe manual little-endian u64 reader (matching `getBalance`).
- **`getEpoch` — batch prescribed-observer gateway reads.** The prescribed-observers loop did one sequential `getGateway` per observer (~50 round-trips per epoch load). Now collects all valid (observer, gateway) pairs and fetches their gateway accounts in a single `getMultipleAccounts` pass. Order and the zero-default fallback for missing/malformed gateways are preserved exactly.
- **Additive batch-by-id readers.** `getGatewaysByAddresses({ addresses })` and `getBalancesForAddresses({ addresses })` — `getMultipleAccounts`-backed batch loads for a known subset of addresses, for detail/watchlist pages that shouldn't sweep the whole network.
- **New `mapWithConcurrency` helper** (`src/solana/concurrency.ts`) — order-preserving bounded worker pool, with unit tests (`concurrency.test.ts`).

## Compatibility

No existing public method signatures or return shapes change; the only API additions are the two new methods. Consumers benefit from the internal speedups (gateways/balances/epoch) just by upgrading.

## Verification

- `yarn tsc -p tsconfig.json --noEmit` — clean
- `yarn test:unit` — 344/344 pass (includes new concurrency tests)
- Verified end-to-end by building this branch and consuming it in the network-portal (companion PR ar-io/network-portal).

Byte-offset notes: SPL token layout `[0..32]=mint, [32..64]=owner, [64..72]=amount`; the `dataSlice {offset:32,length:40}` maps owner→`0..32`, amount→`32..40`. The RPC applies filters to the full account and `dataSlice` only trims the returned bytes (standard `getProgramAccounts` behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)