### PR TITLE
fix(solana): cap MAX_COMPOUND_BATCH at 6 so compound crank tx fits the 1232-byte limit

### DIFF
--- a/src/solana/compound-crank.test.ts
+++ b/src/solana/compound-crank.test.ts
@@ -1,10 +1,26 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { type Address, type Instruction, getAddressDecoder } from '@solana/kit';
+import {
+  type Address,
+  type Instruction,
+  appendTransactionMessageInstructions,
+  blockhash,
+  compileTransaction,
+  createTransactionMessage,
+  getAddressDecoder,
+  getBase64EncodedWireTransaction,
+  pipe,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+} from '@solana/kit';
 
 import { selectCompoundableDelegations } from './delegation-math.js';
-import { SolanaARIOWriteable } from './io-writeable.js';
+import { MAX_COMPOUND_BATCH, SolanaARIOWriteable } from './io-writeable.js';
+
+// Solana's hard transaction-size limit (raw bytes). A versioned tx over this is
+// rejected by the RPC ("VersionedTransaction too large") and never lands.
+const MAX_TX_BYTES = 1232;
 
 const dec = getAddressDecoder();
 function pk(tag: number): Address {
@@ -136,6 +152,44 @@ describe('compoundDelegationRewardsBatch', () => {
     assert.equal(r.id, 'tx-stub');
     assert.equal(w.sent.length, 1, 'a single transaction');
     assert.equal(w.sent[0].ixs.length, 3, 'one instruction per delegation');
+  });
+
+  it('a full MAX_COMPOUND_BATCH batch fits the 1232-byte tx limit (worst case: all-distinct gateways)', async () => {
+    const w = new TestWriteable();
+    // Worst case for tx size: every delegation a distinct gateway, so no account
+    // dedup shrinks the message. This is the shape that wedged epoch progression
+    // on staging-V2 — a full batch of 12 overflows the 1232B raw limit and threw
+    // in the post-distribution tail before create_epoch, so the cranker never
+    // advanced. The cap must keep a full batch sendable.
+    const dels = Array.from({ length: MAX_COMPOUND_BATCH }, (_, i) => ({
+      gateway: pk(100 + i * 3),
+      delegator: pk(101 + i * 3),
+    }));
+    await w.compoundDelegationRewardsBatch(dels);
+    assert.equal(w.sent.length, 1, 'a single transaction');
+
+    // Compile the captured instructions into a real wire transaction and measure
+    // it, mirroring how `sendTransaction` builds the v0 tx.
+    const wire = pipe(
+      createTransactionMessage({ version: 0 }),
+      (tx) => setTransactionMessageFeePayer(pk(99), tx),
+      (tx) =>
+        setTransactionMessageLifetimeUsingBlockhash(
+          {
+            blockhash: blockhash('11111111111111111111111111111111'),
+            lastValidBlockHeight: 0n,
+          },
+          tx,
+        ),
+      (tx) => appendTransactionMessageInstructions(w.sent[0].ixs, tx),
+      (tx) => getBase64EncodedWireTransaction(compileTransaction(tx)),
+    );
+    const bytes = Buffer.from(wire, 'base64').length;
+    assert.ok(
+      bytes <= MAX_TX_BYTES,
+      `a full compound batch of ${MAX_COMPOUND_BATCH} compiled to ${bytes}B, ` +
+        `exceeding Solana's ${MAX_TX_BYTES}-byte tx limit`,
+    );
   });
 });
 

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -440,10 +440,17 @@ export function encodeReportTxId(reportTxId: string | undefined): Buffer {
 
 /**
  * Max `compound_delegation_rewards` instructions packed into one batched tx.
- * Each carries a gateway + delegation + delegator account; 12 stays well within
- * the per-tx account/1232-byte budget even when none share a gateway.
+ * Each is a SEPARATE instruction carrying a gateway + delegation + delegator
+ * account, so — unlike the single-ix `remaining_accounts` lifecycle batch (see
+ * `MAX_LIFECYCLE_BATCH`) and unlike prescribe (which uses an ALT) — the per-item
+ * tx cost is high and there is nothing to compress. Cap low enough that a full
+ * worst-case batch (all-distinct gateways → no account dedup) stays under
+ * Solana's 1232-byte transaction limit. A full batch of 12 overflows it and
+ * wedged epoch progression on staging-V2 (the RPC rejected the tx — observed at
+ * 1928B base64, well over the 1232B raw cap). Exported so the regression test in
+ * `compound-crank.test.ts` asserts this invariant against the live constant.
  */
-const MAX_COMPOUND_BATCH = 12;
+export const MAX_COMPOUND_BATCH = 6;
 /** Observation PDAs closed per tx before close_epoch (each ix carries Epoch +
  *  Observation + payer + system accounts — keep well under the tx account cap). */
 const MAX_CLOSE_OBSERVATION_BATCH = 8;


### PR DESCRIPTION
## Problem

`crankEpochStep`'s post-distribution **`compound`** step (`maybeCompoundStep` → `compoundDelegationRewardsBatch`) packs `MAX_COMPOUND_BATCH` separate `compound_delegation_rewards` instructions into a single transaction. Each instruction carries its own gateway + delegation + delegator accounts, so in the worst case (all-distinct gateways, no account dedup) a batch of **12** compiles to a tx that exceeds Solana's **1232-byte** limit. The RPC rejects it (`VersionedTransaction too large`), the step throws, and because it runs in the tail **before `create_epoch`** (and isn't try/catch-wrapped like `close`), it **wedges epoch progression network-wide**.

Observed on staging-V2: every operator's cranker stuck on the oversized compound tx, epochs stopped advancing, and dependent observation/distribution stalled.

## Why it slipped through

`MAX_COMPOUND_BATCH = 12` shipped with a comment claiming it "stays well within the per-tx account/1232-byte budget" — never true for a full distinct-gateway batch. Unlike the sibling size-safe paths:
- `tally`/`distribute`: one instruction with gateway PDAs as `remaining_accounts`, capped at `MAX_LIFECYCLE_BATCH = 18`.
- `prescribe`: ephemeral Address Lookup Table.

…`compound` is **N full instructions with nothing to compress**, so it needs a low fixed cap and never got one. There was also no test asserting the batch fits a tx.

## Fix

- Cap `MAX_COMPOUND_BATCH` **12 → 6** — a full worst-case batch stays well under 1232 bytes.
- Correct the inaccurate size comment.
- `export` the constant so the test asserts the invariant against the live value.
- Add a regression test in `compound-crank.test.ts` that builds a full worst-case (all-distinct-gateway) batch, compiles it into a real v0 wire transaction, and asserts it fits 1232 bytes. **Fails at 12 (~1488B), passes at 6.**

## Verification

- New test fails at 12, passes at 6; full solana unit suite: **287 pass, 0 fail**.
- `biome format` + `biome check`: clean.
- Validated live on staging-V2: with the batch lowered, `compound` succeeds, the "too large" errors stop, and the cranker advances past the wedge (epochs resume).

## Suggested follow-up (not in this PR)

Wrap the `compound`/demand-factor tail steps in the same best-effort try/catch as `close`, so a future oversized/failing maintenance step can never block `create_epoch` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)