### PR TITLE
fix(solana): returned-name premium clock + demand-factor settings from constants

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@ar.io/solana-contracts": "1.0.0",
+    "@ar.io/solana-contracts": "1.0.1",
     "@noble/hashes": "^1.8.0",
     "@solana-program/address-lookup-table": "^0.11.0",
     "@solana-program/compute-budget": "^0.15.0",

--- a/src/solana/demand-factor-settings.test.ts
+++ b/src/solana/demand-factor-settings.test.ts
@@ -1,0 +1,55 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  DEMAND_FACTOR_DOWN_ADJUSTMENT,
+  DEMAND_FACTOR_MIN,
+  DEMAND_FACTOR_SCALE,
+  DEMAND_FACTOR_UP_ADJUSTMENT,
+  MAX_PERIODS_AT_MIN_DEMAND_FACTOR,
+  MOVING_AVG_PERIOD_COUNT,
+  PERIOD_LENGTH_SECONDS,
+} from '@ar.io/solana-contracts/arns';
+
+/**
+ * Guards the demand-factor settings against the literal-drift bug that
+ * `getDemandFactorSettings` had: the down-adjustment was hardcoded `25` (2.5%)
+ * while the on-chain program uses DEMAND_FACTOR_DOWN_ADJUSTMENT = 985_000
+ * (0.985× → 1.5%). These now derive from the generated program constants
+ * (lifted from the Rust source-of-truth), so this test pins both the constant
+ * values and the derivation `getDemandFactorSettings` performs.
+ *
+ * If `@ar.io/solana-contracts` is regenerated against changed Rust consts,
+ * these fail before a wrong price/quote ships.
+ */
+describe('demand factor settings', () => {
+  it('exports the program constants as bigint with the on-chain values', () => {
+    assert.equal(DEMAND_FACTOR_SCALE, 1_000_000n);
+    assert.equal(DEMAND_FACTOR_UP_ADJUSTMENT, 1_050_000n);
+    assert.equal(DEMAND_FACTOR_DOWN_ADJUSTMENT, 985_000n);
+    assert.equal(DEMAND_FACTOR_MIN, 500_000n);
+    assert.equal(typeof DEMAND_FACTOR_SCALE, 'bigint');
+    assert.equal(typeof DEMAND_FACTOR_DOWN_ADJUSTMENT, 'bigint');
+  });
+
+  it('derives the adjustment rates the way getDemandFactorSettings does', () => {
+    const scale = DEMAND_FACTOR_SCALE;
+    const upRate = Number(
+      ((DEMAND_FACTOR_UP_ADJUSTMENT - scale) * 1000n) / scale,
+    );
+    const downRate = Number(
+      ((scale - DEMAND_FACTOR_DOWN_ADJUSTMENT) * 1000n) / scale,
+    );
+
+    assert.equal(upRate, 50); // 1.05× — unchanged
+    assert.equal(downRate, 15); // 0.985× — was incorrectly hardcoded 25
+    assert.equal(Number(DEMAND_FACTOR_MIN) / Number(scale), 0.5);
+  });
+
+  it('exports period/threshold constants as ergonomic numbers', () => {
+    assert.equal(MOVING_AVG_PERIOD_COUNT, 7);
+    assert.equal(MAX_PERIODS_AT_MIN_DEMAND_FACTOR, 7);
+    assert.equal(Number(PERIOD_LENGTH_SECONDS) * 1000, 86_400_000);
+    assert.equal(typeof MOVING_AVG_PERIOD_COUNT, 'number');
+  });
+});

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -33,6 +33,13 @@ import bs58 from 'bs58';
 
 import {
   ARNS_RECORD_DISCRIMINATOR,
+  DEMAND_FACTOR_DOWN_ADJUSTMENT,
+  DEMAND_FACTOR_MIN,
+  DEMAND_FACTOR_SCALE,
+  DEMAND_FACTOR_UP_ADJUSTMENT,
+  MAX_PERIODS_AT_MIN_DEMAND_FACTOR,
+  MOVING_AVG_PERIOD_COUNT,
+  PERIOD_LENGTH_SECONDS,
   RESERVED_NAME_DISCRIMINATOR,
   RETURNED_NAME_DISCRIMINATOR,
   getArnsConfigDecoder,
@@ -2070,15 +2077,30 @@ export class SolanaARIOReadable {
     }
     const df = deserializeDemandFactor(Buffer.from(account.data));
 
+    // Derive every static setting from the on-chain program constants
+    // (`@ar.io/solana-contracts/arns`, lifted from the Rust source-of-truth)
+    // rather than hand-copied literals, which had drifted: the down-adjustment
+    // was hardcoded `25` (2.5%) while the program uses
+    // DEMAND_FACTOR_DOWN_ADJUSTMENT = 985_000 → 0.985× → 1.5% (`15`), and
+    // `maxPeriodsAtMinDemandFactor` returned the live consecutive-period
+    // counter instead of the MAX_PERIODS_AT_MIN_DEMAND_FACTOR threshold.
+    //
+    // The `*AdjustmentRate` fields are the per-period step magnitude scaled by
+    // 1000 (up: 1.05× → 50; down: 0.985× → 15), matching the existing units.
+    const scale = DEMAND_FACTOR_SCALE;
     return {
       periodZeroStartTimestamp: df.periodZeroStartTimestamp,
-      movingAvgPeriodCount: 7,
-      periodLengthMs: 86_400 * 1000,
+      movingAvgPeriodCount: MOVING_AVG_PERIOD_COUNT,
+      periodLengthMs: Number(PERIOD_LENGTH_SECONDS) * 1000,
       demandFactorBaseValue: 1,
-      demandFactorMin: 0.5,
-      demandFactorUpAdjustmentRate: 50,
-      demandFactorDownAdjustmentRate: 25,
-      maxPeriodsAtMinDemandFactor: df.consecutivePeriodsWithMinDemandFactor,
+      demandFactorMin: Number(DEMAND_FACTOR_MIN) / Number(scale),
+      demandFactorUpAdjustmentRate: Number(
+        ((DEMAND_FACTOR_UP_ADJUSTMENT - scale) * 1000n) / scale,
+      ),
+      demandFactorDownAdjustmentRate: Number(
+        ((scale - DEMAND_FACTOR_DOWN_ADJUSTMENT) * 1000n) / scale,
+      ),
+      maxPeriodsAtMinDemandFactor: MAX_PERIODS_AT_MIN_DEMAND_FACTOR,
       criteria: 'revenue',
     };
   }

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -375,6 +375,35 @@ export class SolanaARIOReadable {
   }
 
   /**
+   * The Solana cluster's `unix_timestamp` (in SECONDS), read read-only.
+   *
+   * On-chain handlers measure time against the cluster clock
+   * (`Clock::get()?.unix_timestamp`), NOT the client wall clock. For any
+   * pricing math that must agree with what the program will charge (e.g. the
+   * Dutch-auction premium for returned names, whose elapsed time gates the
+   * multiplier), the SDK must compare against this same clock — `Date.now()`
+   * drifts from `unix_timestamp` (the cluster clock famously lags real
+   * wall-clock by seconds-to-minutes), which would make the SDK over-estimate
+   * elapsed time and therefore UNDER-quote the premium.
+   *
+   * Sourced via the latest slot's block time (`getSlot` → `getBlockTime`),
+   * which the runtime derives from the same stake-weighted clock the on-chain
+   * `Clock` sysvar exposes. Read-only: no signer, no transaction.
+   */
+  private async getClusterUnixTimestampSeconds(): Promise<number> {
+    const slot = await withRetry(() =>
+      this.rpc.getSlot({ commitment: this.commitment }).send(),
+    );
+    const blockTime = await withRetry(() => this.rpc.getBlockTime(slot).send());
+    if (blockTime == null) {
+      throw new Error(
+        `Cluster block time unavailable for slot ${slot}; cannot match on-chain Clock::get().unix_timestamp`,
+      );
+    }
+    return Number(blockTime);
+  }
+
+  /**
    * Helper for `getProgramAccounts` with a discriminator memcmp filter.
    *
    * Pass the Codama-generated `<NAME>_DISCRIMINATOR: Uint8Array` constant
@@ -1750,6 +1779,51 @@ export class SolanaARIOReadable {
     if (!dfAccount.exists) throw new Error('DemandFactor account not found');
     const df = deserializeDemandFactor(Buffer.from(dfAccount.data));
 
+    // Match the on-chain clock: the program measures time against the Solana
+    // cluster's `Clock::get().unix_timestamp`, not the client wall clock.
+    // Fetch it ONCE here and thread it through both the demand-factor
+    // staleness check and the returned-name premium math below. (Seconds.)
+    const clusterNowSeconds = await this.getClusterUnixTimestampSeconds();
+
+    // Demand-factor staleness warning.
+    //
+    // The handlers that actually charge roll the demand factor INLINE to the
+    // current period before pricing, whereas this read uses the STORED factor —
+    // which is stale whenever a demand period has rolled but no crank (or
+    // buy/extend) has landed to roll it. When that happens the chain prices
+    // against the rolled factor (a +5%/-1.5% step), so this quote can be off by
+    // one demand adjustment.
+    //
+    // We deliberately do NOT replicate the roll client-side: the authoritative
+    // roll math (multi-period catch-up, consecutive-min fee-halving) lives in
+    // the Rust program and depends on inputs a read-only client can't reproduce
+    // faithfully, so guessing would risk replacing a known small error with a
+    // wrong-direction one. The byte-exact path is the writeable
+    // `getCostDetails`, which simulates the on-chain instruction (rolling the
+    // factor inline). Here we just detect the rollover against the cluster
+    // clock and surface it as a debug warning.
+    const PERIOD_LENGTH_SECONDS = 86_400; // mirrors PERIOD_LENGTH_SECONDS in ario-arns
+    const elapsedSincePeriodZero =
+      clusterNowSeconds - df.periodZeroStartTimestamp;
+    const periodForNow =
+      elapsedSincePeriodZero < 0
+        ? 1
+        : Math.floor(elapsedSincePeriodZero / PERIOD_LENGTH_SECONDS) + 1;
+    if (periodForNow > df.currentPeriod) {
+      this.logger.debug(
+        '[pricing] demand factor period has rolled but stored factor is stale; ' +
+          'quote may be off by one demand adjustment until a crank rolls it. ' +
+          'Use the writeable simulated getCostDetails for a byte-exact quote.',
+        {
+          name: params.name,
+          intent: params.intent,
+          storedPeriod: df.currentPeriod,
+          clusterPeriod: periodForNow,
+          storedDemandFactor: df.currentDemandFactor,
+        },
+      );
+    }
+
     const name = params.name.toLowerCase();
     const nameLen = Math.min(Math.max(name.length, 1), 51);
     const baseFee = df.fees[nameLen - 1] ?? df.fees[df.fees.length - 1];
@@ -1781,7 +1855,15 @@ export class SolanaARIOReadable {
           if (returned) {
             // returned.startTimestamp is in ms (public API convention),
             // so the rest of this comparison is in ms too.
-            const now = Date.now();
+            //
+            // CRITICAL: "now" must be the Solana cluster clock, NOT
+            // `Date.now()`. The on-chain returned-name handler measures
+            // premium-elapsed against `Clock::get().unix_timestamp`; because
+            // that clock lags real wall-clock, using `Date.now()` here
+            // over-estimates elapsed time, under-estimates the remaining
+            // premium, and quotes LOW versus what the chain charges. Convert
+            // the cluster seconds to ms to match `startTimestamp`'s units.
+            const now = clusterNowSeconds * 1000;
             const elapsed = now - returned.startTimestamp;
             const duration = 14 * 86_400_000;
             if (elapsed < duration) {
@@ -1871,6 +1953,10 @@ export class SolanaARIOReadable {
             // Match on-chain eligibility from ario-arns pricing.rs
             // `try_apply_gateway_discount`:
             // 1. Tenure: gateway running >= 180 days (15_552_000 seconds)
+            // (This is a coarse 180-day eligibility gate, not the
+            // premium/auction math fixed above; sub-minute cluster-clock drift
+            // is immaterial at this granularity, so the client wall clock is
+            // fine here and we avoid an extra RPC round trip.)
             const GATEWAY_DISCOUNT_MIN_TENURE_S = 15_552_000;
             const nowSeconds = Math.floor(Date.now() / 1000);
             const timeRunning = nowSeconds - gw.startTimestamp;

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,10 @@
   resolved "https://registry.yarnpkg.com/@actions/io/-/io-3.0.2.tgz#6f89b27a159d109836d983efa283997c23b92284"
   integrity sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==
 
-"@ar.io/solana-contracts@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.0.0.tgz#56ec1354542991899c5d641a8221ee2b33b8b99d"
-  integrity sha512-/rmxIyViK9USkedcn4zrHWkg+tGBE160PSbJ2xwEcugtXDSOf5Cc0E6R8YoG7HT5oKkU0QY1QEeSeVvcYgMYBQ==
+"@ar.io/solana-contracts@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@ar.io/solana-contracts/-/solana-contracts-1.0.1.tgz#1a16958d54540222b77def81d5d39e7402b8b69c"
+  integrity sha512-zD7OepkzzWb1SIHRDxSo3y+dzRh9gu+43eI2DBJLtQ+7EkT3Py8v9kHQ40UcRC8CReHHTO74RDty6Hwx5JYVGA==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
Combines #680 and #682 into a single PR. Two related ArNS pricing-accuracy fixes for the Solana SDK.

---

## 1. Price the returned-name premium against the cluster clock (was #682)

`getTokenCost` / `getCostDetails` quoted the **wrong price for returned names** (post-expiry Dutch auction). The auction premium decays linearly **50x → 1x** over 14 days, and the SDK measured elapsed time with `Date.now()`:

```ts
const now = Date.now();
const elapsed = now - returned.startTimestamp;
```

The on-chain handler measures elapsed time against the **Solana cluster clock** (`Clock::get().unix_timestamp`), which lags real wall-clock by seconds-to-minutes. So the SDK over-estimated elapsed time, under-estimated the remaining premium, and **quoted low versus what the chain charges** (~3.5x/day decay → even a small clock gap moves the price).

**Fix:**
- Add read-only `getClusterUnixTimestampSeconds()` (`getSlot` → `getBlockTime`) — same stake-weighted clock the on-chain `Clock` sysvar exposes; no signer, no transaction.
- Use it (in ms) instead of `Date.now()` for the premium.
- Fetch once per `getTokenCost` and reuse it to detect a **stale demand factor** (a demand period has rolled but no crank has landed). When detected, emit a `logger.debug` warning and point callers at the simulated writeable `getCostDetails` for a byte-exact quote. We don't replicate the roll client-side — the authoritative multi-period/fee-halving math lives in the Rust program and isn't faithfully reproducible read-only.
- The coarse 180-day gateway-discount tenure gate keeps `Date.now()` (sub-minute drift is immaterial at day granularity; avoids an extra RPC round trip).

## 2. Source `getDemandFactorSettings` from program constants (was #680)

`getDemandFactorSettings` returned hand-copied literals that had drifted from the program:
- **Down-adjustment was `25` (2.5%)** while the program uses `DEMAND_FACTOR_DOWN_ADJUSTMENT = 985_000` → 0.985× → **1.5% (`15`)**. The ar.io pricing docs already say 1.5%; the SDK was the outlier.
- **`maxPeriodsAtMinDemandFactor` returned the live consecutive-period counter** instead of the `MAX_PERIODS_AT_MIN_DEMAND_FACTOR` threshold.

**Fix:** import the constants (generated from the Rust source-of-truth, published in `@ar.io/solana-contracts@1.0.1`) and derive the rate fields so they can no longer drift:

```ts
demandFactorUpAdjustmentRate:   Number(((DEMAND_FACTOR_UP_ADJUSTMENT   - scale) * 1000n) / scale), // 50
demandFactorDownAdjustmentRate: Number(((scale - DEMAND_FACTOR_DOWN_ADJUSTMENT) * 1000n) / scale), // 15
maxPeriodsAtMinDemandFactor:    MAX_PERIODS_AT_MIN_DEMAND_FACTOR,                                   // 7
```

Bumps `@ar.io/solana-contracts` `1.0.0 → 1.0.1` (the published release that exports those constants).

---

## Test

- New `demand-factor-settings.test.ts` pins the constant values/types and the derivation.
- Full offline solana unit suite: **371/371 pass**.
- `tsc --noEmit`: clean.

Supersedes #680 and #682 (both will be closed in favor of this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)