### PR TITLE
fix(solana): filter finalize_gone candidates by leave-window eligibility

### DIFF
--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -3021,6 +3021,52 @@ export class SolanaARIOReadable {
   }
 
   /**
+   * Enumerate `Leaving` Gateway PDAs that are ACTUALLY eligible for
+   * `finalizeGone` at `now` — i.e. their leave window has fully elapsed
+   * (`now >= leaveTimestamp`) AND no delegated stake remains
+   * (`totalDelegatedStake === 0`). These are exactly the two preconditions the
+   * on-chain `finalize_gone` enforces: it reverts `LeaveWindowNotExpired`
+   * before the window elapses, and will not GC a gateway that still has live
+   * delegations (programs/ario-gar/src/instructions/gateway.rs::finalize_gone).
+   *
+   * {@link getLeavingGateways} over-returns *every* `Leaving` gateway and
+   * relies on those reverts happening on-chain. A cranker that calls
+   * `finalizeGone` per result therefore burns a tx attempt — and logs a
+   * simulation failure — on every not-yet-eligible gateway, every tick. Prefer
+   * this method in cranker loops so only finalizable gateways are attempted.
+   * Mirrors the expiry-filtered discovery pattern of {@link getExpiredVaults}.
+   *
+   * @param now Unix seconds (e.g. `Math.floor(Date.now() / 1000)`).
+   */
+  async getFinalizableGoneGateways(
+    now: number,
+  ): Promise<Array<{ pubkey: Address; operator: Address }>> {
+    const accounts = await this.getAccountsByDiscriminator(
+      this.garProgram,
+      GATEWAY_DISCRIMINATOR,
+    );
+    const decoder = getGatewayDecoder();
+    const out: Array<{ pubkey: Address; operator: Address }> = [];
+    for (const { pubkey, data } of accounts) {
+      try {
+        const g = decoder.decode(data);
+        if (g.status !== GatewayStatus.Leaving) continue;
+        // `leaveTimestamp` is the leave-window END in on-chain seconds; it is
+        // `Some` for a Leaving gateway. Skip until the window has elapsed.
+        if (g.leaveTimestamp.__option !== 'Some') continue;
+        if (Number(g.leaveTimestamp.value) > now) continue;
+        // Live delegations must be cranked out first (separate GC path), else
+        // finalize_gone reverts.
+        if (g.totalDelegatedStake !== 0n) continue;
+        out.push({ pubkey, operator: g.operator });
+      } catch {
+        // skip malformed
+      }
+    }
+    return out;
+  }
+
+  /**
    * Enumerate Joined Gateway PDAs whose delegation has been DISABLED
    * (`allow_delegated_staking == false`) yet still hold delegated stake
    * (`total_delegated_stake > 0`) — i.e. delegates that an operator's disable

--- a/src/solana/prune-discovery.test.ts
+++ b/src/solana/prune-discovery.test.ts
@@ -295,7 +295,11 @@ function makeGatewayBytes(
   operator: Address,
   status: GatewayStatus,
   failedConsecutive: number,
-  opts: { allowDelegatedStaking?: boolean; totalDelegatedStake?: bigint } = {},
+  opts: {
+    allowDelegatedStaking?: boolean;
+    totalDelegatedStake?: bigint;
+    leaveTimestamp?: bigint | null;
+  } = {},
 ): Uint8Array {
   const enc = getGatewayEncoder();
   return enc.encode({
@@ -310,7 +314,7 @@ function makeGatewayBytes(
     totalDelegatedStake: opts.totalDelegatedStake ?? 0n,
     status,
     startTimestamp: 0n,
-    leaveTimestamp: null,
+    leaveTimestamp: opts.leaveTimestamp ?? null,
     leaveEpochDuration: 0n,
     stats: {
       passedEpochs: 0,
@@ -424,6 +428,90 @@ describe('SolanaARIOReadable.getLeavingGateways', () => {
     assert.equal(out.length, 1);
     assert.equal(out[0].pubkey, ADDR_B);
     assert.equal(out[0].operator, PUBKEY_2);
+  });
+});
+
+describe('SolanaARIOReadable.getFinalizableGoneGateways', () => {
+  // Leave window timestamps are on-chain seconds; fix `now` to test the boundary.
+  const NOW = 1_000_000;
+
+  it('includes a Leaving gateway whose leave window elapsed and has no delegations', async () => {
+    const joined = makeGatewayBytes(PUBKEY_1, GatewayStatus.Joined, 0);
+    const eligible = makeGatewayBytes(PUBKEY_2, GatewayStatus.Leaving, 0, {
+      leaveTimestamp: BigInt(NOW - 1), // window already elapsed
+      totalDelegatedStake: 0n,
+    });
+    const r = buildReadable(
+      stubRpcReturning([
+        { pubkey: ADDR_A, bytes: joined },
+        { pubkey: ADDR_B, bytes: eligible },
+      ]),
+    );
+
+    const out = await r.getFinalizableGoneGateways(NOW);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].pubkey, ADDR_B);
+    assert.equal(out[0].operator, PUBKEY_2);
+  });
+
+  it('excludes a Leaving gateway whose leave window has NOT elapsed (would revert LeaveWindowNotExpired)', async () => {
+    const notYet = makeGatewayBytes(PUBKEY_1, GatewayStatus.Leaving, 0, {
+      leaveTimestamp: BigInt(NOW + 1), // window ends in the future
+      totalDelegatedStake: 0n,
+    });
+    const r = buildReadable(
+      stubRpcReturning([{ pubkey: ADDR_A, bytes: notYet }]),
+    );
+    assert.deepEqual(await r.getFinalizableGoneGateways(NOW), []);
+  });
+
+  it('treats the boundary (now === leaveTimestamp) as eligible', async () => {
+    const atBoundary = makeGatewayBytes(PUBKEY_1, GatewayStatus.Leaving, 0, {
+      leaveTimestamp: BigInt(NOW),
+      totalDelegatedStake: 0n,
+    });
+    const r = buildReadable(
+      stubRpcReturning([{ pubkey: ADDR_A, bytes: atBoundary }]),
+    );
+    assert.equal((await r.getFinalizableGoneGateways(NOW)).length, 1);
+  });
+
+  it('excludes a Leaving gateway that still holds delegated stake', async () => {
+    const stillDelegated = makeGatewayBytes(
+      PUBKEY_1,
+      GatewayStatus.Leaving,
+      0,
+      {
+        leaveTimestamp: BigInt(NOW - 1),
+        totalDelegatedStake: 5_000n,
+      },
+    );
+    const r = buildReadable(
+      stubRpcReturning([{ pubkey: ADDR_A, bytes: stillDelegated }]),
+    );
+    assert.deepEqual(await r.getFinalizableGoneGateways(NOW), []);
+  });
+
+  it('excludes a Leaving gateway with no leaveTimestamp set', async () => {
+    const noWindow = makeGatewayBytes(PUBKEY_1, GatewayStatus.Leaving, 0, {
+      leaveTimestamp: null,
+      totalDelegatedStake: 0n,
+    });
+    const r = buildReadable(
+      stubRpcReturning([{ pubkey: ADDR_A, bytes: noWindow }]),
+    );
+    assert.deepEqual(await r.getFinalizableGoneGateways(NOW), []);
+  });
+
+  it('excludes Joined gateways regardless of timestamps', async () => {
+    const joined = makeGatewayBytes(PUBKEY_1, GatewayStatus.Joined, 0, {
+      leaveTimestamp: BigInt(NOW - 1),
+      totalDelegatedStake: 0n,
+    });
+    const r = buildReadable(
+      stubRpcReturning([{ pubkey: ADDR_A, bytes: joined }]),
+    );
+    assert.deepEqual(await r.getFinalizableGoneGateways(NOW), []);
   });
 });
 


### PR DESCRIPTION
## Problem

The Solana epoch cranker spams `finalize_gone` simulation failures. On AR.IO mainnet epoch go-live we saw **~280 `LeaveWindowNotExpired` (Anchor error 6079) reverts per 10 minutes** from a single operator's cranker.

Root cause: `getLeavingGateways()` / `getGoneGateways()` (`io-readable.ts`) return **every** `status === Leaving` gateway with no eligibility filter — by design, per their own comment ("over-returning not-yet-eligible Leaving gateways is safe — the tx just no-ops/reverts"). A cranker loop that calls `finalizeGone()` per result (e.g. ar-io-observer's `epoch-cranker.ts` phase-3 GC) therefore burns a tx attempt **and** logs a full simulation-failure stack trace on every gateway whose leave window hasn't elapsed, every tick. It costs no SOL (sim/revert) and doesn't wedge anything, but it's continuous noise that buries real cranker/observer logs.

The decoder already carries the eligibility data and discards it: a raw `Gateway` has `leaveTimestamp` (leave-window end, on-chain seconds) and `totalDelegatedStake` — the exact two preconditions the on-chain `finalize_gone` enforces (`programs/ario-gar/src/instructions/gateway.rs::finalize_gone` reverts before the window elapses, and won't GC a gateway with live delegations).

## Fix

Add `getFinalizableGoneGateways(now)` that returns only `Leaving` gateways where:
- the leave window has elapsed: `now >= leaveTimestamp`, and
- no delegated stake remains: `totalDelegatedStake === 0`.

This mirrors the existing expiry-filtered discovery pattern (`getExpiredVaults(now)`, `getExpiredArnsRecords(now)`). The unfiltered `getLeavingGateways()` is unchanged for callers that want raw discovery; cranker loops should prefer the filtered method. A follow-up will switch ar-io-observer's phase-3 GC to it.

## Tests

`prune-discovery.test.ts` — 6 new cases (inject encoded `Gateway` accounts, stubbed RPC):
- ✅ Leaving + window elapsed + no delegations → included
- ✅ Leaving + window not elapsed → excluded (the 6079 case)
- ✅ boundary `now === leaveTimestamp` → eligible
- ✅ Leaving + delegations remain → excluded
- ✅ Leaving + no `leaveTimestamp` → excluded
- ✅ Joined → excluded

Full solana unit suite passes; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)