### PR TITLE
fix(cli): normalize argv[1] path separators for Windows compatibility

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1227,9 +1227,11 @@ makeCommand({
   action: escrowClaimEthereumCLICommand,
 });
 
+const normalizedArgv1 = process.argv[1].replace(/\\/g, '/');
+
 if (
-  process.argv[1].includes('bin/ar.io') || // Running from global .bin
-  process.argv[1].includes('cli/cli') // Running from source
+  normalizedArgv1.includes('bin/ar.io') || // Running from global .bin
+  normalizedArgv1.includes('cli/cli') // Running from source
 ) {
   program.parse(process.argv);
 }


### PR DESCRIPTION
## Problem

On Windows, the CLI silently exits without output when run via `node lib/esm/cli/cli.js` or the globally installed `ar.io` command. No error is thrown, nothing is printed — including `--help`.

The root cause is the parse guard at the bottom of `cli.ts`:

```typescript
if (
  process.argv[1].includes('bin/ar.io') ||
  process.argv[1].includes('cli/cli')
) {
  program.parse(process.argv);
}
```

On Windows, `process.argv[1]` uses backslashes (e.g. `C:\...\@ar.io\sdk\lib\esm\cli\cli.js`), so the path contains `cli\cli` — neither substring matches, `program.parse()` is never called, and the CLI exits silently.

## Fix

Normalize the path separators to forward slashes before the check:

```typescript
const normalizedArgv1 = process.argv[1].replace(/\\/g, '/');

if (
  normalizedArgv1.includes('bin/ar.io') ||
  normalizedArgv1.includes('cli/cli')
) {
  program.parse(process.argv);
}
```

No impact on macOS/Linux — backslashes don't appear in those paths, so the replace is a no-op. `tsc --noEmit` clean.

## Notes

Re-creates the fix from #600 on a clean branch off the current `alpha` (PR #600 carried stale auto-release artifacts — CHANGELOG/version bumps — from its old base; this branch contains only the `cli.ts` change). Original fix and Windows testing by @JonnieSparkles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)