### PR TITLE
fix: address CodeRabbit review findings from PR #666

### DIFF
--- a/README.md
+++ b/README.md
@@ -3344,7 +3344,7 @@ import {
 
 | Network | RPC | Programs |
 |---|---|---|
-| Mainnet | not yet deployed | TBD |
+| Mainnet | `https://api.mainnet-beta.solana.com` (mainnet-beta, default) | Not yet deployed — placeholder IDs in `src/solana/constants.ts` |
 | Devnet | `https://api.devnet.solana.com` | See `src/solana/constants.ts` for current devnet program IDs |
 | Localnet | Surfpool — `https://github.com/solana-foundation/surfpool` | Localnet harness in `solana-ar-io` monorepo |
 

--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -23,6 +23,12 @@ const ario = ARIO.init({
   rpc: createSolanaRpc("https://api.devnet.solana.com"),
 });
 
+// The AR.IO faucet backend has not yet been ported to issue Solana-mint
+// transfers (see TODO above), so the "Request 100 tARIO" flow is gated off
+// to avoid routing users into a guaranteed runtime error. Flip to `true`
+// once the faucet backend gains Solana support.
+const FAUCET_AVAILABLE: boolean = false;
+
 function App() {
   const [balance, setBalance] = useState<number | null>(null);
   const [tokenRequestMessage, setTokenRequestMessage] = useState<string | null>(
@@ -181,6 +187,12 @@ function App() {
   };
 
   async function requestTokens() {
+    if (!FAUCET_AVAILABLE) {
+      setTokenRequestMessage(
+        "Faucet is temporarily unavailable: the AR.IO faucet backend is not yet ported to Solana.",
+      );
+      return;
+    }
     try {
       if (localStorage.getItem("ario-jwt")) {
         await ario.faucet
@@ -253,7 +265,7 @@ function App() {
         }}
       >
         <div className="header">
-          <h2>Testnet Faucet Integration</h2>
+          <h2>Devnet Faucet Integration</h2>
         </div>
         <div
           style={{
@@ -286,8 +298,11 @@ function App() {
             }}
           />
 
-          {/* Example of using the testnet faucet to request tokens */}
-          <button onClick={requestTokens} disabled={!selectedAddress}>
+          {/* Example of using the devnet faucet to request tokens */}
+          <button
+            onClick={requestTokens}
+            disabled={!selectedAddress || !FAUCET_AVAILABLE}
+          >
             Request 100 tARIO
           </button>
           {tokenRequestMessage && (
@@ -315,7 +330,7 @@ function App() {
             maxWidth: "500px",
           }}
         >
-          Note: This example uses the AR.IO testnet faucet to request test
+          Note: This example uses the AR.IO devnet faucet to request test
           tokens (tARIO). A captcha verification is required to claim tokens.
         </div>
       </div>

--- a/examples/vite/src/hooks/useArNS.tsx
+++ b/examples/vite/src/hooks/useArNS.tsx
@@ -15,7 +15,10 @@ export const useArNSReturnedNames = ({
   sortOrder: "asc" | "desc";
 }) => {
   const { data, isLoading, error } = useQuery({
-    queryKey: ["ar-ns-returned-names"],
+    queryKey: [
+      "ar-ns-returned-names",
+      { limit, cursor: cursor ?? null, sortBy, sortOrder },
+    ],
     queryFn: () =>
       ario.getArNSReturnedNames({ limit, cursor, sortBy, sortOrder }),
   });
@@ -43,7 +46,10 @@ export const useArNSRecords = ({
   sortOrder: "asc" | "desc";
 }) => {
   const { data, isLoading, error } = useQuery({
-    queryKey: ["ar-ns-records"],
+    queryKey: [
+      "ar-ns-records",
+      { limit, cursor: cursor ?? null, sortBy, sortOrder },
+    ],
     queryFn: () => ario.getArNSRecords({ limit, cursor, sortBy, sortOrder }),
   });
 

--- a/examples/vite/src/hooks/useGatewayRegistry.tsx
+++ b/examples/vite/src/hooks/useGatewayRegistry.tsx
@@ -15,7 +15,10 @@ export const useGateways = ({
   sortOrder: "asc" | "desc";
 }) => {
   const { data, isLoading, error } = useQuery({
-    queryKey: ["gateways"],
+    queryKey: [
+      "gateways",
+      { limit, cursor: cursor ?? null, sortBy, sortOrder },
+    ],
     queryFn: () => ario.getGateways({ limit, cursor, sortBy, sortOrder }),
   });
 
@@ -34,7 +37,11 @@ export const useGatewayDelegations = ({
   cursor: string | undefined;
 }) => {
   const { data, isLoading, error } = useQuery({
-    queryKey: ["gateway-delegations", gatewayAddress],
+    queryKey: [
+      "gateway-delegations",
+      gatewayAddress,
+      { limit, cursor: cursor ?? null },
+    ],
     queryFn: () =>
       ario.getDelegations({
         address: gatewayAddress,

--- a/scripts/sdk-e2e-bootstrap.sh
+++ b/scripts/sdk-e2e-bootstrap.sh
@@ -100,7 +100,13 @@ WALLET_PUBKEY="$(solana-keygen pubkey "$WALLET_FILE")"
 # airdrop` CLI fails against Surfpool 1.1.2 with InvalidProgramForExecution;
 # see https://github.com/txtx/surfpool.
 echo "[sdk-e2e-bootstrap] Airdropping 50 SOL to $WALLET_PUBKEY"
-curl -sf "$RPC_URL" -X POST -H 'Content-Type: application/json' \
+# Bound the call so a stalled/unreachable local RPC can't hang bootstrap
+# indefinitely: cap each attempt's connect/total time and retry a few times
+# (incl. connection-refused while surfpool is still coming up). `-f` + the
+# script's `set -e` make an exhausted retry budget fail the bootstrap.
+curl -sf --retry 5 --retry-connrefused --retry-delay 2 \
+  --connect-timeout 5 --max-time 30 \
+  "$RPC_URL" -X POST -H 'Content-Type: application/json' \
   -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"surfnet_setAccount\",\"params\":[\"$WALLET_PUBKEY\",{\"lamports\":50000000000,\"owner\":\"11111111111111111111111111111111\",\"executable\":false,\"data\":[]}]}" \
   >/dev/null
 

--- a/src/cli/commands/antCommands.ts
+++ b/src/cli/commands/antCommands.ts
@@ -65,10 +65,7 @@ export async function setAntRecordCLICommand(
     );
   }
 
-  return (await writeANTFromOptions(o)).setRecord(
-    recordParams,
-    customTagsFromOptions(o),
-  );
+  return writeAnt.setRecord(recordParams, customTagsFromOptions(o));
 }
 
 export async function setAntBaseNameCLICommand(
@@ -98,10 +95,7 @@ export async function setAntBaseNameCLICommand(
     );
   }
 
-  return (await writeANTFromOptions(o)).setBaseNameRecord(
-    params,
-    customTagsFromOptions(o),
-  );
+  return writeAnt.setBaseNameRecord(params, customTagsFromOptions(o));
 }
 
 export async function setAntUndernameCLICommand(
@@ -133,10 +127,7 @@ export async function setAntUndernameCLICommand(
     );
   }
 
-  return (await writeANTFromOptions(o)).setUndernameRecord(
-    params,
-    customTagsFromOptions(o),
-  );
+  return writeAnt.setUndernameRecord(params, customTagsFromOptions(o));
 }
 
 export async function transferRecordOwnershipCLICommand(
@@ -158,7 +149,7 @@ export async function transferRecordOwnershipCLICommand(
     );
   }
 
-  return (await writeANTFromOptions(o)).transferRecord(
+  return writeAnt.transferRecord(
     { undername, recipient },
     customTagsFromOptions(o),
   );

--- a/src/cli/commands/escrowCommands.ts
+++ b/src/cli/commands/escrowCommands.ts
@@ -282,12 +282,20 @@ export async function escrowClaimArweaveCLICommand(
   if (sigBytes.length !== 512) {
     throw new Error(`signature file must be 512 bytes; got ${sigBytes.length}`);
   }
+  // RSA-PSS salt length: 0 is a valid value, so only reject NaN / negative /
+  // non-integer. An unset flag defaults to 32 (a full SHA-256 digest).
+  const saltLen = o.saltLen ? Number.parseInt(o.saltLen, 10) : 32;
+  if (!Number.isInteger(saltLen) || saltLen < 0) {
+    throw new Error(
+      `--salt-len must be a non-negative integer (got '${o.saltLen}')`,
+    );
+  }
   const escrow = await writeEscrowFromOptions(o);
   const sig = await escrow.claimArweave({
     antMint: antFromOptions(o),
     claimant: address(o.claimant),
     signature: sigBytes,
-    saltLen: o.saltLen ? Number(o.saltLen) : 32,
+    saltLen,
   });
   return { signature: sig };
 }

--- a/src/cli/commands/gatewayWriteCommands.ts
+++ b/src/cli/commands/gatewayWriteCommands.ts
@@ -143,9 +143,7 @@ export async function leaveNetwork(options: WriteActionCLIOptions) {
     );
   }
 
-  return (await writeARIOFromOptions(options)).ario.leaveNetwork(
-    customTagsFromOptions(options),
-  );
+  return ario.leaveNetwork(customTagsFromOptions(options));
 }
 
 export async function saveObservations(
@@ -406,21 +404,20 @@ export async function delegateStake(options: TransferCLIOptions) {
 export async function decreaseDelegateStake(
   options: DecreaseDelegateStakeCLIOptions,
 ) {
-  const ario = await (await writeARIOFromOptions(options)).ario;
+  const { ario, signerAddress } = await writeARIOFromOptions(options);
   const { target, arioQuantity } =
     requiredTargetAndQuantityFromOptions(options);
   const instant = options.instant ?? false;
 
   if (!options.skipConfirmation) {
     // Verify the target gateway exists and look up delegation
-    const signerAddr = (await writeARIOFromOptions(options)).signerAddress;
     const targetGateway = await ario.getGateway({ address: target });
     if (targetGateway === undefined) {
       throw new Error(`Gateway not found: ${target}`);
     }
 
     // Find delegation to this gateway
-    const delegations = await ario.getDelegations({ address: signerAddr });
+    const delegations = await ario.getDelegations({ address: signerAddress });
     const delegation = delegations.items.find(
       (d) => d.gatewayAddress === target && d.type === 'stake',
     ) as StakeDelegation | undefined;
@@ -477,7 +474,7 @@ export async function decreaseDelegateStake(
 }
 
 export async function redelegateStake(options: RedelegateStakeCLIOptions) {
-  const ario = await (await writeARIOFromOptions(options)).ario;
+  const { ario, signerAddress } = await writeARIOFromOptions(options);
   const params = redelegateParamsFromOptions(options);
 
   if (!options.skipConfirmation) {
@@ -496,8 +493,7 @@ export async function redelegateStake(options: RedelegateStakeCLIOptions) {
       throw new Error(`Source gateway not found: ${params.source}`);
     }
 
-    const signerAddr = (await writeARIOFromOptions(options)).signerAddress;
-    const delegations = await ario.getDelegations({ address: signerAddr });
+    const delegations = await ario.getDelegations({ address: signerAddress });
     const delegation = delegations.items.find(
       (d) => d.gatewayAddress === params.source && d.type === 'stake',
     ) as StakeDelegation | undefined;

--- a/src/cli/commands/pruneCommands.ts
+++ b/src/cli/commands/pruneCommands.ts
@@ -47,9 +47,15 @@ async function getSolanaWriter(o: PruneOptions): Promise<SolanaARIOWriteable> {
   return ario as unknown as SolanaARIOWriteable;
 }
 
-function parseMaxNames(o: PruneOptions): number {
+function parseMaxNames(o: PruneOptions, fallbackCount?: number): number {
   const raw = o.max;
   if (raw === undefined) {
+    // When an explicit name list is supplied, derive the u8 batch size from
+    // it (capped at the on-chain max of 255) so callers don't have to also
+    // pass --max. Discovery paths (no explicit list) still require --max.
+    if (fallbackCount !== undefined && fallbackCount > 0) {
+      return Math.min(fallbackCount, 255);
+    }
     throw new Error('--max <count> is required (u8 batch size, 1-255)');
   }
   const n = Number(raw);
@@ -64,7 +70,7 @@ function parseMaxNames(o: PruneOptions): number {
 // =========================================
 
 export async function pruneExpiredNamesCLICommand(o: PruneOptions) {
-  const max = parseMaxNames(o);
+  const max = parseMaxNames(o, o.arnsRecords?.length);
   const ario = await getSolanaWriter(o);
 
   // If `--arns-records` wasn't provided, discover them via the readable's
@@ -102,7 +108,7 @@ export async function pruneNameToReturnedCLICommand(o: PruneOptions) {
 }
 
 export async function pruneReturnedNamesCLICommand(o: PruneOptions) {
-  const max = parseMaxNames(o);
+  const max = parseMaxNames(o, o.returnedNames?.length);
   const ario = await getSolanaWriter(o);
 
   let returned: string[] = o.returnedNames ?? [];
@@ -233,15 +239,13 @@ export async function releaseVaultCLICommand(o: PruneOptions) {
   // configured signer as the owner. The `--owner` flag is accepted as
   // documentation but ignored unless it matches the signer; fail loud if
   // it doesn't, so users don't think they can release someone else's vault.
-  const ario = await getSolanaWriter(o);
-  if (o.owner) {
-    const signerAddr = (await writeARIOFromOptions(o)).signerAddress;
-    if (o.owner !== signerAddr) {
-      throw new Error(
-        `release-vault: --owner ${o.owner} does not match signer ${signerAddr}. ` +
-          `release_vault is owner-signed; use the owner's wallet to call it.`,
-      );
-    }
+  const { ario: arioWrite, signerAddress } = await writeARIOFromOptions(o);
+  const ario = arioWrite as unknown as SolanaARIOWriteable;
+  if (o.owner && o.owner !== signerAddress) {
+    throw new Error(
+      `release-vault: --owner ${o.owner} does not match signer ${signerAddress}. ` +
+        `release_vault is owner-signed; use the owner's wallet to call it.`,
+    );
   }
   const vaultIdStr = requiredStringFromOptions(o, 'vaultId');
   const vaultId = vaultIdStr;

--- a/src/cli/utils.test.ts
+++ b/src/cli/utils.test.ts
@@ -10,7 +10,11 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { fundingPlanFromOptions } from './utils.js';
+import {
+  fundingPlanFromOptions,
+  requiredAddressFromOptions,
+  withdrawalIdFromOptions,
+} from './utils.js';
 
 describe('fundingPlanFromOptions', () => {
   it('returns undefined when the flag is unset', () => {
@@ -56,15 +60,46 @@ describe('fundingPlanFromOptions', () => {
       {
         kind: 'operatorStake',
         amount: '500',
-        gateway: 'OpGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG',
+        gateway: 'GFGaZZWRT1PwKwFw2NkkyMhsRU6qSsxHmJThN7swUe1N',
       },
     ]);
     const out = fundingPlanFromOptions({ fundingPlanJson: json });
     assert.equal(out![0].kind, 'operatorStake');
     assert.equal(
       out![0].gateway,
-      'OpGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG',
+      'GFGaZZWRT1PwKwFw2NkkyMhsRU6qSsxHmJThN7swUe1N',
     );
+  });
+
+  it('rejects a gateway that is not valid base58', () => {
+    assert.throws(
+      () =>
+        fundingPlanFromOptions({
+          // 'O' is not in the base58 alphabet.
+          fundingPlanJson:
+            '[{"kind":"delegation","amount":"100","gateway":"OpGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG"}]',
+        }),
+      /is not a valid base58 Solana address/,
+    );
+  });
+
+  it('rejects an amount above u64 max', () => {
+    const overU64 = (1n << 64n).toString(); // 2^64, one past the max
+    assert.throws(
+      () =>
+        fundingPlanFromOptions({
+          fundingPlanJson: `[{"kind":"balance","amount":"${overU64}"}]`,
+        }),
+      /exceeds u64 max/,
+    );
+  });
+
+  it('accepts an amount at exactly u64 max', () => {
+    const u64Max = ((1n << 64n) - 1n).toString();
+    const out = fundingPlanFromOptions({
+      fundingPlanJson: `[{"kind":"balance","amount":"${u64Max}"}]`,
+    });
+    assert.equal(out![0].amount, (1n << 64n) - 1n);
   });
 
   it('rejects gateway field on balance source', () => {
@@ -141,6 +176,54 @@ describe('fundingPlanFromOptions', () => {
           fundingPlanJson: '[{"kind":"balance","amount":"abc"}]',
         }),
       /not a valid u64/,
+    );
+  });
+});
+
+describe('withdrawalIdFromOptions', () => {
+  it('returns undefined when the flag is unset', () => {
+    assert.equal(withdrawalIdFromOptions({}), undefined);
+  });
+
+  it('parses a valid decimal id', () => {
+    assert.equal(withdrawalIdFromOptions({ withdrawalId: '42' }), 42n);
+  });
+
+  it('accepts the u64 max', () => {
+    const u64Max = ((1n << 64n) - 1n).toString();
+    assert.equal(
+      withdrawalIdFromOptions({ withdrawalId: u64Max }),
+      (1n << 64n) - 1n,
+    );
+  });
+
+  it('rejects a value above u64 max', () => {
+    assert.throws(
+      () => withdrawalIdFromOptions({ withdrawalId: (1n << 64n).toString() }),
+      /outside u64 range/,
+    );
+  });
+
+  it('rejects a negative value', () => {
+    assert.throws(
+      () => withdrawalIdFromOptions({ withdrawalId: '-1' }),
+      /outside u64 range/,
+    );
+  });
+
+  it('rejects a non-integer string', () => {
+    assert.throws(
+      () => withdrawalIdFromOptions({ withdrawalId: 'abc' }),
+      /not a valid u64 integer/,
+    );
+  });
+});
+
+describe('requiredAddressFromOptions', () => {
+  it('mentions --private-key when no address source is provided', () => {
+    assert.throws(
+      () => requiredAddressFromOptions({}),
+      /--address, --wallet-file, or --private-key/,
     );
   });
 });

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -353,7 +353,9 @@ export function requiredAddressFromOptions<O extends AddressCLIOptions>(
   if (address !== undefined) {
     return address;
   }
-  throw new Error('No address provided. Use --address or --wallet-file');
+  throw new Error(
+    'No address provided. Use --address, --wallet-file, or --private-key',
+  );
 }
 
 const defaultCliPaginationLimit = 10; // more friendly UX than 100
@@ -834,6 +836,9 @@ export function referrerFromOptions<
   return o.referrer;
 }
 
+/** Largest value representable by an unsigned 64-bit integer (2^64 - 1). */
+const U64_MAX = (1n << 64n) - 1n;
+
 /** Parse `--withdrawal-id` from CLI options into a bigint. */
 export function withdrawalIdFromOptions<
   O extends {
@@ -841,13 +846,22 @@ export function withdrawalIdFromOptions<
   },
 >(o: O): bigint | undefined {
   if (o.withdrawalId === undefined) return undefined;
+  let id: bigint;
   try {
-    return BigInt(o.withdrawalId);
+    id = BigInt(o.withdrawalId);
   } catch {
     throw new Error(
       `Invalid --withdrawal-id: '${o.withdrawalId}' is not a valid u64 integer`,
     );
   }
+  // The on-chain seed encoder treats the id as a u64; reject out-of-range
+  // values here with a clear message instead of a downstream encoder error.
+  if (id < 0n || id > U64_MAX) {
+    throw new Error(
+      `Invalid --withdrawal-id: '${o.withdrawalId}' is outside u64 range (0..${U64_MAX})`,
+    );
+  }
+  return id;
 }
 
 /**
@@ -916,6 +930,11 @@ export function fundingPlanFromOptions<
         `--funding-plan-json[${idx}].amount must be > 0 (got ${e.amount})`,
       );
     }
+    if (amount > U64_MAX) {
+      throw new Error(
+        `--funding-plan-json[${idx}].amount '${e.amount}' exceeds u64 max (${U64_MAX})`,
+      );
+    }
     const out: { kind: string; amount: bigint; gateway?: string } = {
       kind: e.kind,
       amount,
@@ -929,6 +948,17 @@ export function fundingPlanFromOptions<
       if (e.kind !== 'delegation' && e.kind !== 'operatorStake') {
         throw new Error(
           `--funding-plan-json[${idx}].gateway is only valid for kind 'delegation' or 'operatorStake' (got '${e.kind}')`,
+        );
+      }
+      // The gateway is going to be used: confirm it actually decodes as a
+      // base58 Solana address. `address()` throws on malformed input, so a
+      // bad string fails the CLI here rather than deep in instruction
+      // building.
+      try {
+        address(e.gateway);
+      } catch {
+        throw new Error(
+          `--funding-plan-json[${idx}].gateway '${e.gateway}' is not a valid base58 Solana address`,
         );
       }
       out.gateway = e.gateway;

--- a/src/common/faucet.test.ts
+++ b/src/common/faucet.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for `createFaucet` — focused on the `processId` boundary guard.
+ * The HTTP methods of `ARIOTokenFaucet` are exercised by integration flows,
+ * not here.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { ARIORead } from '../types/index.js';
+import { createFaucet } from './faucet.js';
+
+// The proxy only forwards property access, so a bare object stands in for a
+// real ARIO instance for the purposes of these tests.
+const stubArio = {} as unknown as ARIORead;
+
+describe('createFaucet', () => {
+  it('throws when processId is an empty string', () => {
+    assert.throws(
+      () => createFaucet({ arioInstance: stubArio, processId: '' }),
+      /`processId` is required/,
+    );
+  });
+
+  it('throws when processId is whitespace only', () => {
+    assert.throws(
+      () => createFaucet({ arioInstance: stubArio, processId: '   ' }),
+      /`processId` is required/,
+    );
+  });
+
+  it('returns an instance exposing a `.faucet` namespace for a valid processId', () => {
+    const ario = createFaucet({
+      arioInstance: stubArio,
+      processId: 'process-123',
+    });
+    assert.equal(typeof ario.faucet, 'object');
+    assert.equal(typeof ario.faucet.captchaUrl, 'function');
+  });
+});

--- a/src/common/faucet.ts
+++ b/src/common/faucet.ts
@@ -44,6 +44,14 @@ export function createFaucet({
    */
   processId: string;
 }): ARIOWithFaucet<ARIORead | ARIOWrite> {
+  // The backend has no implicit default for `processId`; fail at the API
+  // boundary so callers get immediate feedback instead of an opaque HTTP
+  // error on the first faucet call.
+  if (typeof processId !== 'string' || processId.trim() === '') {
+    throw new Error(
+      'createFaucet: `processId` is required and must be non-empty',
+    );
+  }
   const faucet = new ARIOTokenFaucet({
     faucetUrl: faucetApiUrl,
     processId,

--- a/src/common/io.ts
+++ b/src/common/io.ts
@@ -54,6 +54,26 @@ export type ARIOConfig = {
 export const DEFAULT_SOLANA_RPC_URL = 'https://api.mainnet-beta.solana.com';
 
 export class ARIO {
+  /**
+   * Create an ARIO client bound to a Solana RPC transport.
+   *
+   * The return type is selected by the {@link ARIOConfig} you pass:
+   * - **Read-write** — when `signer` (a {@link SolanaSigner}) is provided. A
+   *   {@link SolanaRpcSubscriptions} client is then also required so
+   *   `@solana/kit`'s `sendAndConfirmTransaction` can await confirmations;
+   *   omitting it throws. Returns {@link ARIOWrite}.
+   * - **Read-only** — when `signer` is omitted. Returns {@link ARIORead}.
+   *
+   * Program-id overrides (`coreProgramId` / `garProgramId` / `arnsProgramId` /
+   * `antProgramId`) are required on any non-mainnet cluster (devnet, localnet,
+   * Surfpool); see {@link ARIOConfig}.
+   *
+   * @param config - RPC transport, optional signer/subscriptions, and
+   *   per-cluster program-id overrides.
+   * @returns {@link ARIOWrite} when a signer is supplied, otherwise
+   *   {@link ARIORead}.
+   * @throws If a signer is supplied without `rpcSubscriptions`.
+   */
   // Overload: with signer -> writeable. `rpcSubscriptions` is required so
   // kit's `sendAndConfirmTransaction` can subscribe to the confirmation.
   static init(


### PR DESCRIPTION
## Summary

Addresses the CodeRabbit review on #666 (alpha → main, Solana-native 4.0.0). Each finding was verified against current code; valid issues are fixed with minimal changes, two were intentionally skipped (see below). CI-equivalent checks pass locally: `lint:check` (exit 0), `format:check`, `build`, and `test:unit` (**366/366**, +9 new tests).

## Fixed

**CLI input validation**
- `cli/utils`: bound `--withdrawal-id` and funding-plan amounts to the u64 range (reject negatives + overflow); validate funding-plan `gateway` as a real base58 address via `@solana/kit` `address()`; add `--private-key` to the missing-address error.
- `cli/escrowCommands`: validate `--salt-len` as a non-negative integer (0 is a valid RSA-PSS salt length).
- `common/faucet`: guard empty/whitespace `processId` at the API boundary.

**Redundant client init (nitpicks)**
- `cli/{antCommands, gatewayWriteCommands, pruneCommands}`: reuse the already-awaited writer instead of re-initializing it — the second `writeANTFromOptions`/`writeARIOFromOptions` call repeated the ANT-program RPC resolution / signer lookup. Also removed a redundant `await (await …).ario` double-await.

**Behavior/UX**
- `cli/pruneCommands`: derive the `--max` batch size from an explicit name list when `--max` is omitted.

**Docs / examples / tooling**
- `common/io`: JSDoc for the `ARIO.init` read/write overload contract.
- `examples/vite`: gate the (currently unavailable) Solana faucet button behind a flag with a clear message; align `testnet → devnet` labels; include pagination/sort params in React Query keys to avoid cache staleness.
- `README`: resolve the mainnet Networks-table contradiction — the mainnet-beta RPC is the default; the *programs* are not yet deployed.
- `scripts/sdk-e2e-bootstrap`: bound the `surfnet_setAccount` curl with connect/total timeouts and bounded retries so a stalled local RPC can't hang bootstrap.

## Tests
- Extended `src/cli/utils.test.ts`: u64 bounds (withdrawal-id + amount), invalid-base58 gateway, `--private-key` error message.
- New `src/common/faucet.test.ts`: `processId` guard.
- Caught a latent bug: the existing `OpGGG…` gateway test fixture was *invalid base58* (`O` isn't in the alphabet); replaced with a real address.

## Intentionally skipped
- **CHANGELOG MD001 heading levels** — `CHANGELOG.md` is regenerated by semantic-release; a manual heading edit would be overwritten.
- **`coerceFundingPlanSources` cast** — `kind` is already validated against the identical literal set upstream in `fundingPlanFromOptions`, and `FundingSourceKind` *is* those exact 4 strings, so the cast is provably safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)