### PR TITLE
fix(solana): finalize_gone eligibility must use the full leave window

### DIFF
--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -324,6 +324,21 @@ function paginate<T>(
  * const record = await ario.getArNSRecord({ name: 'ardrive' });
  * ```
  */
+
+/**
+ * Fixed leave cooldown (seconds) a `Leaving` gateway must wait before
+ * `finalize_gone` can GC it. Mirrors the on-chain `GATEWAY_LEAVE_PERIOD`
+ * (90 days) in ar-io-solana-contracts (`programs/ario-gar/src/lib.rs`).
+ */
+const GATEWAY_LEAVE_PERIOD_SECONDS = 90 * 86_400; // 7_776_000
+
+/**
+ * Epoch-retention multiplier in the on-chain finalize_gone window
+ * (`leave_timestamp + GATEWAY_LEAVE_PERIOD + 7 * epoch_duration`), mirroring
+ * the GAR-006 epoch retention.
+ */
+const FINALIZE_GONE_EPOCH_RETENTION = 7;
+
 export class SolanaARIOReadable {
   protected readonly rpc: SolanaRpc;
   protected readonly commitment: Commitment;
@@ -3022,25 +3037,45 @@ export class SolanaARIOReadable {
 
   /**
    * Enumerate `Leaving` Gateway PDAs that are ACTUALLY eligible for
-   * `finalizeGone` at `now` — i.e. their leave window has fully elapsed
-   * (`now >= leaveTimestamp`) AND no delegated stake remains
-   * (`totalDelegatedStake === 0`). These are exactly the two preconditions the
-   * on-chain `finalize_gone` enforces: it reverts `LeaveWindowNotExpired`
-   * before the window elapses, and will not GC a gateway that still has live
-   * delegations (programs/ario-gar/src/instructions/gateway.rs::finalize_gone).
+   * `finalizeGone` at `now`. The on-chain GC window
+   * (`programs/ario-gar/src/instructions/gateway.rs::finalize_gone`) is:
    *
-   * {@link getLeavingGateways} over-returns *every* `Leaving` gateway and
-   * relies on those reverts happening on-chain. A cranker that calls
-   * `finalizeGone` per result therefore burns a tx attempt — and logs a
-   * simulation failure — on every not-yet-eligible gateway, every tick. Prefer
-   * this method in cranker loops so only finalizable gateways are attempted.
-   * Mirrors the expiry-filtered discovery pattern of {@link getExpiredVaults}.
+   * ```
+   * eligibleAt = leaveTimestamp
+   *            + GATEWAY_LEAVE_PERIOD                 // 90 days, fixed
+   *            + 7 * max(leaveEpochDuration, epoch_settings.epoch_duration)
+   * ```
+   *
+   * The 7-epoch term mirrors GAR-006 epoch retention; the `max` is the
+   * program's defense against an admin shortening `epoch_duration` after a
+   * gateway left (`leaveEpochDuration` is the snapshot taken at leave time).
+   * A gateway is finalizable only once `now >= eligibleAt` AND it holds no
+   * delegated stake (`totalDelegatedStake === 0`) — `finalize_gone` reverts
+   * `LeaveWindowNotExpired` before the window and won't GC a gateway with live
+   * delegations.
+   *
+   * {@link getLeavingGateways} over-returns *every* `Leaving` gateway; a cranker
+   * that calls `finalizeGone` on those burns a reverting tx (and a logged
+   * simulation failure) on every not-yet-eligible gateway each tick. Prefer
+   * this method in cranker loops so only truly-finalizable gateways are tried.
    *
    * @param now Unix seconds (e.g. `Math.floor(Date.now() / 1000)`).
    */
   async getFinalizableGoneGateways(
     now: number,
   ): Promise<Array<{ pubkey: Address; operator: Address }>> {
+    // Current epoch_duration (seconds) for the on-chain `max(snapshot, current)`.
+    // If the settings read fails, fall back to 0 so only the per-gateway
+    // snapshot is used — the dominant GATEWAY_LEAVE_PERIOD term still applies.
+    let currentEpochDuration = 0;
+    try {
+      currentEpochDuration = Number(
+        (await this.getEpochSettings()).epochDuration,
+      );
+    } catch {
+      // settings unavailable — snapshot-only window
+    }
+
     const accounts = await this.getAccountsByDiscriminator(
       this.garProgram,
       GATEWAY_DISCRIMINATOR,
@@ -3051,13 +3086,19 @@ export class SolanaARIOReadable {
       try {
         const g = decoder.decode(data);
         if (g.status !== GatewayStatus.Leaving) continue;
-        // `leaveTimestamp` is the leave-window END in on-chain seconds; it is
-        // `Some` for a Leaving gateway. Skip until the window has elapsed.
         if (g.leaveTimestamp.__option !== 'Some') continue;
-        if (Number(g.leaveTimestamp.value) > now) continue;
         // Live delegations must be cranked out first (separate GC path), else
         // finalize_gone reverts.
         if (g.totalDelegatedStake !== 0n) continue;
+        const epochDuration = Math.max(
+          Number(g.leaveEpochDuration),
+          currentEpochDuration,
+        );
+        const eligibleAt =
+          Number(g.leaveTimestamp.value) +
+          GATEWAY_LEAVE_PERIOD_SECONDS +
+          FINALIZE_GONE_EPOCH_RETENTION * epochDuration;
+        if (eligibleAt > now) continue;
         out.push({ pubkey, operator: g.operator });
       } catch {
         // skip malformed

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -3069,9 +3069,10 @@ export class SolanaARIOReadable {
     // snapshot is used — the dominant GATEWAY_LEAVE_PERIOD term still applies.
     let currentEpochDuration = 0;
     try {
-      currentEpochDuration = Number(
-        (await this.getEpochSettings()).epochDuration,
-      );
+      // getEpochSettings() exposes the duration as `durationMs`; the on-chain
+      // window math is in seconds (matching leaveTimestamp/leaveEpochDuration).
+      currentEpochDuration =
+        Number((await this.getEpochSettings()).durationMs) / 1000;
     } catch {
       // settings unavailable — snapshot-only window
     }

--- a/src/solana/prune-discovery.test.ts
+++ b/src/solana/prune-discovery.test.ts
@@ -299,6 +299,7 @@ function makeGatewayBytes(
     allowDelegatedStaking?: boolean;
     totalDelegatedStake?: bigint;
     leaveTimestamp?: bigint | null;
+    leaveEpochDuration?: bigint;
   } = {},
 ): Uint8Array {
   const enc = getGatewayEncoder();
@@ -315,7 +316,7 @@ function makeGatewayBytes(
     status,
     startTimestamp: 0n,
     leaveTimestamp: opts.leaveTimestamp ?? null,
-    leaveEpochDuration: 0n,
+    leaveEpochDuration: opts.leaveEpochDuration ?? 0n,
     stats: {
       passedEpochs: 0,
       failedEpochs: failedConsecutive,
@@ -432,13 +433,19 @@ describe('SolanaARIOReadable.getLeavingGateways', () => {
 });
 
 describe('SolanaARIOReadable.getFinalizableGoneGateways', () => {
-  // Leave window timestamps are on-chain seconds; fix `now` to test the boundary.
-  const NOW = 1_000_000;
+  // On-chain seconds. finalize_gone window =
+  //   leaveTimestamp + GATEWAY_LEAVE_PERIOD (90d) + 7 * max(leaveEpochDuration, epoch_duration).
+  // The stubbed rpc has no epoch-settings account, so getEpochSettings() throws
+  // and the method falls back to currentEpochDuration = 0 (snapshot-only window).
+  const NOW = 1_700_000_000;
+  const LEAVE_PERIOD = 7_776_000; // 90 days
+  const DAY = 86_400;
 
-  it('includes a Leaving gateway whose leave window elapsed and has no delegations', async () => {
+  it('includes a Leaving gateway past the full 90d window with no delegations', async () => {
     const joined = makeGatewayBytes(PUBKEY_1, GatewayStatus.Joined, 0);
     const eligible = makeGatewayBytes(PUBKEY_2, GatewayStatus.Leaving, 0, {
-      leaveTimestamp: BigInt(NOW - 1), // window already elapsed
+      leaveTimestamp: BigInt(NOW - LEAVE_PERIOD - 100), // window fully elapsed
+      leaveEpochDuration: 0n,
       totalDelegatedStake: 0n,
     });
     const r = buildReadable(
@@ -454,20 +461,10 @@ describe('SolanaARIOReadable.getFinalizableGoneGateways', () => {
     assert.equal(out[0].operator, PUBKEY_2);
   });
 
-  it('excludes a Leaving gateway whose leave window has NOT elapsed (would revert LeaveWindowNotExpired)', async () => {
-    const notYet = makeGatewayBytes(PUBKEY_1, GatewayStatus.Leaving, 0, {
-      leaveTimestamp: BigInt(NOW + 1), // window ends in the future
-      totalDelegatedStake: 0n,
-    });
-    const r = buildReadable(
-      stubRpcReturning([{ pubkey: ADDR_A, bytes: notYet }]),
-    );
-    assert.deepEqual(await r.getFinalizableGoneGateways(NOW), []);
-  });
-
-  it('treats the boundary (now === leaveTimestamp) as eligible', async () => {
+  it('treats exactly leaveTimestamp + 90d (epochDuration 0) as eligible (boundary)', async () => {
     const atBoundary = makeGatewayBytes(PUBKEY_1, GatewayStatus.Leaving, 0, {
-      leaveTimestamp: BigInt(NOW),
+      leaveTimestamp: BigInt(NOW - LEAVE_PERIOD),
+      leaveEpochDuration: 0n,
       totalDelegatedStake: 0n,
     });
     const r = buildReadable(
@@ -476,13 +473,43 @@ describe('SolanaARIOReadable.getFinalizableGoneGateways', () => {
     assert.equal((await r.getFinalizableGoneGateways(NOW)).length, 1);
   });
 
+  it('excludes a recently-left gateway still inside the 90d window (the LeaveWindowNotExpired case)', async () => {
+    // Left 1000s ago — far short of the 90d cooldown. This is the production
+    // scenario the leaveTimestamp-only filter wrongly admitted.
+    const recent = makeGatewayBytes(PUBKEY_1, GatewayStatus.Leaving, 0, {
+      leaveTimestamp: BigInt(NOW - 1000),
+      leaveEpochDuration: BigInt(DAY),
+      totalDelegatedStake: 0n,
+    });
+    const r = buildReadable(
+      stubRpcReturning([{ pubkey: ADDR_A, bytes: recent }]),
+    );
+    assert.deepEqual(await r.getFinalizableGoneGateways(NOW), []);
+  });
+
+  it('accounts for the 7*epoch_duration term — past 90d but not past 90d + 7 epochs is NOT eligible', async () => {
+    // 100s past the 90d mark, but 7 * 1-day epochs (7 days) has not elapsed →
+    // finalize_gone would still revert, so it must be excluded. This is the
+    // case the original leaveTimestamp-only filter got wrong.
+    const within7Epochs = makeGatewayBytes(PUBKEY_1, GatewayStatus.Leaving, 0, {
+      leaveTimestamp: BigInt(NOW - LEAVE_PERIOD - 100),
+      leaveEpochDuration: BigInt(DAY), // 7 * 86400 = 7 days >> 100s remaining
+      totalDelegatedStake: 0n,
+    });
+    const r = buildReadable(
+      stubRpcReturning([{ pubkey: ADDR_A, bytes: within7Epochs }]),
+    );
+    assert.deepEqual(await r.getFinalizableGoneGateways(NOW), []);
+  });
+
   it('excludes a Leaving gateway that still holds delegated stake', async () => {
     const stillDelegated = makeGatewayBytes(
       PUBKEY_1,
       GatewayStatus.Leaving,
       0,
       {
-        leaveTimestamp: BigInt(NOW - 1),
+        leaveTimestamp: BigInt(NOW - LEAVE_PERIOD - 100), // window elapsed
+        leaveEpochDuration: 0n,
         totalDelegatedStake: 5_000n,
       },
     );
@@ -505,7 +532,7 @@ describe('SolanaARIOReadable.getFinalizableGoneGateways', () => {
 
   it('excludes Joined gateways regardless of timestamps', async () => {
     const joined = makeGatewayBytes(PUBKEY_1, GatewayStatus.Joined, 0, {
-      leaveTimestamp: BigInt(NOW - 1),
+      leaveTimestamp: BigInt(NOW - LEAVE_PERIOD - 100),
       totalDelegatedStake: 0n,
     });
     const r = buildReadable(


### PR DESCRIPTION
## Corrects #685

`getFinalizableGoneGateways(now)` (added in #685) filtered on `leaveTimestamp <= now` only. But the on-chain `finalize_gone` GC window (`programs/ario-gar/src/instructions/gateway.rs`) is:

```
eligibleAt = leaveTimestamp + GATEWAY_LEAVE_PERIOD (90 days)
                            + 7 × max(leaveEpochDuration_snapshot, epoch_settings.epoch_duration)
```

So #685 returned gateways still inside their ~97-day cooldown. A cranker calling `finalizeGone` on them hits the exact revert the method was supposed to prevent (`LeaveWindowNotExpired` / 6079).

**Verified live on mainnet** (running the #685 build in an isolated observer on an operator box): `getFinalizableGoneGateways` returned **33 "eligible"** → **0 finalize_gone successes, 100% reverted**. The spam continued unchanged.

## Fix
Compute the real window:
- `GATEWAY_LEAVE_PERIOD_SECONDS = 90 * 86_400` (mirrors `ario-gar` `GATEWAY_LEAVE_PERIOD`).
- `+ 7 * max(leaveEpochDuration, current epoch_duration)` — read current `epoch_duration` via `getEpochSettings()`; on read failure, fall back to the per-gateway snapshot (the 90-day term still dominates).
- Keep the `totalDelegatedStake === 0` precondition.

## Tests
`prune-discovery.test.ts` rewritten for the real window — incl. a **regression test** for "past 90d but not past 90d + 7 epochs → NOT eligible" (the case the old filter wrongly admitted), plus boundary, recently-left, delegated-stake, no-timestamp, and Joined cases. Full solana unit suite: **321 pass / 0 fail**; biome clean.

## Rollout
Release → bump `@ar.io/sdk` in ar-io-observer (the consumer already calls `getFinalizableGoneGateways(now)` via #100, no code change) → rebuild observer image → deploy. Expectation on the current young mainnet: **0 finalizable gateways → 0 finalize_gone attempts → no spam.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved gateway finalization eligibility calculations by properly accounting for epoch duration and aligning system behavior with on-chain requirements, ensuring gateways transition correctly through their lifecycle at the appropriate time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->