### PR TITLE
fix(arns): floor returned-name premium at 1x to match on-chain pricing

### DIFF
--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -1768,10 +1768,16 @@ export class SolanaARIOReadable {
             const elapsed = now - returned.startTimestamp;
             const duration = 14 * 86_400_000;
             if (elapsed < duration) {
-              const remaining = BigInt(duration - elapsed);
+              // Returned Name Premium (RNP) decays linearly from 50x to 1x
+              // over the window, matching the whitepaper (RNP = 50 - 49/14*t)
+              // and the on-chain ario-arns pricing
+              // (calculate_returned_name_premium):
+              //   multiplier = (50*dur - 49*elapsed) * scale / dur
+              // Floors at 1x at window close (NOT 0x) — at which point the
+              // name reverts to standard pricing.
               const dur = BigInt(duration);
-              const pctRemaining = (remaining * scale) / dur;
-              const multiplier = 50n * pctRemaining;
+              const el = BigInt(elapsed);
+              const multiplier = ((50n * dur - 49n * el) * scale) / dur;
               cost = (cost * multiplier) / scale;
             }
           }


### PR DESCRIPTION
## Problem

`getTokenCost` (Solana `IOReadable`) computes the returned-name **Dutch auction premium** with the legacy formula:

```ts
const multiplier = 50n * ((remaining * scale) / dur); // 50 * remaining/duration
```

This decays to **0×** at the end of the 14-day window. But the on-chain `ario-arns` program (`calculate_returned_name_premium`) and the [whitepaper] decay the premium linearly from **50× to 1×**, never below 1×:

```
RNP = 50 - (49/14) * t                              (whitepaper)
multiplier = (50*dur - 49*elapsed) * scale / dur    (on-chain ario-arns)
```

The two formulas diverge increasingly toward the end of the auction window — the SDK systematically **under-quotes**, worst near window close (SDK trends to 0× while the chain holds at 1×).

### Observed in production

A 1-year lease on a returned name bought ~97% of the way through the window:

| Source | Quote |
|---|---|
| SDK / arns-react (`getTokenCost`) | ~**1767 ARIO** |
| On-chain charge (Solflare) | ~**2963 ARIO** |

Ratio 2963/1767 ≈ 1.68 corresponds exactly to the formula divergence at ~97% elapsed.

## Fix

Replace the decay formula with the on-chain / whitepaper one so SDK quotes match what the contract actually charges:

```ts
const dur = BigInt(duration);
const el = BigInt(elapsed);
const multiplier = ((50n * dur - 49n * el) * scale) / dur; // 50x -> 1x, never 0x
cost = (cost * multiplier) / scale;
```

## Notes

- Only the SDK was wrong. `arns-react`'s `RNPChart` already uses the correct formula and reverse-derives the base price from `tokenCost`, so it becomes consistent once this lands.
- `tsc -p tsconfig.json --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the premium pricing multiplier calculation for returned names purchased within the premium window. The pricing decay formula for Buy-Name and Buy-Record transactions has been refined to improve how premium fees scale down as the window approaches closure, providing more accurate pricing throughout the premium period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->