### PR TITLE
fix(solana): use base64 encoding for memcmp filters in getProgramAccounts

### DIFF
--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -29,8 +29,6 @@ import {
   fetchEncodedAccounts,
   getAddressDecoder,
 } from '@solana/kit';
-import bs58 from 'bs58';
-
 import {
   ARNS_RECORD_DISCRIMINATOR,
   DEMAND_FACTOR_DOWN_ADJUSTMENT,
@@ -442,9 +440,11 @@ export class SolanaARIOReadable {
    * Helper for `getProgramAccounts` with a discriminator memcmp filter.
    *
    * Pass the Codama-generated `<NAME>_DISCRIMINATOR: Uint8Array` constant
-   * directly — kit's RPC requires a base58 string for `memcmp.bytes`, so
-   * we bs58-encode here to keep call sites from doing it inline (and to
-   * keep the IDL-derived bytes as the single source of truth).
+   * directly — we base64-encode here to keep call sites from doing it
+   * inline (and to keep the IDL-derived bytes as the single source of
+   * truth). Uses base64 rather than base58 because some browser
+   * environments / RPC proxies mishandle base58-encoded memcmp filters
+   * when multiple filters are present.
    */
   private async getAccountsByDiscriminator(
     programId: Address,
@@ -455,8 +455,8 @@ export class SolanaARIOReadable {
       {
         memcmp: {
           offset: 0n,
-          bytes: bs58.encode(discriminator as Uint8Array),
-          encoding: 'base58',
+          bytes: Buffer.from(discriminator as Uint8Array).toString('base64'),
+          encoding: 'base64',
         },
       },
       ...extraFilters,
@@ -1657,8 +1657,8 @@ export class SolanaARIOReadable {
         {
           memcmp: {
             offset: 8n,
-            bytes: bs58.encode(epochIndexBuf),
-            encoding: 'base58',
+            bytes: Buffer.from(epochIndexBuf).toString('base64'),
+            encoding: 'base64',
           },
         },
       ],
@@ -1717,8 +1717,8 @@ export class SolanaARIOReadable {
         {
           memcmp: {
             offset: 8n,
-            bytes: bs58.encode(epochIndexBuf),
-            encoding: 'base58',
+            bytes: Buffer.from(epochIndexBuf).toString('base64'),
+            encoding: 'base64',
           },
         },
       ],

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -1,34 +1,3 @@
-/**
- * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-/**
- * Solana implementation of the ARIORead interface.
- *
- * Reads AR.IO protocol state directly from Solana PDAs using RPC,
- * returning the same types that the AO implementation returns.
- * This allows consumers to switch backends transparently.
- */
-import {
-  type Address,
-  type Commitment,
-  type ReadonlyUint8Array,
-  address,
-  fetchEncodedAccount,
-  fetchEncodedAccounts,
-  getAddressDecoder,
-} from '@solana/kit';
 import {
   ARNS_RECORD_DISCRIMINATOR,
   DEMAND_FACTOR_DOWN_ADJUSTMENT,
@@ -63,6 +32,37 @@ import {
   getGatewayDecoder,
   getWithdrawalDecoder,
 } from '@ar.io/solana-contracts/gar';
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Solana implementation of the ARIORead interface.
+ *
+ * Reads AR.IO protocol state directly from Solana PDAs using RPC,
+ * returning the same types that the AO implementation returns.
+ * This allows consumers to switch backends transparently.
+ */
+import {
+  type Address,
+  type Commitment,
+  type ReadonlyUint8Array,
+  address,
+  fetchEncodedAccount,
+  fetchEncodedAccounts,
+  getAddressDecoder,
+} from '@solana/kit';
 import { type ILogger, Logger } from '../common/logger.js';
 import type {
   PrimaryName,

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -1,3 +1,25 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Solana implementation of the ARIORead interface.
+ *
+ * Reads AR.IO protocol state directly from Solana PDAs using RPC,
+ * returning the same types that the AO implementation returns.
+ * This allows consumers to switch backends transparently.
+ */
 import {
   ARNS_RECORD_DISCRIMINATOR,
   DEMAND_FACTOR_DOWN_ADJUSTMENT,
@@ -32,28 +54,6 @@ import {
   getGatewayDecoder,
   getWithdrawalDecoder,
 } from '@ar.io/solana-contracts/gar';
-/**
- * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-/**
- * Solana implementation of the ARIORead interface.
- *
- * Reads AR.IO protocol state directly from Solana PDAs using RPC,
- * returning the same types that the AO implementation returns.
- * This allows consumers to switch backends transparently.
- */
 import {
   type Address,
   type Commitment,


### PR DESCRIPTION
## Summary
- Switch `getAccountsByDiscriminator`, `getObservations`, and `getEpochObservers` from `bs58`/`base58` to `Buffer.toString('base64')`/`base64` for memcmp filter encoding
- Remove unused `bs58` import

## Problem
Browser-bundled apps (e.g. the network portal via Vite) get **0 results** from `getProgramAccounts` when multiple memcmp filters use base58 encoding. The RPC call succeeds but matches zero accounts. The same call works correctly in Node.js.

**Reproduction:** The network portal's `getObservations()` (discriminator + epoch index = 2 filters) returns empty in the browser, while the identical call from Node.js returns the correct 4-5 observation accounts. Single-filter calls like `getGateways()` (discriminator only) work fine in both environments.

**Root cause:** The browser-polyfilled `bs58` encoder produces strings that fail to match on-chain data when combined with multiple memcmp filters. Switching to base64 encoding (equally valid per the Solana JSON-RPC spec) resolves the issue in both environments.

## Changes
- `getAccountsByDiscriminator`: discriminator filter → base64
- `getObservations`: epoch index filter → base64
- `getEpochObservers`: epoch index filter → base64
- Address-string filters (already base58 public keys, e.g. gateway/owner lookups) are **unchanged** — they work fine

## Test plan
- [x] `io-readable.test.ts` passes
- [x] SDK builds clean (`yarn build`)
- [x] Verified `getObservations({epochIndex: 454})` returns 4+ reports via Node.js with both `createSolanaRpc` and `createCircuitBreakerRpc`
- [x] Verified network portal shows "Submitted" status for observers after applying this fix
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)