### PR TITLE
fix(deps): pin @ar.io/solana-contracts to stable 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@ar.io/solana-contracts": "0.8.0-staging.18",
+    "@ar.io/solana-contracts": "1.0.0",
     "@noble/hashes": "^1.8.0",
     "@solana-program/address-lookup-table": "^0.11.0",
     "@solana-program/compute-budget": "^0.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,10 @@
   resolved "https://registry.yarnpkg.com/@actions/io/-/io-3.0.2.tgz#6f89b27a159d109836d983efa283997c23b92284"
   integrity sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==
 
-"@ar.io/solana-contracts@0.8.0-staging.18":
-  version "0.8.0-staging.18"
-  resolved "https://registry.npmjs.org/@ar.io/solana-contracts/-/solana-contracts-0.8.0-staging.18.tgz#38077738eaeab05e235baff29fc1e2fd1c4ed652"
-  integrity sha512-w8UyC1qtDWjjeT5x1cE7zE7rmbmupSB9+0cFOS1h+eqlppyvnRQLoAUs/mdJZ4qDVitwsEG9XmYWyq+dlSOEwA==
+"@ar.io/solana-contracts@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.0.0.tgz#56ec1354542991899c5d641a8221ee2b33b8b99d"
+  integrity sha512-/rmxIyViK9USkedcn4zrHWkg+tGBE160PSbJ2xwEcugtXDSOf5Cc0E6R8YoG7HT5oKkU0QY1QEeSeVvcYgMYBQ==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
## Summary

Repins the SDK from the prerelease `@ar.io/solana-contracts@0.8.0-staging.18` to the first **stable** release, **`1.0.0`** (now on npm `@latest`). This lets the SDK's `alpha → main` (#666) stand on a stable contracts release instead of a staging prerelease.

## Why it's a safe drop-in
- Per **ADR-024**, every cluster compiles production-sized registries, so the Codama encoders/decoders in `1.0.0` are identical to the `0.8.0-staging.18` build the SDK was validated against.
- `tsc` type-check clean (no client API drift).
- **366/366** unit tests pass unchanged.

## Changes
- `package.json`: `@ar.io/solana-contracts` `0.8.0-staging.18` → `1.0.0`
- `yarn.lock`: resolved to `1.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)