### PR TITLE
fix(escrow): bind recipient + correct headers in canonical claim message

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
   },
   "dependencies": {
     "@ar.io/solana-contracts": "0.7.0-staging.17",
+    "@noble/hashes": "^1.8.0",
     "@solana-program/address-lookup-table": "^0.11.0",
     "@solana-program/compute-budget": "^0.15.0",
     "@solana-program/token": "^0.13.0",

--- a/src/solana/canonical-message.test.ts
+++ b/src/solana/canonical-message.test.ts
@@ -7,7 +7,26 @@ import {
   bytesToHexLower,
   canonicalMessage,
   canonicalMessageV2,
+  deriveRecipientId,
 } from './canonical-message.js';
+
+// Stable "Arweave-shaped" recipient bytes shared with the Rust canonical tests
+// (`TEST_RECIPIENT_AB512` in canonical.rs): 512 bytes of 0xAB. The builder only
+// hashes them, so the exact content is irrelevant — only the derived id matters.
+const RECIPIENT = new Uint8Array(512).fill(0xab);
+// base64url(sha256(RECIPIENT)), no padding — must match the Rust
+// `derive_recipient_id_b64url(TEST_RECIPIENT_AB512)`.
+const RECIPIENT_ID = 'hHx6v09k4T8WQVZDGCYNaxNPodBlgwvSYKfMABJ0TDE';
+
+describe('deriveRecipientId', () => {
+  it('matches the Rust derive_recipient_id_b64url for 512×0xAB', () => {
+    assert.equal(deriveRecipientId(RECIPIENT), RECIPIENT_ID);
+    assert.equal(RECIPIENT_ID.length, 43); // 32-byte hash → 43 b64url chars, no pad
+  });
+  it('rejects empty recipient bytes', () => {
+    assert.throws(() => deriveRecipientId(new Uint8Array()), /non-empty/);
+  });
+});
 
 describe('canonical message', () => {
   const ant = address('9PnRFwk2Yp7QyU3sQzXwUhJj6tVyM4nN2KqL5fT8RbAW');
@@ -23,15 +42,17 @@ describe('canonical message', () => {
       network: 'solana-mainnet',
       antMint: ant,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     const text = new TextDecoder().decode(out);
     // Must match Rust `canonical_message_matches_design_doc_example` test
-    // and docs/ANT_ESCROW_DESIGN.md § Canonical message format.
+    // (ario-ant-escrow/src/canonical.rs) and docs/ANT_ESCROW_DESIGN.md.
     assert.equal(
       text,
-      'ar.io ant-escrow claim v1\n' +
+      'ar.io ant-escrow claim\n' +
         'network: solana-mainnet\n' +
+        `recipient: ${RECIPIENT_ID}\n` +
         'ant: 9PnRFwk2Yp7QyU3sQzXwUhJj6tVyM4nN2KqL5fT8RbAW\n' +
         'claimant: Hk6RfBp4FpvF2hYBmJ9kqyL5dE3xR8wPzN7sV6cTqL2A\n' +
         'nonce: a3f1c8d92e0b4f7a8e1d6c5b4a3920817f6e5d4c3b2a19188776655443322110',
@@ -43,6 +64,7 @@ describe('canonical message', () => {
       network: 'solana-mainnet',
       antMint: ant,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     assert.notEqual(out[out.length - 1], 0x0a);
@@ -55,6 +77,7 @@ describe('canonical message', () => {
           network: 'solana-mainnet',
           antMint: ant,
           claimant,
+          recipient: RECIPIENT,
           nonce: new Uint8Array(31),
         }),
       /32 bytes/,
@@ -66,15 +89,26 @@ describe('canonical message', () => {
       network: 'solana-mainnet',
       antMint: ant,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     const otherNetwork = canonicalMessage({
       network: 'solana-devnet',
       antMint: ant,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     assert.notDeepEqual(otherNetwork, base);
+
+    const otherRecipient = canonicalMessage({
+      network: 'solana-mainnet',
+      antMint: ant,
+      claimant,
+      recipient: new Uint8Array(512).fill(0xcd),
+      nonce,
+    });
+    assert.notDeepEqual(otherRecipient, base);
 
     const otherNonce = new Uint8Array(nonce);
     otherNonce[0] ^= 0x01;
@@ -82,6 +116,7 @@ describe('canonical message', () => {
       network: 'solana-mainnet',
       antMint: ant,
       claimant,
+      recipient: RECIPIENT,
       nonce: otherNonce,
     });
     assert.notDeepEqual(tweakedNonce, base);
@@ -104,13 +139,15 @@ describe('canonical message v2', () => {
       assetId,
       amount: 500_000_000n,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     const text = new TextDecoder().decode(out);
     assert.equal(
       text,
-      'ar.io escrow claim v2\n' +
+      'ar.io escrow claim\n' +
         'network: solana-mainnet\n' +
+        `recipient: ${RECIPIENT_ID}\n` +
         'type: token\n' +
         'asset: abababababababababababababababababababababababababababababababab\n' +
         'amount: 500000000\n' +
@@ -126,6 +163,7 @@ describe('canonical message v2', () => {
       assetId,
       amount: 100n,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     assert.notEqual(out[out.length - 1], 0x0a);
@@ -140,6 +178,7 @@ describe('canonical message v2', () => {
           assetId: new Uint8Array(31),
           amount: 100n,
           claimant,
+          recipient: RECIPIENT,
           nonce,
         }),
       /32 bytes/,
@@ -155,6 +194,7 @@ describe('canonical message v2', () => {
           assetId,
           amount: 100n,
           claimant,
+          recipient: RECIPIENT,
           nonce: new Uint8Array(31),
         }),
       /32 bytes/,
@@ -168,6 +208,7 @@ describe('canonical message v2', () => {
       assetId,
       amount: 100n,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     const vault = canonicalMessageV2({
@@ -176,9 +217,32 @@ describe('canonical message v2', () => {
       assetId,
       amount: 100n,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     assert.notDeepEqual(token, vault);
+  });
+
+  it('changes with recipient', () => {
+    const base = canonicalMessageV2({
+      network: 'solana-mainnet',
+      assetType: 'token',
+      assetId,
+      amount: 100n,
+      claimant,
+      recipient: RECIPIENT,
+      nonce,
+    });
+    const other = canonicalMessageV2({
+      network: 'solana-mainnet',
+      assetType: 'token',
+      assetId,
+      amount: 100n,
+      claimant,
+      recipient: new Uint8Array(20).fill(0x11), // ETH-shaped, different id
+      nonce,
+    });
+    assert.notDeepEqual(base, other);
   });
 
   it('changes with asset id', () => {
@@ -188,6 +252,7 @@ describe('canonical message v2', () => {
       assetId,
       amount: 100n,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     const other = canonicalMessageV2({
@@ -196,6 +261,7 @@ describe('canonical message v2', () => {
       assetId: new Uint8Array(32).fill(0xcd),
       amount: 100n,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     assert.notDeepEqual(base, other);
@@ -208,6 +274,7 @@ describe('canonical message v2', () => {
       assetId,
       amount: 100n,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     const other = canonicalMessageV2({
@@ -216,6 +283,7 @@ describe('canonical message v2', () => {
       assetId,
       amount: 200n,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     assert.notDeepEqual(base, other);
@@ -228,6 +296,7 @@ describe('canonical message v2', () => {
       assetId,
       amount: 100n,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     const devnet = canonicalMessageV2({
@@ -236,6 +305,7 @@ describe('canonical message v2', () => {
       assetId,
       amount: 100n,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     assert.notDeepEqual(mainnet, devnet);
@@ -248,6 +318,7 @@ describe('canonical message v2', () => {
       assetId,
       amount: 100n,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     });
     const otherNonce = new Uint8Array(nonce);
@@ -258,6 +329,7 @@ describe('canonical message v2', () => {
       assetId,
       amount: 100n,
       claimant,
+      recipient: RECIPIENT,
       nonce: otherNonce,
     });
     assert.notDeepEqual(base, other);
@@ -270,6 +342,7 @@ describe('canonical message v2', () => {
       assetId,
       amount: 1_000_000n,
       claimant,
+      recipient: RECIPIENT,
       nonce,
     };
     const a = canonicalMessageV2(input);
@@ -277,19 +350,21 @@ describe('canonical message v2', () => {
     assert.deepEqual(a, b);
   });
 
-  it('matches the Rust v2_format_structure test', () => {
+  it('matches the Rust v2 format structure', () => {
     const out = canonicalMessageV2({
       network: 'solana-mainnet',
       assetType: 'token',
       assetId: new Uint8Array(32).fill(0xab),
       amount: 500_000_000n,
       claimant: address('Hk6RfBp4FpvF2hYBmJ9kqyL5dE3xR8wPzN7sV6cTqL2A'),
+      recipient: RECIPIENT,
       nonce: new Uint8Array(32).fill(0xcd),
     });
     const text = new TextDecoder().decode(out);
 
-    assert.ok(text.startsWith('ar.io escrow claim v2\n'));
+    assert.ok(text.startsWith('ar.io escrow claim\n'));
     assert.ok(text.includes('network: '));
+    assert.ok(text.includes(`\nrecipient: ${RECIPIENT_ID}\n`));
     assert.ok(text.includes('\ntype: token\n'));
     assert.ok(
       text.includes(

--- a/src/solana/canonical-message.ts
+++ b/src/solana/canonical-message.ts
@@ -18,15 +18,18 @@
  *
  * Produces the EXACT bytes a recipient signs to release an escrowed
  * ANT. Output MUST be byte-identical to the Rust implementation in
- * `contracts/programs/ario-ant-escrow/src/canonical.rs::build_canonical_message`.
- * Cross-language equivalence is asserted by `canonical-message.test.ts`
- * which spawns the Rust `canonical` example binary and diffs the bytes.
+ * `ario-ant-escrow/src/canonical.rs::build_ant_escrow_claim_message`
+ * (header `ANT_ESCROW_CLAIM_HEADER = "ar.io ant-escrow claim"`). The on-chain
+ * program reconstructs these exact bytes and verifies the signature against
+ * them, so any drift (header, field set, or ordering) makes every claim fail
+ * `EthereumAddressMismatch` / signature verification.
  *
  * Format (UTF-8, line-feed separated, no trailing newline):
  *
  * ```text
- * ar.io ant-escrow claim v1
+ * ar.io ant-escrow claim
  * network: <network>
+ * recipient: <base64url(sha256(recipient_pubkey)) — 43 chars, no pad>
  * ant: <ant_mint_base58>
  * claimant: <claimant_solana_pubkey_base58>
  * nonce: <nonce_hex_lowercase>
@@ -38,6 +41,7 @@
  *   (the wallet applies the EIP-191 prefix; on-chain code re-applies it).
  */
 
+import { sha256 } from '@noble/hashes/sha256';
 import type { Address } from '@solana/kit';
 
 /** Network bound into the canonical message at compile-time on the Rust
@@ -53,12 +57,18 @@ export interface CanonicalMessageInput {
   /** Solana pubkey that will receive the ANT on claim. Bound into the
    *  signature so front-runners can't redirect. */
   claimant: Address;
+  /** Recipient identity pubkey bytes the deposit targeted (ETH 20-byte
+   *  address, Solana 32-byte pubkey, or Arweave RSA modulus). Bound into the
+   *  message as `recipient: base64url(sha256(bytes))` to match the contract's
+   *  `derive_recipient_id_b64url`. REQUIRED — the program reconstructs this
+   *  line, so omitting it makes the claim mismatch. */
+  recipient: Uint8Array;
   /** 32-byte anti-replay nonce — read from the EscrowAnt account. */
   nonce: Uint8Array;
 }
 
-/** Header literal — must match Rust `CANONICAL_HEADER`. */
-const CANONICAL_HEADER = 'ar.io ant-escrow claim v1';
+/** Header literal — must match Rust `ANT_ESCROW_CLAIM_HEADER`. */
+const CANONICAL_HEADER = 'ar.io ant-escrow claim';
 
 /**
  * Build the canonical claim message bytes. UTF-8 encoded, no trailing
@@ -77,6 +87,7 @@ export function canonicalMessage(input: CanonicalMessageInput): Uint8Array {
   const text =
     `${CANONICAL_HEADER}\n` +
     `network: ${input.network}\n` +
+    `recipient: ${deriveRecipientId(input.recipient)}\n` +
     `ant: ${input.antMint}\n` +
     `claimant: ${input.claimant}\n` +
     `nonce: ${bytesToHexLower(input.nonce)}`;
@@ -99,12 +110,18 @@ export interface CanonicalMessageV2Input {
   amount: bigint;
   /** Solana pubkey that will receive the tokens on claim. */
   claimant: Address;
+  /** Recipient identity pubkey bytes the deposit targeted (ETH 20-byte
+   *  address, Solana 32-byte pubkey, or Arweave RSA modulus). Bound into the
+   *  message as `recipient: base64url(sha256(bytes))` to match the contract's
+   *  `derive_recipient_id_b64url`. REQUIRED — the program reconstructs this
+   *  line, so omitting it makes the claim mismatch. */
+  recipient: Uint8Array;
   /** 32-byte anti-replay nonce — read from the EscrowToken account. */
   nonce: Uint8Array;
 }
 
-/** Header literal — must match Rust `CANONICAL_HEADER_V2`. */
-const CANONICAL_HEADER_V2 = 'ar.io escrow claim v2';
+/** Header literal — must match Rust `ESCROW_CLAIM_HEADER`. */
+const CANONICAL_HEADER_V2 = 'ar.io escrow claim';
 
 /**
  * Build the v2 canonical claim message bytes for token/vault escrows.
@@ -112,8 +129,9 @@ const CANONICAL_HEADER_V2 = 'ar.io escrow claim v2';
  *
  * Format:
  * ```text
- * ar.io escrow claim v2
+ * ar.io escrow claim
  * network: <network>
+ * recipient: <base64url(sha256(recipient_pubkey)) — 43 chars, no pad>
  * type: <token|vault>
  * asset: <asset_id_hex_lowercase_64chars>
  * amount: <u64_decimal>
@@ -138,6 +156,7 @@ export function canonicalMessageV2(input: CanonicalMessageV2Input): Uint8Array {
   const text =
     `${CANONICAL_HEADER_V2}\n` +
     `network: ${input.network}\n` +
+    `recipient: ${deriveRecipientId(input.recipient)}\n` +
     `type: ${input.assetType}\n` +
     `asset: ${bytesToHexLower(input.assetId)}\n` +
     `amount: ${input.amount.toString()}\n` +
@@ -150,6 +169,21 @@ export function canonicalMessageV2(input: CanonicalMessageV2Input): Uint8Array {
 // =========================================
 // Shared utilities
 // =========================================
+
+/**
+ * Recipient identity bound into the claim message — `base64url(sha256(bytes))`
+ * with no padding (32-byte hash → 43 chars). Byte-identical to the contract's
+ * `canonical.rs::derive_recipient_id_b64url`. Input is the recipient pubkey
+ * bytes the deposit targeted (ETH 20-byte address / Solana 32-byte pubkey /
+ * Arweave RSA modulus, etc.).
+ */
+export function deriveRecipientId(recipient: Uint8Array): string {
+  if (recipient.length === 0) {
+    throw new Error('deriveRecipientId: recipient bytes must be non-empty');
+  }
+  // Node's 'base64url' encoding is unpadded — matches the Rust no-pad alphabet.
+  return Buffer.from(sha256(recipient)).toString('base64url');
+}
 
 /** Lowercase-hex encoding. Matches Rust `encode_hex_lowercase`. */
 export function bytesToHexLower(bytes: Uint8Array): string {

--- a/src/solana/index.ts
+++ b/src/solana/index.ts
@@ -133,6 +133,7 @@ export type {
 export {
   canonicalMessage,
   canonicalMessageV2,
+  deriveRecipientId,
   bytesToHexLower,
 } from './canonical-message.js';
 export type {

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,7 +698,7 @@
   resolved "https://registry.yarnpkg.com/@jspm/core/-/core-2.1.0.tgz#ee21ff64591d68de98b79ca8e4bd6c5249fded53"
   integrity sha512-3sRl+pkyFY/kLmHl0cgHiFp2xEqErA8N3ECjMs7serSUBmoJ70lBa0PG5t0IM6WJgdZNyyI0R8YFfi5wM8+mzg==
 
-"@noble/hashes@^1.5.0":
+"@noble/hashes@^1.5.0", "@noble/hashes@^1.8.0":
   version "1.8.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==


### PR DESCRIPTION
The SDK's `canonicalMessage` / `canonicalMessageV2` had drifted from the deployed `ario-ant-escrow` contract, so every **direct-sign** escrow claim (`claim_*_ethereum`, direct Arweave) fails `EthereumAddressMismatch` / signature verification. **Confirmed live on staging-v2** (token ETH claim → error `6010`).

## Root cause — three drifts from `canonical.rs`
The on-chain program reconstructs the exact signed bytes; the SDK's were wrong in three ways (all enshrined by a TS-only test with no real Rust cross-check):

| | SDK (was) | Contract (correct) |
|---|---|---|
| v1 header | `ar.io ant-escrow claim v1` | `ar.io ant-escrow claim` |
| v2 header | `ar.io escrow claim v2` | `ar.io escrow claim` |
| `recipient:` line | *absent* | `recipient: base64url(sha256(recipientBytes))` after `network:` |

## Fix (byte-identical to the contract)
- Correct both headers.
- Both builders now emit `recipient: <base64url(sha256(recipientBytes)), no-pad, 43 chars>` — matching `derive_recipient_id_b64url`. `recipient: Uint8Array` (the deposit's recipient pubkey — ETH 20-byte / Solana 32-byte / Arweave RSA modulus) is now a **required** input on `CanonicalMessageInput` + `CanonicalMessageV2Input`.
- New exported `deriveRecipientId(bytes)` helper.
- Adds `@noble/hashes` (browser-safe sync sha256; `canonical-message.ts` is consumed in-browser by the escrow app).

## Tests
Rewrote `canonical-message.test.ts` against the **Rust test vectors** (recipient = 512×0xAB → `hHx6v09k4T8WQVZDGCYNaxNPodBlgwvSYKfMABJ0TDE`), with byte-exact expected strings for both v1 and v2 + a `deriveRecipientId` vector. **341/341 unit tests pass; tsc + biome clean.**

## Notes
- Attested (Arweave) claims were unaffected — the off-chain attestor builds the message and already matched the contract; only the SDK's direct-sign path was broken.
- **Breaking** for callers of `canonicalMessage*` (must now pass `recipient`) — correct, since omitting it produced invalid signatures. Downstream: the escrow app + `migration/import/e2e-smoke.ts` need the recipient threaded through after this releases.
- Root-caused from `ar-io/solana-ar-io` ISSUES.md (escrow ETH-claim entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)