### PR TITLE
fix(solana): source demand-factor settings from program constants

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@ar.io/solana-contracts": "1.0.0",
+    "@ar.io/solana-contracts": "1.0.1",
     "@noble/hashes": "^1.8.0",
     "@solana-program/address-lookup-table": "^0.11.0",
     "@solana-program/compute-budget": "^0.15.0",

--- a/src/solana/demand-factor-settings.test.ts
+++ b/src/solana/demand-factor-settings.test.ts
@@ -1,0 +1,55 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  DEMAND_FACTOR_DOWN_ADJUSTMENT,
+  DEMAND_FACTOR_MIN,
+  DEMAND_FACTOR_SCALE,
+  DEMAND_FACTOR_UP_ADJUSTMENT,
+  MAX_PERIODS_AT_MIN_DEMAND_FACTOR,
+  MOVING_AVG_PERIOD_COUNT,
+  PERIOD_LENGTH_SECONDS,
+} from '@ar.io/solana-contracts/arns';
+
+/**
+ * Guards the demand-factor settings against the literal-drift bug that
+ * `getDemandFactorSettings` had: the down-adjustment was hardcoded `25` (2.5%)
+ * while the on-chain program uses DEMAND_FACTOR_DOWN_ADJUSTMENT = 985_000
+ * (0.985× → 1.5%). These now derive from the generated program constants
+ * (lifted from the Rust source-of-truth), so this test pins both the constant
+ * values and the derivation `getDemandFactorSettings` performs.
+ *
+ * If `@ar.io/solana-contracts` is regenerated against changed Rust consts,
+ * these fail before a wrong price/quote ships.
+ */
+describe('demand factor settings', () => {
+  it('exports the program constants as bigint with the on-chain values', () => {
+    assert.equal(DEMAND_FACTOR_SCALE, 1_000_000n);
+    assert.equal(DEMAND_FACTOR_UP_ADJUSTMENT, 1_050_000n);
+    assert.equal(DEMAND_FACTOR_DOWN_ADJUSTMENT, 985_000n);
+    assert.equal(DEMAND_FACTOR_MIN, 500_000n);
+    assert.equal(typeof DEMAND_FACTOR_SCALE, 'bigint');
+    assert.equal(typeof DEMAND_FACTOR_DOWN_ADJUSTMENT, 'bigint');
+  });
+
+  it('derives the adjustment rates the way getDemandFactorSettings does', () => {
+    const scale = DEMAND_FACTOR_SCALE;
+    const upRate = Number(
+      ((DEMAND_FACTOR_UP_ADJUSTMENT - scale) * 1000n) / scale,
+    );
+    const downRate = Number(
+      ((scale - DEMAND_FACTOR_DOWN_ADJUSTMENT) * 1000n) / scale,
+    );
+
+    assert.equal(upRate, 50); // 1.05× — unchanged
+    assert.equal(downRate, 15); // 0.985× — was incorrectly hardcoded 25
+    assert.equal(Number(DEMAND_FACTOR_MIN) / Number(scale), 0.5);
+  });
+
+  it('exports period/threshold constants as ergonomic numbers', () => {
+    assert.equal(MOVING_AVG_PERIOD_COUNT, 7);
+    assert.equal(MAX_PERIODS_AT_MIN_DEMAND_FACTOR, 7);
+    assert.equal(Number(PERIOD_LENGTH_SECONDS) * 1000, 86_400_000);
+    assert.equal(typeof MOVING_AVG_PERIOD_COUNT, 'number');
+  });
+});

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -33,6 +33,13 @@ import bs58 from 'bs58';
 
 import {
   ARNS_RECORD_DISCRIMINATOR,
+  DEMAND_FACTOR_DOWN_ADJUSTMENT,
+  DEMAND_FACTOR_MIN,
+  DEMAND_FACTOR_SCALE,
+  DEMAND_FACTOR_UP_ADJUSTMENT,
+  MAX_PERIODS_AT_MIN_DEMAND_FACTOR,
+  MOVING_AVG_PERIOD_COUNT,
+  PERIOD_LENGTH_SECONDS,
   RESERVED_NAME_DISCRIMINATOR,
   RETURNED_NAME_DISCRIMINATOR,
   getArnsConfigDecoder,
@@ -2060,15 +2067,30 @@ export class SolanaARIOReadable {
     }
     const df = deserializeDemandFactor(Buffer.from(account.data));
 
+    // Derive every static setting from the on-chain program constants
+    // (`@ar.io/solana-contracts/arns`, lifted from the Rust source-of-truth)
+    // rather than hand-copied literals, which had drifted: the down-adjustment
+    // was hardcoded `25` (2.5%) while the program uses
+    // DEMAND_FACTOR_DOWN_ADJUSTMENT = 985_000 → 0.985× → 1.5% (`15`), and
+    // `maxPeriodsAtMinDemandFactor` returned the live consecutive-period
+    // counter instead of the MAX_PERIODS_AT_MIN_DEMAND_FACTOR threshold.
+    //
+    // The `*AdjustmentRate` fields are the per-period step magnitude scaled by
+    // 1000 (up: 1.05× → 50; down: 0.985× → 15), matching the existing units.
+    const scale = DEMAND_FACTOR_SCALE;
     return {
       periodZeroStartTimestamp: df.periodZeroStartTimestamp,
-      movingAvgPeriodCount: 7,
-      periodLengthMs: 86_400 * 1000,
+      movingAvgPeriodCount: MOVING_AVG_PERIOD_COUNT,
+      periodLengthMs: Number(PERIOD_LENGTH_SECONDS) * 1000,
       demandFactorBaseValue: 1,
-      demandFactorMin: 0.5,
-      demandFactorUpAdjustmentRate: 50,
-      demandFactorDownAdjustmentRate: 25,
-      maxPeriodsAtMinDemandFactor: df.consecutivePeriodsWithMinDemandFactor,
+      demandFactorMin: Number(DEMAND_FACTOR_MIN) / Number(scale),
+      demandFactorUpAdjustmentRate: Number(
+        ((DEMAND_FACTOR_UP_ADJUSTMENT - scale) * 1000n) / scale,
+      ),
+      demandFactorDownAdjustmentRate: Number(
+        ((scale - DEMAND_FACTOR_DOWN_ADJUSTMENT) * 1000n) / scale,
+      ),
+      maxPeriodsAtMinDemandFactor: MAX_PERIODS_AT_MIN_DEMAND_FACTOR,
       criteria: 'revenue',
     };
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,10 @@
   resolved "https://registry.yarnpkg.com/@actions/io/-/io-3.0.2.tgz#6f89b27a159d109836d983efa283997c23b92284"
   integrity sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==
 
-"@ar.io/solana-contracts@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.0.0.tgz#56ec1354542991899c5d641a8221ee2b33b8b99d"
-  integrity sha512-/rmxIyViK9USkedcn4zrHWkg+tGBE160PSbJ2xwEcugtXDSOf5Cc0E6R8YoG7HT5oKkU0QY1QEeSeVvcYgMYBQ==
+"@ar.io/solana-contracts@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@ar.io/solana-contracts/-/solana-contracts-1.0.1.tgz#1a16958d54540222b77def81d5d39e7402b8b69c"
+  integrity sha512-zD7OepkzzWb1SIHRDxSo3y+dzRh9gu+43eI2DBJLtQ+7EkT3Py8v9kHQ40UcRC8CReHHTO74RDty6Hwx5JYVGA==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
## What

Source `getDemandFactorSettings` from the on-chain program constants (`@ar.io/solana-contracts/arns`) instead of hand-copied literals.

## Why

The literals had drifted from the program:
- **Down-adjustment was `25` (2.5%)** while the program uses `DEMAND_FACTOR_DOWN_ADJUSTMENT = 985_000` → 0.985× → **1.5% (`15`)**. The ar.io pricing docs already say 1.5%; the SDK was the outlier.
- **`maxPeriodsAtMinDemandFactor` returned the live consecutive-period counter** (`df.consecutivePeriodsWithMinDemandFactor`) instead of the `MAX_PERIODS_AT_MIN_DEMAND_FACTOR` threshold.

## How

Import the constants (generated from the Rust source-of-truth) and derive the rate fields, so they can no longer drift:

```ts
demandFactorUpAdjustmentRate:   Number(((DEMAND_FACTOR_UP_ADJUSTMENT   - scale) * 1000n) / scale), // 50
demandFactorDownAdjustmentRate: Number(((scale - DEMAND_FACTOR_DOWN_ADJUSTMENT) * 1000n) / scale), // 15
maxPeriodsAtMinDemandFactor:    MAX_PERIODS_AT_MIN_DEMAND_FACTOR,                                   // 7
```

`upRate` stays `50` (unchanged); `downRate` corrects `25 → 15`.

## Test

- New `demand-factor-settings.test.ts` pins the constant values/types and the derivation — **3/3 pass**.
- Full offline solana unit suite: **290/290 pass**.
- `tsc --noEmit`: clean.

## Dependency

Consumes `@ar.io/solana-contracts@1.0.1` (published from ar-io/ar-io-solana-contracts#110, which exports the arns constants). The release is published and pinned in `package.json` + `yarn.lock` — **no longer blocked**; tests and typecheck above run against the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)