### PR TITLE
feat(crank): prune expired returned names inside crankEpochStep

### DIFF
--- a/src/solana/crank-epoch-step.test.ts
+++ b/src/solana/crank-epoch-step.test.ts
@@ -140,6 +140,24 @@ class TestCranker extends SolanaARIOWriteable {
     this.calls.push('updateDemandFactor');
     return { id: 'tx-df' };
   }
+
+  // --- Returned-name prune stubs. Default [] makes the prune step a no-op so
+  // the lifecycle tests above are unaffected. ---
+  expiredReturned: Array<{
+    pubkey: Address;
+    name: string;
+    returnedAt: bigint;
+  }> = [];
+  // biome-ignore lint/suspicious/noExplicitAny: test stubs
+  async getExpiredReturnedNames(): Promise<any> {
+    this.calls.push('getExpiredReturned');
+    return this.expiredReturned;
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: test stubs
+  async pruneReturnedNames(p: any): Promise<any> {
+    this.calls.push(`pruneReturned:${p.returnedNames.length}`);
+    return { id: 'tx-prune-returned' };
+  }
 }
 
 const baseSettings: Settings = {
@@ -417,5 +435,109 @@ describe('crankEpochStep', () => {
     assert.equal(r.action, 'compound');
     assert.ok(!c.calls.includes('updateDemandFactor'));
     assert.ok(!c.calls.includes('createEpoch'));
+  });
+});
+
+describe('crankEpochStep — returned-name pruning', () => {
+  const expired = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      pubkey: pk(20 + i),
+      name: `name${i}`,
+      returnedAt: 0n,
+    }));
+
+  // Live epoch parked in the observation window (now < endTimestamp), rewards
+  // not yet distributed — the dominant idle state where staging epochs sit.
+  const liveWaiting = (c: TestCranker) => {
+    c.settings = { ...baseSettings };
+    c.epochs[0] = { ...liveEpoch, rewardsDistributed: 0, endTimestamp: 9999 };
+  };
+
+  it('prunes expired returned names during the observation window', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.expiredReturned = expired(3);
+    const r = await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
+    assert.equal(r.action, 'prune_returned_names');
+    assert.equal(r.txId, 'tx-prune-returned');
+    assert.deepEqual(r.progress, { index: 3, total: 3 });
+    assert.ok(c.calls.includes('pruneReturned:3'));
+  });
+
+  it('does NOT consult config.next_returned_names_prune_timestamp (scans directly)', async () => {
+    // The harness has no getArnsConfigRaw stub; if the step tried to gate on the
+    // config timestamp it would blow up. Reaching prune proves it scans direct.
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.expiredReturned = expired(1);
+    const r = await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
+    assert.equal(r.action, 'prune_returned_names');
+  });
+
+  it('caps the prune batch at pruneBatchSize and reports total', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.expiredReturned = expired(20);
+    const r = await c.crankEpochStep({
+      now: 5000,
+      pruneScanIntervalMs: 0,
+      pruneBatchSize: 5,
+    });
+    assert.equal(r.action, 'prune_returned_names');
+    assert.deepEqual(r.progress, { index: 5, total: 20 });
+    assert.ok(c.calls.includes('pruneReturned:5'));
+  });
+
+  it('idles waiting_for_observations when nothing is expired', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.expiredReturned = [];
+    const r = await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
+    assert.equal(r.action, 'idle');
+    assert.equal(r.reason, 'waiting_for_observations');
+  });
+
+  it('enablePrune:false skips pruning even with expired names', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.expiredReturned = expired(3);
+    const r = await c.crankEpochStep({
+      now: 5000,
+      pruneScanIntervalMs: 0,
+      enablePrune: false,
+    });
+    assert.equal(r.action, 'idle');
+    assert.equal(r.reason, 'waiting_for_observations');
+    assert.ok(!c.calls.some((x) => x.startsWith('pruneReturned')));
+  });
+
+  it('throttles the scan by pruneScanIntervalMs (no re-scan within the window)', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.expiredReturned = expired(3);
+    const r1 = await c.crankEpochStep({ now: 5000 }); // default 60s; first call scans
+    assert.equal(r1.action, 'prune_returned_names');
+    const scansAfterFirst = c.calls.filter(
+      (x) => x === 'getExpiredReturned',
+    ).length;
+    const r2 = await c.crankEpochStep({ now: 5000 }); // immediate → throttled
+    assert.equal(r2.action, 'idle');
+    assert.equal(r2.reason, 'waiting_for_observations');
+    assert.equal(
+      c.calls.filter((x) => x === 'getExpiredReturned').length,
+      scansAfterFirst,
+      'second call within the throttle window must not re-scan',
+    );
+  });
+
+  it('prunes in the post-distribution tail (obs window passed, next epoch not started)', async () => {
+    const c = new TestCranker();
+    c.settings = { ...baseSettings, currentEpochIndex: 1 };
+    c.epochs[0] = { ...liveEpoch, endTimestamp: 1000 }; // fully distributed
+    c.expiredReturned = expired(2);
+    // now >= endTimestamp(1000) → past obs; now < nextEpochStart(1100) → no create.
+    const r = await c.crankEpochStep({ now: 1050, pruneScanIntervalMs: 0 });
+    assert.equal(r.action, 'prune_returned_names');
+    assert.deepEqual(r.progress, { index: 2, total: 2 });
   });
 });

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -455,6 +455,7 @@ export type CrankAction =
   | 'distribute'
   | 'compound'
   | 'update_demand_factor'
+  | 'prune_returned_names'
   | 'close'
   | 'idle';
 
@@ -493,6 +494,24 @@ export interface CrankEpochStepOptions {
    * between buys) current. Default true. Runs only in the idle tail.
    */
   enableDemandFactorRoll?: boolean;
+  /**
+   * Prune expired ReturnedName PDAs (auction window elapsed) as part of the
+   * crank. Default true. Runs whenever the epoch lifecycle is otherwise idle
+   * (the live observation window AND the post-distribution tail), one batch per
+   * step. It scans the ReturnedName PDAs DIRECTLY (via getExpiredReturnedNames)
+   * and does NOT consult `config.next_returned_names_prune_timestamp` — that
+   * hint is only set for on-chain returns and is never updated for imported
+   * returned names, so trusting it strands imported auctions forever.
+   */
+  enablePrune?: boolean;
+  /** ReturnedName PDAs to prune per tx (u8, max 255). Default 15. */
+  pruneBatchSize?: number;
+  /**
+   * Minimum wall-clock gap between returned-name prune SCANS (ms). The scan is a
+   * `getProgramAccounts` over ReturnedName PDAs, so this throttles it below the
+   * crank poll rate. Default 60_000 (1 min). Set 0 to scan every step (tests).
+   */
+  pruneScanIntervalMs?: number;
   /** Unix seconds; defaults to the wall clock. Injectable for testing. */
   now?: number;
 }
@@ -4077,6 +4096,7 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     const enableCompound = opts.enableCompound ?? true;
     const compoundMinPending = opts.compoundMinPendingRewards ?? 0;
     const enableDemandFactorRoll = opts.enableDemandFactorRoll ?? true;
+    const enablePrune = opts.enablePrune ?? true;
     const now = opts.now ?? Math.floor(Date.now() / 1000);
 
     const settings = await this.getEpochSettingsFull();
@@ -4143,9 +4163,18 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       return { action: 'prescribe', epochIndex: targetEpochIndex, txId: id };
     }
 
-    // Observations happen while the epoch is live.
-    if (now < epoch.endTimestamp)
+    // Observations happen while the epoch is live. This is the dominant idle
+    // window — fold returned-name pruning in here so it isn't starved on
+    // clusters whose epochs park here (e.g. imported gateways that can't
+    // observe → distribution never advances → the post-distribution tail below
+    // is never reached).
+    if (now < epoch.endTimestamp) {
+      if (enablePrune) {
+        const pruned = await this.maybePruneReturnedNamesStep(opts, now);
+        if (pruned) return pruned;
+      }
       return { action: 'idle', reason: 'waiting_for_observations' };
+    }
 
     // Distribute (batched).
     if (epoch.rewardsDistributed === 0) {
@@ -4194,6 +4223,10 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     if (enableDemandFactorRoll) {
       const rolled = await this.maybeRollDemandFactorStep(now);
       if (rolled) return rolled;
+    }
+    if (enablePrune) {
+      const pruned = await this.maybePruneReturnedNamesStep(opts, now);
+      if (pruned) return pruned;
     }
 
     // Current epoch fully processed — create the next once its start arrives.
@@ -4244,6 +4277,43 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     if (periodForNow <= state.currentPeriod) return null; // same period — no-op
     const { id } = await this.updateDemandFactor();
     return { action: 'update_demand_factor', txId: id };
+  }
+
+  /** Wall-clock (ms) of the last returned-name prune scan; throttles the
+   *  getProgramAccounts scan below the crank poll rate. */
+  private lastReturnedNamePruneScanMs = 0;
+
+  /**
+   * One prune batch over ReturnedName PDAs whose 14-day auction window has
+   * elapsed (≤ {@link CrankEpochStepOptions.pruneBatchSize} per tx), or `null`
+   * when none are due / the scan is throttled. Scans the PDAs directly — it does
+   * NOT gate on `config.next_returned_names_prune_timestamp`, which is never set
+   * for imported returned names and would strand them. The contract re-checks
+   * each account's window, so a slightly-skewed client clock is safe.
+   */
+  private async maybePruneReturnedNamesStep(
+    opts: CrankEpochStepOptions,
+    now: number,
+  ): Promise<CrankEpochStepResult | null> {
+    const scanInterval = opts.pruneScanIntervalMs ?? 60_000;
+    const wallNow = Date.now();
+    if (wallNow - this.lastReturnedNamePruneScanMs < scanInterval) return null;
+    this.lastReturnedNamePruneScanMs = wallNow;
+
+    const expired = await this.getExpiredReturnedNames(now);
+    if (expired.length === 0) return null;
+
+    const batchSize = opts.pruneBatchSize ?? 15;
+    const batch = expired.slice(0, batchSize).map((r) => r.pubkey);
+    const { id } = await this.pruneReturnedNames({
+      maxNames: batch.length,
+      returnedNames: batch,
+    });
+    return {
+      action: 'prune_returned_names',
+      txId: id,
+      progress: { index: batch.length, total: expired.length },
+    };
   }
 
   /**


### PR DESCRIPTION
Folds returned-name pruning into `crankEpochStep` so both the observer and standalone crankers get it for free — and fixes the bug that strands imported returned names forever.

## The bug
Returned-name pruning was only done by each cranker's hand-rolled `runCleanup`, gated on `config.next_returned_names_prune_timestamp`. That hint is only lowered by **on-chain** `release_name` / `prune_name_to_returned`; it's **never set for imported returned names** (migration writes the `ReturnedName` PDAs directly), and `prune_returned_names` never recomputes it. So it sits far in the future while imported auctions are already expired — stranding them.

**Confirmed on staging-v2:** gate = `2026-06-17`, with **22 expired `ReturnedName` PDAs due now** that `getExpiredReturnedNames(now)` already finds.

## The fix
- New `prune_returned_names` `CrankAction`; options `enablePrune` (default true), `pruneBatchSize` (15), `pruneScanIntervalMs` (60s scan throttle).
- Runs at the **two idle exits** — the `waiting_for_observations` window **and** the post-distribution tail — so it isn't starved on clusters whose epochs park at `waiting_for_observations` (imported gateways can't observe → distribution never advances → the tail is never reached). Never competes with the lifecycle (create/tally/prescribe/distribute/close all return first).
- Scans `ReturnedName` PDAs **directly** via `getExpiredReturnedNames` — **no config-timestamp gate**. The contract re-checks each account's 14-day window, so a skewed client clock is safe.

## Tests
7 new cases (prune during obs window, batch cap, no-config-gate, enablePrune:false, throttle, tail prune, no-op when none). **348/348 unit pass; tsc + lint clean.**

## Rollout
After release, the observer (+ standalone cranker) bump the SDK and **delete their hand-rolled returned-names cleanup phase** (crankEpochStep owns it now). Then deploy the observer to staging-v2 and watch the 22 prune off the list. (Records/gateway cleanup stay cranker-side for now — a later pass can pull those in too.)

Root-caused from `solana-ar-io` (returned-name pruning blocked on staging-v2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)