### PR TITLE
fix(solana): add tenure and performance checks to gateway operator discount

### DIFF
--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -1811,14 +1811,31 @@ export class SolanaARIOReadable {
         if (gwAccount.exists) {
           const gw = deserializeGateway(Buffer.from(gwAccount.data));
           if (gw.status === 'joined') {
-            const discountAmount = Math.floor(
-              (tokenCost * 200_000) / RATE_SCALE,
-            );
-            discounts.push({
-              name: 'Gateway Operator',
-              discountTotal: discountAmount,
-              multiplier: 0.8,
-            });
+            // Match on-chain eligibility from ario-arns pricing.rs
+            // `try_apply_gateway_discount`:
+            // 1. Tenure: gateway running >= 180 days (15_552_000 seconds)
+            const GATEWAY_DISCOUNT_MIN_TENURE_S = 15_552_000;
+            const nowSeconds = Math.floor(Date.now() / 1000);
+            const timeRunning = nowSeconds - gw.startTimestamp;
+            // 2. Performance: >= 90% epoch pass rate
+            const passRate =
+              ((1 + gw.stats.passedEpochCount) /
+                (1 + gw.stats.totalEpochCount)) *
+              1_000_000;
+
+            if (
+              timeRunning >= GATEWAY_DISCOUNT_MIN_TENURE_S &&
+              passRate >= 900_000
+            ) {
+              const discountAmount = Math.floor(
+                (tokenCost * 200_000) / RATE_SCALE,
+              );
+              discounts.push({
+                name: 'Gateway Operator',
+                discountTotal: discountAmount,
+                multiplier: 0.8,
+              });
+            }
           }
         }
       } catch {


### PR DESCRIPTION
## Summary

`getCostDetails` was applying the 20% gateway operator discount to any wallet with a gateway in `joined` status, without checking tenure or epoch performance. The on-chain contract (`ario-arns/pricing.rs::try_apply_gateway_discount`) enforces two additional requirements that the SDK was skipping:

1. **Tenure**: gateway must have been running >= 180 days (`15,552,000` seconds)
2. **Performance**: >= 90% epoch pass rate (`(1 + passedEpochCount) / (1 + totalEpochCount) >= 0.9`)

This caused the frontend to show discounted prices for recently-joined gateways that would be rejected at transaction time on-chain.

## Changes

- `src/solana/io-readable.ts`: Added tenure and performance eligibility checks inside `getCostDetails` before applying the gateway operator discount, matching the contract logic exactly.

## Test plan

- [ ] Gateway joined < 180 days ago — verify no discount shown in `getCostDetails`
- [ ] Gateway joined >= 180 days ago with >= 90% pass rate — verify 20% discount applied
- [ ] Gateway joined >= 180 days ago with < 90% pass rate — verify no discount
- [ ] Non-gateway wallet — verify no discount (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)