### PR TITLE
feat(crank): close epoch observations before close_epoch (un-wedge progression)

### DIFF
--- a/src/solana/crank-epoch-step.test.ts
+++ b/src/solana/crank-epoch-step.test.ts
@@ -36,6 +36,8 @@ type EpochRaw = {
   weightsTallied: number;
   prescriptionsDone: number;
   rewardsDistributed: number;
+  observationsSubmitted: number;
+  observationsClosed: number;
   activeGatewayCount: number;
   endTimestamp: number;
 };
@@ -94,9 +96,22 @@ class TestCranker extends SolanaARIOWriteable {
     return { id: 'tx-distribute' };
   }
   // biome-ignore lint/suspicious/noExplicitAny: test stubs
+  closeEpochError: Error | null = null;
   async closeEpoch(p: any): Promise<any> {
     this.calls.push(`close:${p.epochIndex}`);
+    if (this.closeEpochError) throw this.closeEpochError;
     return { id: 'tx-close' };
+  }
+  // Observation-close stubs — close_observations must run before close_epoch.
+  epochObservers: Record<number, Address[]> = {};
+  async getEpochObservers(i: number): Promise<Address[]> {
+    this.calls.push(`getEpochObservers:${i}`);
+    return this.epochObservers[i] ?? [];
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: test stubs
+  async closeObservations(p: any): Promise<any> {
+    this.calls.push(`closeObservations:${p.epochIndex}:${p.observers.length}`);
+    return { id: 'tx-close-obs' };
   }
   // biome-ignore lint/suspicious/noExplicitAny: test stubs
   async prescribeEpoch(p: any): Promise<any> {
@@ -173,6 +188,8 @@ const liveEpoch: EpochRaw = {
   weightsTallied: 1,
   prescriptionsDone: 1,
   rewardsDistributed: 1,
+  observationsSubmitted: 0,
+  observationsClosed: 0,
   activeGatewayCount: 10,
   endTimestamp: 1090,
 };
@@ -539,5 +556,69 @@ describe('crankEpochStep — returned-name pruning', () => {
     const r = await c.crankEpochStep({ now: 1050, pruneScanIntervalMs: 0 });
     assert.equal(r.action, 'prune_returned_names');
     assert.deepEqual(r.progress, { index: 2, total: 2 });
+  });
+});
+
+describe('crankEpochStep — close observations before close_epoch', () => {
+  // currentEpochIndex 10 → live target 9, retention 7 → closeTarget 2.
+  // nextEpochStart = genesis(1000) + 10*duration(100) = 2000.
+  const setup = (c: TestCranker, closeTargetEpoch: Partial<EpochRaw>) => {
+    c.settings = { ...baseSettings, currentEpochIndex: 10 };
+    c.epochs[9] = { ...liveEpoch, endTimestamp: 1000 };
+    c.epochs[2] = { ...liveEpoch, ...closeTargetEpoch };
+  };
+
+  it('closes observations (not the epoch) when the retention target has open observations', async () => {
+    const c = new TestCranker();
+    setup(c, { observationsSubmitted: 3, observationsClosed: 0 });
+    c.epochObservers[2] = [pk(1), pk(2), pk(3)];
+    const r = await c.crankEpochStep({ now: 1900, epochRetention: 7 });
+    assert.equal(r.action, 'close_observation');
+    assert.equal(r.epochIndex, 2);
+    assert.deepEqual(r.progress, { index: 3, total: 3 });
+    assert.ok(c.calls.includes('closeObservations:2:3'));
+    assert.ok(
+      !c.calls.some((x) => x.startsWith('close:')),
+      'must NOT call close_epoch while observations are open',
+    );
+  });
+
+  it('caps the observation-close batch at 8', async () => {
+    const c = new TestCranker();
+    setup(c, { observationsSubmitted: 20, observationsClosed: 0 });
+    c.epochObservers[2] = Array.from({ length: 20 }, (_, i) => pk(i + 1));
+    const r = await c.crankEpochStep({ now: 1900, epochRetention: 7 });
+    assert.equal(r.action, 'close_observation');
+    assert.deepEqual(r.progress, { index: 8, total: 20 });
+    assert.ok(c.calls.includes('closeObservations:2:8'));
+  });
+
+  it('closes the epoch once observations are fully closed', async () => {
+    const c = new TestCranker();
+    setup(c, { observationsSubmitted: 3, observationsClosed: 3 });
+    const r = await c.crankEpochStep({ now: 1900, epochRetention: 7 });
+    assert.equal(r.action, 'close');
+    assert.equal(r.epochIndex, 2);
+    assert.ok(!c.calls.some((x) => x.startsWith('closeObservations')));
+  });
+
+  it('does NOT wedge when close_epoch fails — falls through to create-next', async () => {
+    const c = new TestCranker();
+    setup(c, { observationsSubmitted: 0, observationsClosed: 0 });
+    c.closeEpochError = new Error('EpochObservationsNotClosed');
+    // now >= nextEpochStart(2000) → create-next must fire instead of wedging.
+    const r = await c.crankEpochStep({ now: 5000, epochRetention: 7 });
+    assert.equal(r.action, 'create');
+    assert.ok(c.calls.includes('createEpoch'));
+  });
+
+  it('does not wedge on an orphaned observation counter (submitted>closed, no PDAs)', async () => {
+    const c = new TestCranker();
+    setup(c, { observationsSubmitted: 1, observationsClosed: 0 });
+    c.epochObservers[2] = []; // counter says open but no PDA exists to close
+    const r = await c.crankEpochStep({ now: 5000, epochRetention: 7 });
+    assert.notEqual(r.action, 'close_observation');
+    assert.notEqual(r.action, 'close');
+    assert.equal(r.action, 'create'); // progression continues
   });
 });

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -1619,6 +1619,40 @@ export class SolanaARIOReadable {
     return { failureSummaries, reports };
   }
 
+  /**
+   * Observer pubkeys that have an OPEN Observation PDA for `epochIndex`. Lean —
+   * reads only the Observation accounts (no gateway-registry decode like
+   * {@link getObservations}). Used by the crank to close observations before
+   * `close_epoch`, whose `observations_closed == observations_submitted`
+   * precondition would otherwise wedge epoch progression.
+   */
+  async getEpochObservers(epochIndex: number): Promise<Address[]> {
+    const epochIndexBuf = Buffer.alloc(8);
+    epochIndexBuf.writeBigUInt64LE(BigInt(epochIndex));
+    const accounts = await this.getAccountsByDiscriminator(
+      this.garProgram,
+      OBSERVATION_DISCRIMINATOR,
+      [
+        {
+          memcmp: {
+            offset: 8n,
+            bytes: bs58.encode(epochIndexBuf),
+            encoding: 'base58',
+          },
+        },
+      ],
+    );
+    const observers: Address[] = [];
+    for (const { data } of accounts) {
+      try {
+        observers.push(address(deserializeObservation(data).observer));
+      } catch {
+        // skip malformed
+      }
+    }
+    return observers;
+  }
+
   async getDistributions(epoch?: EpochInput): Promise<EpochDistributionData> {
     const epochIndex = await this.resolveEpochIndex(epoch);
     const epochData = await this.fetchEpoch(epochIndex);

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -444,6 +444,9 @@ export function encodeReportTxId(reportTxId: string | undefined): Buffer {
  * the per-tx account/1232-byte budget even when none share a gateway.
  */
 const MAX_COMPOUND_BATCH = 12;
+/** Observation PDAs closed per tx before close_epoch (each ix carries Epoch +
+ *  Observation + payer + system accounts — keep well under the tx account cap). */
+const MAX_CLOSE_OBSERVATION_BATCH = 8;
 /** Demand-factor period length (seconds) — mirrors `PERIOD_LENGTH_SECONDS` in ario-arns. */
 const DEMAND_FACTOR_PERIOD_SECONDS = 86_400;
 
@@ -456,6 +459,7 @@ export type CrankAction =
   | 'compound'
   | 'update_demand_factor'
   | 'prune_returned_names'
+  | 'close_observation'
   | 'close'
   | 'idle';
 
@@ -4215,12 +4219,45 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     }
 
     // Close a fully-distributed epoch past retention (GAR-006).
+    //
+    // CRITICAL: this is cleanup of OLD epochs and must NEVER block creation of
+    // NEW ones. `close_epoch` reverts with EpochObservationsNotClosed until the
+    // epoch's Observation PDAs are closed (observations_closed ==
+    // observations_submitted), so we close those FIRST. The whole branch is
+    // wrapped so any failure falls through to create-next instead of throwing
+    // out of crankEpochStep — otherwise a single un-closeable epoch wedges epoch
+    // progression network-wide (every operator's crank hits the same wall).
     if (enableClose && targetEpochIndex >= retention) {
       const closeTarget = targetEpochIndex - retention;
-      const old = await this.getEpochRaw(closeTarget);
-      if (old && old.rewardsDistributed === 1) {
-        const { id } = await this.closeEpoch({ epochIndex: closeTarget });
-        return { action: 'close', epochIndex: closeTarget, txId: id };
+      try {
+        const old = await this.getEpochRaw(closeTarget);
+        if (old && old.rewardsDistributed === 1) {
+          if (old.observationsSubmitted > old.observationsClosed) {
+            // Open observations remain — close a batch before close_epoch.
+            const observers = await this.getEpochObservers(closeTarget);
+            if (observers.length > 0) {
+              const batch = observers.slice(0, MAX_CLOSE_OBSERVATION_BATCH);
+              const { id } = await this.closeObservations({
+                epochIndex: closeTarget,
+                observers: batch,
+              });
+              return {
+                action: 'close_observation',
+                epochIndex: closeTarget,
+                txId: id,
+                progress: { index: batch.length, total: observers.length },
+              };
+            }
+            // Counter says open but no Observation PDA exists (orphaned counter):
+            // can't close it, so don't attempt close_epoch (it would revert) and
+            // don't wedge — fall through to create-next.
+          } else {
+            const { id } = await this.closeEpoch({ epochIndex: closeTarget });
+            return { action: 'close', epochIndex: closeTarget, txId: id };
+          }
+        }
+      } catch {
+        // Best-effort cleanup — never block epoch creation. Retried next tick.
       }
     }
 
@@ -4361,6 +4398,8 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     weightsTallied: number;
     prescriptionsDone: number;
     rewardsDistributed: number;
+    observationsSubmitted: number;
+    observationsClosed: number;
     activeGatewayCount: number;
     endTimestamp: number;
   } | null> {
@@ -4386,10 +4425,13 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
    *   [8 per_obs][8 reward_rate][8 weight_lo][8 weight_hi][32 hashchain]
    *   [4 active_gw_count][4 dist_idx][4 tally_idx]
    *   [1 observer_count][1 name_count][1 obs_submitted][1 rewards_dist]
-   *   [1 weights_tallied][1 prescriptions_done][1 bump][1 _pad1]
+   *   [1 weights_tallied][1 prescriptions_done][1 bump][1 obs_closed]
    *   [6000 failure_counts][1600 prescribed_observers]
    *   [1600 prescribed_observer_gateways][64 prescribed_names]
    *   [7 has_observed][5 _pad2]
+   *
+   * NOTE: byte +123 is `observations_closed` (NOT padding) — `close_epoch`
+   * reverts with EpochObservationsNotClosed until it equals obs_submitted.
    */
   private fetchEpochRawFields(data: Buffer): {
     tallyIndex: number;
@@ -4397,6 +4439,8 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     weightsTallied: number;
     prescriptionsDone: number;
     rewardsDistributed: number;
+    observationsSubmitted: number;
+    observationsClosed: number;
     activeGatewayCount: number;
     endTimestamp: number;
   } {
@@ -4405,9 +4449,11 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     const activeGatewayCount = data.readUInt32LE(base + 104);
     const distributionIndex = data.readUInt32LE(base + 108);
     const tallyIndex = data.readUInt32LE(base + 112);
+    const observationsSubmitted = data.readUInt8(base + 118);
     const rewardsDistributed = data.readUInt8(base + 119);
     const weightsTallied = data.readUInt8(base + 120);
     const prescriptionsDone = data.readUInt8(base + 121);
+    const observationsClosed = data.readUInt8(base + 123);
 
     return {
       tallyIndex,
@@ -4415,6 +4461,8 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       weightsTallied,
       prescriptionsDone,
       rewardsDistributed,
+      observationsSubmitted,
+      observationsClosed,
       activeGatewayCount,
       endTimestamp,
     };
@@ -4679,6 +4727,42 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     );
 
     const sig = await this.sendTransaction([ix]);
+    return { id: sig };
+  }
+
+  /**
+   * Close multiple Observation PDAs for one epoch in a single tx (each
+   * `close_observation` increments the parent Epoch's `observations_closed`).
+   * Permissionless; rent is refunded to the payer. Used by the crank to satisfy
+   * `close_epoch`'s `observations_closed == observations_submitted` precondition
+   * before closing a retention-aged epoch. Keep the batch small — each ix carries
+   * the Epoch + Observation + payer + system accounts.
+   */
+  async closeObservations(
+    params: { epochIndex: number; observers: string[] },
+    _options?: WriteOptions,
+  ): Promise<MessageResult> {
+    if (params.observers.length === 0) {
+      throw new Error('closeObservations: observers must be non-empty');
+    }
+    const ixs = await Promise.all(
+      params.observers.map(async (obs) => {
+        const [observationPda] = await getObservationPDA(
+          params.epochIndex,
+          address(obs),
+          this.garProgram,
+        );
+        return getCloseObservationInstructionAsync(
+          {
+            observation: observationPda,
+            payer: this.signer,
+            epochIndex: BigInt(params.epochIndex),
+          },
+          { programAddress: this.garProgram },
+        );
+      }),
+    );
+    const sig = await this.sendTransaction(ixs);
     return { id: sig };
   }
 


### PR DESCRIPTION
## The blocker
`crankEpochStep`'s retention close called bare `close_epoch`, which the contract reverts with `EpochObservationsNotClosed` until the epoch's Observation PDAs are closed (`observations_closed == observations_submitted`). The close branch sits **before** create-next and **threw**, so a single un-closeable epoch **wedged epoch creation network-wide**.

**Confirmed on staging-v2:** stuck at epoch 483, ~12 epochs behind wall-clock, the moment observations started landing within the retention window (epoch 476 had `submitted=1, closed=0` + a live Observation PDA). Every operator's cranker hits the same wall. On mainnet — where observations are submitted every epoch — this halts the network as soon as retention reaches the first epoch-with-observations.

## NOT a contract change
The precondition is correct (it prevents orphaned Observation PDAs / stranded rent). Fix is fully client-side:

- **Close observations first**: when the retention target has `observationsSubmitted > observationsClosed`, close its Observation PDAs (new `close_observation` action, batched ≤8/tx via the permissionless `close_observation`), **then** `close_epoch`.
- **Non-wedging**: wrap the whole close branch so any failure falls through to create-next instead of throwing out of `crankEpochStep` — retention cleanup of OLD epochs must never block creation of NEW ones.
- `getEpochRaw` now decodes `observationsSubmitted` (off +118) / `observationsClosed` (off +123 — the layout comment's `_pad1` was wrong).
- New readable `getEpochObservers` (lean Observation-PDA enumerate) + writeable `closeObservations` (batched). `close_observation` **refunds rent → net SOL-positive** (~0.0042 SOL/PDA reclaimed).

## Cost
Per closed epoch: N `close_observation` txs (N = observers that submitted; 1 on staging, up to ~`prescribed_observer_count` ≈ 50 on mainnet), batched ≤8/tx → ~4 txs/epoch worst case, **once per epoch** at retention close. Net SOL-positive (reclaims stranded rent).

## Tests
**353/353 unit pass** (5 new: close-obs-then-close, batch cap, non-wedging on close failure, orphaned-counter passthrough). tsc + lint clean.

Companion rollout: bump + deploy observer (un-sticks staging), then standalone cranker. Each also drops its now-redundant hand-rolled `runCleanup` close-observation phase. Root-caused from `solana-ar-io`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)