### PR TITLE
release: stabilize alpha → main (finalize_gone window + Solana fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.2-alpha.3](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.2...v4.0.2-alpha.3) (2026-06-07)
+
+
+### Bug Fixes
+
+* **arns:** floor returned-name premium at 1x to match on-chain pricing ([9ddfd9e](https://github.com/ar-io/ar-io-sdk/commit/9ddfd9eac36e3a2d14aa9152450dbfbfbf7dd955))
+
 ## [4.0.2-alpha.2](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.1...v4.0.2-alpha.2) (2026-06-06)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.2-alpha.9](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.8...v4.0.2-alpha.9) (2026-06-17)
+
+
+### Bug Fixes
+
+* **solana:** use base64 encoding for memcmp filters in getProgramAccounts ([26de129](https://github.com/ar-io/ar-io-sdk/commit/26de12916ffaaa3ad4ee8917b9db568fe2b6b95e))
+
 ## [4.0.2-alpha.8](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.7...v4.0.2-alpha.8) (2026-06-16)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [4.0.2-alpha.1](https://github.com/ar-io/ar-io-sdk/compare/v4.0.1...v4.0.2-alpha.1) (2026-06-06)
+
+
+### Bug Fixes
+
+* **primary names:** fix primary names funding plan for permabought names ([0aac17c](https://github.com/ar-io/ar-io-sdk/commit/0aac17c7626f8487417e8bc4631c5954f89c558b))
+* **signing:** update signing to include compute budget and limit, update blockheight logic ([189dc44](https://github.com/ar-io/ar-io-sdk/commit/189dc4447917cd868b0e4d757615b7569acc9ac2))
+* **undername increase:** fix undername increase action ([83aa1de](https://github.com/ar-io/ar-io-sdk/commit/83aa1deb7944fcf73a8253cd9f31c5c98cf63438))
+
 ## [4.0.1](https://github.com/ar-io/ar-io-sdk/compare/v4.0.0...v4.0.1) (2026-06-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## [4.0.3-alpha.1](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2...v4.0.3-alpha.1) (2026-06-20)
+
+
+### Bug Fixes
+
+* **arns:** floor returned-name premium at 1x to match on-chain pricing ([9ddfd9e](https://github.com/ar-io/ar-io-sdk/commit/9ddfd9eac36e3a2d14aa9152450dbfbfbf7dd955))
+* chunk delegates getMultipleAccounts call at 100 ([bfeaa60](https://github.com/ar-io/ar-io-sdk/commit/bfeaa6042507491dbd2b2714272d1bd25f1ce3fb))
+* **cli:** normalize argv[1] path separators for Windows compatibility ([c1d100b](https://github.com/ar-io/ar-io-sdk/commit/c1d100bad47537ceaa0a6c70a01e8fff52dbbe63))
+* **gas est:** add gas estimation utils ([12f2bcf](https://github.com/ar-io/ar-io-sdk/commit/12f2bcf8ba680757712d6f1c52cf6572d2e1b4ff))
+* **gas:** update gas estimate logic ([e667568](https://github.com/ar-io/ar-io-sdk/commit/e667568d712c9700e8f07356cdcb3c7aaf0ea21b))
+* **gas:** update gas utils comments ([af4889b](https://github.com/ar-io/ar-io-sdk/commit/af4889bd1d29fbfa6f462a349b10319a2f856edf))
+* **primary names:** fix primary names funding plan for permabought names ([0aac17c](https://github.com/ar-io/ar-io-sdk/commit/0aac17c7626f8487417e8bc4631c5954f89c558b))
+* **send tx:** update send tx ([693cb93](https://github.com/ar-io/ar-io-sdk/commit/693cb9391c9a87b3d6b4025e8a943b0d2659c226))
+* **solana:** filter finalize_gone candidates by leave-window eligibility ([900319c](https://github.com/ar-io/ar-io-sdk/commit/900319c43fb5a090e00d43a2f74309f3d18c047e))
+* **solana:** finalize_gone eligibility must use the full leave window ([49c70d2](https://github.com/ar-io/ar-io-sdk/commit/49c70d202f1bcdbe45448d26eb55028ba6471fdc)), closes [#685](https://github.com/ar-io/ar-io-sdk/issues/685)
+* **solana:** price returned-name premium against the cluster clock ([8ffec26](https://github.com/ar-io/ar-io-sdk/commit/8ffec264a77f0a54f0f83d484fe0431bb0094827))
+* **solana:** source demand-factor settings from program constants ([f5bccb1](https://github.com/ar-io/ar-io-sdk/commit/f5bccb123da246fa2aabccb5d632965ca5bb56f1)), closes [ar-io/ar-io-solana-contracts#export-arns-constants](https://github.com/ar-io/ar-io-solana-contracts/issues/export-arns-constants)
+* **solana:** use base64 encoding for memcmp filters in getProgramAccounts ([26de129](https://github.com/ar-io/ar-io-sdk/commit/26de12916ffaaa3ad4ee8917b9db568fe2b6b95e))
+* **solana:** use epoch duration in seconds for finalize_gone window ([de99061](https://github.com/ar-io/ar-io-sdk/commit/de990613af7806a1b7a0c96a0d0e453eeb09f1aa))
+* **undername increase:** fix undername increase action ([83aa1de](https://github.com/ar-io/ar-io-sdk/commit/83aa1deb7944fcf73a8253cd9f31c5c98cf63438))
+
 ## [4.0.2-alpha.10](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.9...v4.0.2-alpha.10) (2026-06-18)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.0.2-alpha.10](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.9...v4.0.2-alpha.10) (2026-06-18)
+
+
+### Bug Fixes
+
+* **solana:** finalize_gone eligibility must use the full leave window ([49c70d2](https://github.com/ar-io/ar-io-sdk/commit/49c70d202f1bcdbe45448d26eb55028ba6471fdc)), closes [#685](https://github.com/ar-io/ar-io-sdk/issues/685)
+* **solana:** use epoch duration in seconds for finalize_gone window ([de99061](https://github.com/ar-io/ar-io-sdk/commit/de990613af7806a1b7a0c96a0d0e453eeb09f1aa))
+
 ## [4.0.2-alpha.9](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.8...v4.0.2-alpha.9) (2026-06-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.2-alpha.4](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.3...v4.0.2-alpha.4) (2026-06-08)
+
+
+### Bug Fixes
+
+* chunk delegates getMultipleAccounts call at 100 ([bfeaa60](https://github.com/ar-io/ar-io-sdk/commit/bfeaa6042507491dbd2b2714272d1bd25f1ce3fb))
+
 ## [4.0.2-alpha.3](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.2...v4.0.2-alpha.3) (2026-06-07)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.2-alpha.2](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.1...v4.0.2-alpha.2) (2026-06-06)
+
+
+### Bug Fixes
+
+* **send tx:** update send tx ([693cb93](https://github.com/ar-io/ar-io-sdk/commit/693cb9391c9a87b3d6b4025e8a943b0d2659c226))
+
 ## [4.0.2-alpha.1](https://github.com/ar-io/ar-io-sdk/compare/v4.0.1...v4.0.2-alpha.1) (2026-06-06)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.0.2-alpha.6](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.5...v4.0.2-alpha.6) (2026-06-09)
+
+
+### Bug Fixes
+
+* **solana:** price returned-name premium against the cluster clock ([8ffec26](https://github.com/ar-io/ar-io-sdk/commit/8ffec264a77f0a54f0f83d484fe0431bb0094827))
+* **solana:** source demand-factor settings from program constants ([f5bccb1](https://github.com/ar-io/ar-io-sdk/commit/f5bccb123da246fa2aabccb5d632965ca5bb56f1)), closes [ar-io/ar-io-solana-contracts#export-arns-constants](https://github.com/ar-io/ar-io-solana-contracts/issues/export-arns-constants)
+
 ## [4.0.2-alpha.5](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.4...v4.0.2-alpha.5) (2026-06-09)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.2-alpha.5](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.4...v4.0.2-alpha.5) (2026-06-09)
+
+
+### Bug Fixes
+
+* **cli:** normalize argv[1] path separators for Windows compatibility ([c1d100b](https://github.com/ar-io/ar-io-sdk/commit/c1d100bad47537ceaa0a6c70a01e8fff52dbbe63))
+
 ## [4.0.2-alpha.4](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.3...v4.0.2-alpha.4) (2026-06-08)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.2-alpha.8](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.7...v4.0.2-alpha.8) (2026-06-16)
+
+
+### Bug Fixes
+
+* **solana:** filter finalize_gone candidates by leave-window eligibility ([900319c](https://github.com/ar-io/ar-io-sdk/commit/900319c43fb5a090e00d43a2f74309f3d18c047e))
+
 ## [4.0.2-alpha.7](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.6...v4.0.2-alpha.7) (2026-06-12)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [4.0.2-alpha.7](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.6...v4.0.2-alpha.7) (2026-06-12)
+
+
+### Bug Fixes
+
+* **gas est:** add gas estimation utils ([12f2bcf](https://github.com/ar-io/ar-io-sdk/commit/12f2bcf8ba680757712d6f1c52cf6572d2e1b4ff))
+* **gas:** update gas estimate logic ([e667568](https://github.com/ar-io/ar-io-sdk/commit/e667568d712c9700e8f07356cdcb3c7aaf0ea21b))
+* **gas:** update gas utils comments ([af4889b](https://github.com/ar-io/ar-io-sdk/commit/af4889bd1d29fbfa6f462a349b10319a2f856edf))
+
 ## [4.0.2-alpha.6](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2-alpha.5...v4.0.2-alpha.6) (2026-06-09)
 
 

--- a/README.md
+++ b/README.md
@@ -1624,6 +1624,8 @@ const price = await ario
 
 Calculates the expanded cost details for the interaction in question, e.g a 'Buy-Name' interaction, where args are the specific params for that interaction. The fromAddress is the address that would be charged for the interaction, and fundFrom is where the funds would be taken from, either `balance`, `stakes`, or `any`.
 
+On Solana, the result also includes a `gasEstimate` — the total SOL (in lamports) the wallet needs to execute the intent: transaction fees (quoted from recent on-chain prioritization fees) plus rent-exempt deposits for the accounts the flow creates. For `Buy-Name` that covers both transactions (ANT spawn + buy) and the rent for the spawned asset/PDAs and the ArNS record; first-time buyers with no ACL accounts yet are quoted the ACL bootstrap rent as well (pass `fromAddress` so that check can be made). The fee side is a conservative upper bound: the write path tightens the compute-unit limit from a pre-send simulation, so the landed fee is usually lower.
+
 ```typescript
 const costDetails = await ario.getCostDetails({
   intent: "Buy-Name",
@@ -1646,7 +1648,19 @@ const costDetails = await ario.getCostDetails({
       "discountTotal": 476850455,
       "multiplier": 0.8
     }
-  ]
+  ],
+  "gasEstimate": {
+    "totalLamports": 14679680,
+    "feeLamports": 23000,
+    "baseFeeLamports": 15000,
+    "priorityFeeLamports": 8000,
+    "rentLamports": 14656680,
+    "rentReclaimedLamports": 0,
+    "priorityFeeMicroLamports": 10000,
+    "computeUnitLimit": 400000,
+    "signatureCount": 3,
+    "transactionCount": 2
+  }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.0.2-alpha.3",
+  "version": "4.0.2-alpha.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.0.1",
+  "version": "4.0.2-alpha.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.0.2-alpha.2",
+  "version": "4.0.2-alpha.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.0.2-alpha.4",
+  "version": "4.0.2-alpha.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@ar.io/solana-contracts": "1.0.0",
+    "@ar.io/solana-contracts": "1.0.1",
     "@noble/hashes": "^1.8.0",
     "@solana-program/address-lookup-table": "^0.11.0",
     "@solana-program/compute-budget": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.0.2-alpha.7",
+  "version": "4.0.2-alpha.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.0.2-alpha.9",
+  "version": "4.0.2-alpha.10",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.0.2-alpha.8",
+  "version": "4.0.2-alpha.9",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.0.2-alpha.5",
+  "version": "4.0.2-alpha.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.0.2-alpha.1",
+  "version": "4.0.2-alpha.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.0.2",
+  "version": "4.0.3-alpha.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.0.2-alpha.6",
+  "version": "4.0.2-alpha.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1227,9 +1227,11 @@ makeCommand({
   action: escrowClaimEthereumCLICommand,
 });
 
+const normalizedArgv1 = process.argv[1].replace(/\\/g, '/');
+
 if (
-  process.argv[1].includes('bin/ar.io') || // Running from global .bin
-  process.argv[1].includes('cli/cli') // Running from source
+  normalizedArgv1.includes('bin/ar.io') || // Running from global .bin
+  normalizedArgv1.includes('cli/cli') // Running from source
 ) {
   program.parse(process.argv);
 }

--- a/src/solana/ant-readable.ts
+++ b/src/solana/ant-readable.ts
@@ -56,7 +56,7 @@ import { SolanaANTRegistryReadable } from './ant-registry-readable.js';
 import { ANT_CONFIG_VERSION, ARIO_ANT_PROGRAM_ID } from './constants.js';
 import {
   ACL_BOOTSTRAP_ACCOUNT_BYTES,
-  antRecordBytes,
+  ANT_RECORD_BYTES,
   estimateRentLamports,
   spawnAntAccountBytes,
 } from './gas.js';
@@ -279,7 +279,7 @@ export class SolanaANTReadable {
    */
   async getGasEstimate(
     params:
-      | { workflow: 'set-record'; undername: string; targetLength?: number }
+      | { workflow: 'set-record'; undername: string }
       // Editing an existing record mutates in place — fees only.
       | { workflow: 'edit-record'; undername: string }
       | { workflow: 'remove-record'; undername: string }
@@ -292,7 +292,7 @@ export class SolanaANTReadable {
     switch (params.workflow) {
       case 'set-record': {
         const rentLamports = await estimateRentLamports(this.rpc, [
-          antRecordBytes(params.undername.length, params.targetLength),
+          ANT_RECORD_BYTES,
         ]);
         return estimateGasFee(this.rpc, { rentLamports });
       }

--- a/src/solana/ant-readable.ts
+++ b/src/solana/ant-readable.ts
@@ -51,15 +51,24 @@ import type {
   SortedANTRecords,
 } from '../types/ant.js';
 import type { WalletAddress } from '../types/common.js';
+import type { GasEstimate } from '../types/io.js';
 import { SolanaANTRegistryReadable } from './ant-registry-readable.js';
 import { ANT_CONFIG_VERSION, ARIO_ANT_PROGRAM_ID } from './constants.js';
 import {
+  ACL_BOOTSTRAP_ACCOUNT_BYTES,
+  antRecordBytes,
+  estimateRentLamports,
+  spawnAntAccountBytes,
+} from './gas.js';
+import {
+  getAclConfigPDA,
   getAntConfigPDA,
   getAntControllersPDA,
   getAntRecordMetadataPDA,
   getAntRecordPDA,
 } from './pda.js';
 import { withRetry } from './retry.js';
+import { estimateGasFee } from './send.js';
 import type { SolanaRpc } from './types.js';
 
 /**
@@ -245,6 +254,107 @@ export class SolanaANTReadable {
   async getOwner(_opts?: AntReadOptions): Promise<WalletAddress> {
     const config = await this.fetchConfig();
     return config.owner;
+  }
+
+  /**
+   * Estimate the Solana network cost ("gas") of an ANT management action,
+   * in lamports — transaction fees plus rent for accounts the action
+   * creates, and (for closes) the rent refunded back to the caller.
+   *
+   * - `set-record` (add/edit undername): creating the record deposits rent
+   *   (~0.0022 SOL); editing an existing record costs fees only, but this
+   *   quote conservatively assumes creation.
+   * - `remove-record`: the record account (and its metadata PDA, if any) is
+   *   CLOSED and its actual on-chain deposit refunded to the caller —
+   *   reported in `rentReclaimedLamports`, read live from the chain.
+   * - `transfer`: the caller pays to bootstrap the RECIPIENT's ACL
+   *   registry accounts (~0.06 SOL) when the recipient has never owned an
+   *   ANT; otherwise fees only. Removed ACL entries don't refund rent —
+   *   pages stay open.
+   * - `reassign-name`: mutates the ArNS record in place; fees only.
+   *
+   * Never throws on the quote path: fee and rent queries fall back
+   * internally, and the recipient-ACL check falls back to the conservative
+   * (bootstrap-needed) assumption.
+   */
+  async getGasEstimate(
+    params:
+      | { workflow: 'set-record'; undername: string; targetLength?: number }
+      // Editing an existing record mutates in place — fees only.
+      | { workflow: 'edit-record'; undername: string }
+      | { workflow: 'remove-record'; undername: string }
+      | { workflow: 'transfer'; recipient: WalletAddress }
+      // `spawnsNewAnt` covers the "reassign to a brand-new ANT" flow,
+      // which spawns a fresh asset first (rent for the spawned accounts;
+      // `name` sizes the name-bearing ones).
+      | { workflow: 'reassign-name'; spawnsNewAnt?: boolean; name?: string },
+  ): Promise<GasEstimate> {
+    switch (params.workflow) {
+      case 'set-record': {
+        const rentLamports = await estimateRentLamports(this.rpc, [
+          antRecordBytes(params.undername.length, params.targetLength),
+        ]);
+        return estimateGasFee(this.rpc, { rentLamports });
+      }
+      case 'remove-record': {
+        // Exact, not modeled: the close refunds whatever the record account
+        // actually holds, so read its (and the metadata PDA's) lamports.
+        let rentReclaimedLamports = 0;
+        try {
+          const [[recordPda], [metaPda]] = await Promise.all([
+            getAntRecordPDA(this.mint, params.undername, this.antProgram),
+            getAntRecordMetadataPDA(
+              this.mint,
+              params.undername,
+              this.antProgram,
+            ),
+          ]);
+          const accounts = await withRetry(() =>
+            fetchEncodedAccounts(this.rpc, [recordPda, metaPda], {
+              commitment: this.commitment,
+            }),
+          );
+          rentReclaimedLamports = accounts.reduce(
+            (sum, a) => (a.exists ? sum + Number(a.lamports) : sum),
+            0,
+          );
+        } catch {
+          // Quote stays fees-only; the refund still happens on chain.
+        }
+        return estimateGasFee(this.rpc, { rentReclaimedLamports });
+      }
+      case 'transfer': {
+        let needsAclBootstrap = true;
+        try {
+          const [aclPda] = await getAclConfigPDA(
+            address(params.recipient),
+            this.antProgram,
+          );
+          needsAclBootstrap = !(await this.getAccount(aclPda)).exists;
+        } catch {
+          // keep the conservative default
+        }
+        const rentLamports = needsAclBootstrap
+          ? await estimateRentLamports(this.rpc, ACL_BOOTSTRAP_ACCOUNT_BYTES)
+          : 0;
+        return estimateGasFee(this.rpc, { rentLamports });
+      }
+      case 'reassign-name': {
+        if (!params.spawnsNewAnt) return estimateGasFee(this.rpc);
+        // spawn (fee payer + mint keypair) then reassign (fee payer)
+        const rentLamports = await estimateRentLamports(
+          this.rpc,
+          spawnAntAccountBytes(params.name?.length ?? 12),
+        );
+        return estimateGasFee(this.rpc, {
+          rentLamports,
+          transactionCount: 2,
+          signatureCount: 3,
+        });
+      }
+      default:
+        return estimateGasFee(this.rpc);
+    }
   }
 
   /** Get the on-chain schema version of this ANT's config. */

--- a/src/solana/demand-factor-settings.test.ts
+++ b/src/solana/demand-factor-settings.test.ts
@@ -1,0 +1,55 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  DEMAND_FACTOR_DOWN_ADJUSTMENT,
+  DEMAND_FACTOR_MIN,
+  DEMAND_FACTOR_SCALE,
+  DEMAND_FACTOR_UP_ADJUSTMENT,
+  MAX_PERIODS_AT_MIN_DEMAND_FACTOR,
+  MOVING_AVG_PERIOD_COUNT,
+  PERIOD_LENGTH_SECONDS,
+} from '@ar.io/solana-contracts/arns';
+
+/**
+ * Guards the demand-factor settings against the literal-drift bug that
+ * `getDemandFactorSettings` had: the down-adjustment was hardcoded `25` (2.5%)
+ * while the on-chain program uses DEMAND_FACTOR_DOWN_ADJUSTMENT = 985_000
+ * (0.985× → 1.5%). These now derive from the generated program constants
+ * (lifted from the Rust source-of-truth), so this test pins both the constant
+ * values and the derivation `getDemandFactorSettings` performs.
+ *
+ * If `@ar.io/solana-contracts` is regenerated against changed Rust consts,
+ * these fail before a wrong price/quote ships.
+ */
+describe('demand factor settings', () => {
+  it('exports the program constants as bigint with the on-chain values', () => {
+    assert.equal(DEMAND_FACTOR_SCALE, 1_000_000n);
+    assert.equal(DEMAND_FACTOR_UP_ADJUSTMENT, 1_050_000n);
+    assert.equal(DEMAND_FACTOR_DOWN_ADJUSTMENT, 985_000n);
+    assert.equal(DEMAND_FACTOR_MIN, 500_000n);
+    assert.equal(typeof DEMAND_FACTOR_SCALE, 'bigint');
+    assert.equal(typeof DEMAND_FACTOR_DOWN_ADJUSTMENT, 'bigint');
+  });
+
+  it('derives the adjustment rates the way getDemandFactorSettings does', () => {
+    const scale = DEMAND_FACTOR_SCALE;
+    const upRate = Number(
+      ((DEMAND_FACTOR_UP_ADJUSTMENT - scale) * 1000n) / scale,
+    );
+    const downRate = Number(
+      ((scale - DEMAND_FACTOR_DOWN_ADJUSTMENT) * 1000n) / scale,
+    );
+
+    assert.equal(upRate, 50); // 1.05× — unchanged
+    assert.equal(downRate, 15); // 0.985× — was incorrectly hardcoded 25
+    assert.equal(Number(DEMAND_FACTOR_MIN) / Number(scale), 0.5);
+  });
+
+  it('exports period/threshold constants as ergonomic numbers', () => {
+    assert.equal(MOVING_AVG_PERIOD_COUNT, 7);
+    assert.equal(MAX_PERIODS_AT_MIN_DEMAND_FACTOR, 7);
+    assert.equal(Number(PERIOD_LENGTH_SECONDS) * 1000, 86_400_000);
+    assert.equal(typeof MOVING_AVG_PERIOD_COUNT, 'number');
+  });
+});

--- a/src/solana/gas-estimate.test.ts
+++ b/src/solana/gas-estimate.test.ts
@@ -6,7 +6,7 @@ import bs58 from 'bs58';
 import { Logger } from '../common/logger.js';
 import { SolanaANTReadable } from './ant-readable.js';
 import {
-  antRecordBytes,
+  ANT_RECORD_BYTES,
   estimateRentLamports,
   getIntentGasProfile,
 } from './gas.js';
@@ -163,8 +163,8 @@ describe('getIntentGasProfile', () => {
     });
     assert.equal(profile.transactionCount, 2);
     assert.equal(profile.signatureCount, 3);
-    // asset, antConfig, antControllers, rootRecord, arnsRecord
-    assert.deepEqual(profile.accountBytes, [302, 452, 176, 316, 191]);
+    // asset (281 + 2×12), antConfig, antControllers, rootRecord, arnsRecord
+    assert.deepEqual(profile.accountBytes, [305, 452, 176, 316, 191]);
   });
 
   it('adds ACL bootstrap accounts for first-time buyers', () => {
@@ -173,7 +173,7 @@ describe('getIntentGasProfile', () => {
       name: 'brandybuck35',
       needsAclBootstrap: true,
     });
-    assert.deepEqual(profile.accountBytes, [302, 452, 176, 316, 191, 60, 8504]);
+    assert.deepEqual(profile.accountBytes, [305, 452, 176, 316, 191, 60, 8504]);
   });
 
   it('models mutate-in-place intents as a single free-rent transaction', () => {
@@ -194,7 +194,7 @@ describe('getIntentGasProfile', () => {
   it('models Primary-Name-Request as request + approve', () => {
     const profile = getIntentGasProfile({
       intent: 'Primary-Name-Request',
-      name: 'amsterdam-trip', // 14 chars — matches the mainnet measurement
+      name: 'amsterdam-trip',
       needsPrimaryNameAccount: true,
     });
     assert.equal(profile.transactionCount, 2);
@@ -238,7 +238,7 @@ describe('SolanaARIOReadable.getGasEstimate', () => {
       name: 'brandybuck35',
     });
     // No fromAddress → conservatively assumes first-time buyer (ACL incl.)
-    const bytes = 302 + 452 + 176 + 316 + 191 + 60 + 8504 + 128 * 6;
+    const bytes = 305 + 452 + 176 + 316 + 191 + 60 + 8504 + 128 * 6;
     assert.equal(quote.rentLamports, Number((128n + BigInt(bytes)) * 6960n));
     assert.equal(quote.transactionCount, 2);
     assert.equal(quote.signatureCount, 3);
@@ -307,7 +307,7 @@ describe('SolanaANTReadable.getGasEstimate', () => {
       undername: 'docs',
     });
     const expectedRent = Number(
-      (128n + BigInt(antRecordBytes('docs'.length))) * RENT_PER_BYTE,
+      (128n + BigInt(ANT_RECORD_BYTES)) * RENT_PER_BYTE,
     );
     assert.equal(quote.rentLamports, expectedRent);
     assert.equal(quote.rentReclaimedLamports, 0);
@@ -333,5 +333,64 @@ describe('SolanaANTReadable.getGasEstimate', () => {
     assert.equal(quote.rentLamports, 0);
     assert.equal(quote.rentReclaimedLamports, 0);
     assert.equal(quote.transactionCount, 1);
+  });
+});
+
+describe('SolanaARIOReadable.getGarGasEstimate', () => {
+  function makeReadable(rpc: unknown) {
+    return new SolanaARIOReadable({
+      rpc: rpc as never,
+      logger: new Logger({ level: 'none' }),
+    });
+  }
+
+  it('quotes gateway + observer-lookup rent and registry realloc on join', async () => {
+    const { rpc } = stubRpc({ fees: [100_000], scopedFees: [] });
+    const quote = await makeReadable(rpc).getGarGasEstimate({
+      workflow: 'join-network',
+    });
+    // gateway(964) + observerLookup(44) + inter-account overhead(128)
+    // + registry realloc(32); the rpc quote adds the final 128.
+    const expectedRent = Number((128n + 1168n) * RENT_PER_BYTE);
+    assert.equal(quote.rentLamports, expectedRent);
+    // GAR writes pin a 1M CU limit — fees are quoted on it
+    assert.equal(quote.computeUnitLimit, 1_000_000);
+    assert.equal(quote.priorityFeeLamports, 100_000); // 1M × 100_000 / 1e6
+  });
+
+  it('quotes a withdrawal vault (and first-time counter) on decrease', async () => {
+    // getAccountInfo stub → null: no withdrawal counter yet
+    const { rpc } = stubRpc({ fees: [100_000], scopedFees: [] });
+    const quote = await makeReadable(rpc).getGarGasEstimate({
+      workflow: 'decrease-delegate-stake',
+      fromAddress: bs58.encode(Buffer.alloc(32, 5)),
+    });
+    // withdrawal(111) + counter(52) + overhead(128)
+    assert.equal(quote.rentLamports, Number((128n + 291n) * RENT_PER_BYTE));
+    assert.equal(quote.transactionCount, 1);
+    assert.equal(quote.rentReclaimedLamports, 0);
+  });
+
+  it('reports the vault rent as reclaimed for instant decreases', async () => {
+    const { rpc } = stubRpc({ fees: [100_000], scopedFees: [] });
+    const quote = await makeReadable(rpc).getGarGasEstimate({
+      workflow: 'decrease-delegate-stake',
+      fromAddress: bs58.encode(Buffer.alloc(32, 5)),
+      instant: true,
+    });
+    assert.equal(quote.transactionCount, 2);
+    assert.equal(quote.rentReclaimedLamports, quote.rentLamports);
+  });
+
+  it('quotes fees only for settings updates', async () => {
+    const { rpc } = stubRpc({ fees: [100_000], scopedFees: [] });
+    const quote = await makeReadable(rpc).getGarGasEstimate({
+      workflow: 'update-gateway-settings',
+    });
+    assert.equal(quote.rentLamports, 0);
+    assert.equal(
+      quote.totalLamports,
+      BASE_FEE_LAMPORTS_PER_SIGNATURE + 100_000,
+    );
   });
 });

--- a/src/solana/gas-estimate.test.ts
+++ b/src/solana/gas-estimate.test.ts
@@ -1,0 +1,337 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import bs58 from 'bs58';
+
+import { Logger } from '../common/logger.js';
+import { SolanaANTReadable } from './ant-readable.js';
+import {
+  antRecordBytes,
+  estimateRentLamports,
+  getIntentGasProfile,
+} from './gas.js';
+import { SolanaARIOReadable } from './io-readable.js';
+import {
+  BASE_FEE_LAMPORTS_PER_SIGNATURE,
+  DEFAULT_COMPUTE_UNIT_LIMIT,
+  estimateGasFee,
+} from './send.js';
+
+const RENT_PER_BYTE = 6960n;
+
+function stubRpc(
+  opts: {
+    fees?: number[] | 'throws';
+    /** fees returned for the address-scoped (wallet market) query */
+    scopedFees?: number[];
+    rentThrows?: boolean;
+    /** lamports per account returned by getMultipleAccounts (null = missing) */
+    accountLamports?: (number | null)[];
+  } = {},
+  counts = { feeCalls: 0, rentCalls: 0, accountCalls: 0 },
+): { rpc: unknown; counts: typeof counts } {
+  return {
+    counts,
+    rpc: {
+      getRecentPrioritizationFees: (addresses?: unknown[]) => ({
+        send: async () => {
+          counts.feeCalls++;
+          if (opts.fees === 'throws') throw new Error('rpc down');
+          const fees = addresses
+            ? (opts.scopedFees ?? opts.fees ?? [])
+            : (opts.fees ?? []);
+          return fees.map((prioritizationFee) => ({
+            prioritizationFee,
+            slot: 1n,
+          }));
+        },
+      }),
+      getMinimumBalanceForRentExemption: (bytes: bigint) => ({
+        send: async () => {
+          counts.rentCalls++;
+          if (opts.rentThrows) throw new Error('rpc down');
+          return (128n + bytes) * RENT_PER_BYTE;
+        },
+      }),
+      getAccountInfo: () => ({
+        send: async () => {
+          counts.accountCalls++;
+          return { value: null }; // no ACL config / primary name
+        },
+      }),
+      getMultipleAccounts: (addrs: unknown[]) => ({
+        send: async () => ({
+          value: addrs.map((_, i) => {
+            const lamports = opts.accountLamports?.[i] ?? null;
+            return lamports === null
+              ? null
+              : {
+                  lamports: BigInt(lamports),
+                  data: ['', 'base64'],
+                  owner: '11111111111111111111111111111111',
+                  executable: false,
+                  rentEpoch: 0n,
+                  space: 0n,
+                };
+          }),
+        }),
+      }),
+    },
+  };
+}
+
+describe('estimateGasFee', () => {
+  it('quotes fees + rent with a pinned compute-unit price', async () => {
+    const { rpc, counts } = stubRpc({ fees: 'throws' });
+    const quote = await estimateGasFee(rpc as never, {
+      priorityFeeMicroLamports: 250_000,
+      signatureCount: 3,
+      transactionCount: 2,
+      rentLamports: 12_000_000,
+    });
+    // per-tx priority: 400k CU × 250_000 µ◎/CU / 1e6 = 100_000 lamports
+    assert.equal(quote.priorityFeeLamports, 200_000);
+    assert.equal(quote.baseFeeLamports, 3 * BASE_FEE_LAMPORTS_PER_SIGNATURE);
+    assert.equal(quote.feeLamports, 215_000);
+    assert.equal(quote.rentLamports, 12_000_000);
+    assert.equal(quote.totalLamports, 12_215_000);
+    assert.equal(quote.computeUnitLimit, DEFAULT_COMPUTE_UNIT_LIMIT);
+    assert.equal(quote.priorityFeeMicroLamports, 250_000);
+    assert.equal(quote.transactionCount, 2);
+    assert.equal(counts.feeCalls, 0, 'pinned price must not query the rpc');
+  });
+
+  it('rounds the per-transaction priority fee up to whole lamports', async () => {
+    const { rpc } = stubRpc({ fees: 'throws' });
+    const quote = await estimateGasFee(rpc as never, {
+      computeUnitLimit: 1,
+      priorityFeeMicroLamports: 1n,
+      transactionCount: 2,
+    });
+    // 1 CU × 1 µ◎/CU is a fraction of a lamport — the runtime charges 1 per tx.
+    assert.equal(quote.priorityFeeLamports, 2);
+  });
+
+  it('estimates the compute-unit price from recent on-chain fees', async () => {
+    const { rpc } = stubRpc({
+      fees: [20_000, 50_000, 30_000, 40_000],
+      scopedFees: [],
+    });
+    const quote = await estimateGasFee(rpc as never);
+    // p75 of the sorted non-zero fees is 50_000 µ◎/CU.
+    assert.equal(quote.priorityFeeMicroLamports, 50_000);
+    assert.equal(quote.priorityFeeLamports, 20_000); // 400k × 50_000 / 1e6
+    assert.equal(quote.rentLamports, 0);
+    assert.equal(quote.totalLamports, BASE_FEE_LAMPORTS_PER_SIGNATURE + 20_000);
+  });
+
+  it('falls back to the floor price when the fee query fails', async () => {
+    const { rpc } = stubRpc({ fees: 'throws' });
+    const quote = await estimateGasFee(rpc as never);
+    assert.equal(quote.priorityFeeMicroLamports, 10_000);
+    assert.equal(quote.priorityFeeLamports, 4_000); // 400k × 10_000 / 1e6
+  });
+
+  it('quotes the wallet market rate when it exceeds the base estimate', async () => {
+    // Global per-slot minimums are quiet, but the busy-reference (wallet)
+    // queries report what fee-paying transactions actually attach — the
+    // quote must cover the wallet rate, since that's what Phantom charges.
+    const { rpc } = stubRpc({
+      fees: [20_000],
+      scopedFees: [400_000, 500_000, 600_000],
+    });
+    const quote = await estimateGasFee(rpc as never);
+    // pooled p85 (600_000) shrunk toward the 500_000 prior → 550_000,
+    // which wins over the global p75 (20_000)
+    assert.equal(quote.priorityFeeMicroLamports, 550_000);
+    assert.equal(quote.priorityFeeLamports, 220_000); // 400k × 550_000 / 1e6
+  });
+
+  it('keeps the floor on clusters with no fee market (devnet)', async () => {
+    const { rpc } = stubRpc({ fees: [], scopedFees: [] });
+    const quote = await estimateGasFee(rpc as never);
+    // no fee-paying slots anywhere → floor, NOT the wallet prior
+    assert.equal(quote.priorityFeeMicroLamports, 10_000);
+  });
+});
+
+describe('getIntentGasProfile', () => {
+  it('models Buy-Name as spawn + buy with the spawned account set', () => {
+    const profile = getIntentGasProfile({
+      intent: 'Buy-Name',
+      name: 'brandybuck35', // 12 chars — matches the mainnet measurement
+    });
+    assert.equal(profile.transactionCount, 2);
+    assert.equal(profile.signatureCount, 3);
+    // asset, antConfig, antControllers, rootRecord, arnsRecord
+    assert.deepEqual(profile.accountBytes, [302, 452, 176, 316, 191]);
+  });
+
+  it('adds ACL bootstrap accounts for first-time buyers', () => {
+    const profile = getIntentGasProfile({
+      intent: 'Buy-Name',
+      name: 'brandybuck35',
+      needsAclBootstrap: true,
+    });
+    assert.deepEqual(profile.accountBytes, [302, 452, 176, 316, 191, 60, 8504]);
+  });
+
+  it('models mutate-in-place intents as a single free-rent transaction', () => {
+    for (const intent of [
+      'Extend-Lease',
+      'Upgrade-Name',
+      'Increase-Undername-Limit',
+    ] as const) {
+      const profile = getIntentGasProfile({ intent, name: 'x' });
+      assert.deepEqual(profile, {
+        transactionCount: 1,
+        signatureCount: 1,
+        accountBytes: [],
+      });
+    }
+  });
+
+  it('models Primary-Name-Request as request + approve', () => {
+    const profile = getIntentGasProfile({
+      intent: 'Primary-Name-Request',
+      name: 'amsterdam-trip', // 14 chars — matches the mainnet measurement
+      needsPrimaryNameAccount: true,
+    });
+    assert.equal(profile.transactionCount, 2);
+    // transient request PDA + the PrimaryName account itself
+    assert.deepEqual(profile.accountBytes, [119, 119]);
+  });
+});
+
+describe('estimateRentLamports', () => {
+  it('collapses N accounts into one rent-exemption query', async () => {
+    const { rpc, counts } = stubRpc();
+    const rent = await estimateRentLamports(rpc as never, [302, 452, 176]);
+    // Σbytes + 128×(N−1) = 930 + 256; quote adds the final 128 overhead.
+    assert.equal(rent, Number((128n + 1186n) * RENT_PER_BYTE));
+    assert.equal(counts.rentCalls, 1);
+  });
+
+  it('returns 0 for intents that create no accounts', async () => {
+    const { rpc, counts } = stubRpc();
+    assert.equal(await estimateRentLamports(rpc as never, []), 0);
+    assert.equal(counts.rentCalls, 0);
+  });
+
+  it('falls back to the protocol-constant formula when the rpc fails', async () => {
+    const { rpc } = stubRpc({ rentThrows: true });
+    const rent = await estimateRentLamports(rpc as never, [100]);
+    assert.equal(rent, Number((128n + 100n) * RENT_PER_BYTE));
+  });
+});
+
+describe('SolanaARIOReadable.getGasEstimate', () => {
+  it('includes ANT spawn + record rent for Buy-Name and memoizes queries', async () => {
+    const { rpc, counts } = stubRpc({ fees: [100_000], scopedFees: [] });
+    const readable = new SolanaARIOReadable({
+      rpc: rpc as never,
+      logger: new Logger({ level: 'none' }),
+    });
+
+    const quote = await readable.getGasEstimate({
+      intent: 'Buy-Name',
+      name: 'brandybuck35',
+    });
+    // No fromAddress → conservatively assumes first-time buyer (ACL incl.)
+    const bytes = 302 + 452 + 176 + 316 + 191 + 60 + 8504 + 128 * 6;
+    assert.equal(quote.rentLamports, Number((128n + BigInt(bytes)) * 6960n));
+    assert.equal(quote.transactionCount, 2);
+    assert.equal(quote.signatureCount, 3);
+    assert.equal(quote.totalLamports, quote.feeLamports + quote.rentLamports);
+
+    const second = await readable.getGasEstimate({
+      intent: 'Buy-Name',
+      name: 'brandybuck35',
+    });
+    // one refresh = three queries (global + two wallet-market references)
+    assert.equal(counts.feeCalls, 3, 'priority fee memoized within TTL');
+    assert.equal(counts.rentCalls, 1, 'rent memoized per byte size');
+    assert.equal(second.totalLamports, quote.totalLamports);
+  });
+
+  it('quotes a single cheap transaction for Extend-Lease', async () => {
+    const { rpc } = stubRpc({ fees: [100_000], scopedFees: [] });
+    const readable = new SolanaARIOReadable({
+      rpc: rpc as never,
+      logger: new Logger({ level: 'none' }),
+    });
+    const quote = await readable.getGasEstimate({
+      intent: 'Extend-Lease',
+      name: 'brandybuck35',
+    });
+    assert.equal(quote.rentLamports, 0);
+    assert.equal(quote.transactionCount, 1);
+    assert.equal(quote.signatureCount, 1);
+    assert.equal(
+      quote.totalLamports,
+      BASE_FEE_LAMPORTS_PER_SIGNATURE + 40_000, // 400k × 100_000 µ◎ / 1e6
+    );
+  });
+});
+
+describe('SolanaANTReadable.getGasEstimate', () => {
+  function makeAnt(rpc: unknown) {
+    return new SolanaANTReadable({
+      rpc: rpc as never,
+      processId: bs58.encode(Buffer.alloc(32, 7)),
+      logger: new Logger({ level: 'none' }),
+    });
+  }
+
+  it('reports the live record deposit as reclaimed rent on remove-record', async () => {
+    const { rpc } = stubRpc({
+      fees: [100_000],
+      scopedFees: [],
+      // record account holds 3_090_240 lamports; no metadata PDA
+      accountLamports: [3_090_240, null],
+    });
+    const quote = await makeAnt(rpc).getGasEstimate({
+      workflow: 'remove-record',
+      undername: 'docs',
+    });
+    assert.equal(quote.rentReclaimedLamports, 3_090_240);
+    assert.equal(quote.rentLamports, 0);
+    // upfront need is fees only; the refund is reported, not netted
+    assert.equal(quote.totalLamports, BASE_FEE_LAMPORTS_PER_SIGNATURE + 40_000);
+  });
+
+  it('quotes record rent for set-record', async () => {
+    const { rpc } = stubRpc({ fees: [100_000], scopedFees: [] });
+    const quote = await makeAnt(rpc).getGasEstimate({
+      workflow: 'set-record',
+      undername: 'docs',
+    });
+    const expectedRent = Number(
+      (128n + BigInt(antRecordBytes('docs'.length))) * RENT_PER_BYTE,
+    );
+    assert.equal(quote.rentLamports, expectedRent);
+    assert.equal(quote.rentReclaimedLamports, 0);
+    assert.equal(quote.totalLamports, quote.feeLamports + expectedRent);
+  });
+
+  it('quotes the recipient ACL bootstrap for transfers to fresh wallets', async () => {
+    const { rpc } = stubRpc({ fees: [100_000], scopedFees: [] }); // getAccountInfo → null
+    const quote = await makeAnt(rpc).getGasEstimate({
+      workflow: 'transfer',
+      recipient: bs58.encode(Buffer.alloc(32, 9)),
+    });
+    // aclConfig(60) + aclPage(8504) + inter-account overhead(128)
+    const expectedRent = Number((128n + 8692n) * RENT_PER_BYTE);
+    assert.equal(quote.rentLamports, expectedRent);
+  });
+
+  it('quotes fees only for reassign-name', async () => {
+    const { rpc } = stubRpc({ fees: [100_000], scopedFees: [] });
+    const quote = await makeAnt(rpc).getGasEstimate({
+      workflow: 'reassign-name',
+    });
+    assert.equal(quote.rentLamports, 0);
+    assert.equal(quote.rentReclaimedLamports, 0);
+    assert.equal(quote.transactionCount, 1);
+  });
+});

--- a/src/solana/gas.ts
+++ b/src/solana/gas.ts
@@ -1,0 +1,210 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Intent-aware gas (network cost) profiles for the ArNS purchase flows.
+ *
+ * On Solana the dominant cost of a purchase is NOT the transaction fee but
+ * the rent-exempt deposits for the accounts the flow creates. Buy-Name in
+ * particular runs TWO transactions — `ANT.spawn` (mints the MPL Core asset
+ * and initializes the ANT state PDAs) followed by `buy_record` (creates the
+ * ArNS record PDA) — and the spawn alone deposits ~0.012 SOL of rent, three
+ * orders of magnitude more than the fees.
+ *
+ * Account byte sizes below were measured against mainnet accounts created by
+ * the current program deployments (see the `(measured)` notes per constant).
+ * Sizes that embed the (Arweave-normalized, ≤51 char) name carry a
+ * `+ nameLen` linear term. Rent itself is NOT hardcoded — it's quoted from
+ * the cluster via `getMinimumBalanceForRentExemption` so validator rent
+ * parameter changes are picked up automatically.
+ */
+import type { Intent } from '../types/io.js';
+import type { SolanaRpc } from './types.js';
+
+/**
+ * Per-account byte sizes created by `spawnSolanaANT` (one transaction:
+ * MPL Core `CreateV1` + `ario_ant::initialize` + ACL bootstrap).
+ * Measured from a mainnet spawn of a 12-char name (asset
+ * 2ZUspD5DUv4mPVvVg5XMt1sNTN9jnMUXTCPGUNDTmmyh):
+ *   asset=302, antConfig=452, antControllers=176, rootRecord=316.
+ */
+const SPAWN_ASSET_BYTES_BASE = 290; // + nameLen
+const SPAWN_ANT_CONFIG_BYTES_BASE = 440; // + nameLen
+const SPAWN_ANT_CONTROLLERS_BYTES = 176;
+const SPAWN_ROOT_RECORD_BYTES = 316;
+
+/** ArNS record PDA created by `buy_record` (measured: 191 for 12 chars). */
+const ARNS_RECORD_BYTES_BASE = 179; // + nameLen
+
+/**
+ * First-time ACL bootstrap: `register_acl_config` + `add_acl_page`
+ * (measured: 60 + 8504). Only created when the buyer has never owned an
+ * ANT before (or, rarely, when every existing page is at capacity — that
+ * edge is ignored here; pages hold hundreds of entries).
+ */
+const ACL_CONFIG_BYTES = 60;
+const ACL_PAGE_BYTES = 8504;
+
+/**
+ * PrimaryName PDA created on approve (measured: 119 for a 14-char name).
+ * The request flow also creates a transient PrimaryNameRequest PDA that is
+ * closed (rent refunded) on approve — approximated with the same size so
+ * the wallet is gated on what it must hold UPFRONT, not the net cost.
+ */
+const PRIMARY_NAME_BYTES_BASE = 105; // + nameLen
+
+/**
+ * Undername `AntRecord` PDA created by `set_record`. Derived from the
+ * measured root record (316 bytes for a 1-char `@` undername and a 43-char
+ * Arweave target): base excludes both variable strings. IPFS CID targets
+ * run longer (~46–59 chars) — pass the actual target length when known.
+ */
+const ANT_RECORD_BYTES_BASE = 272; // + undernameLen + targetLen
+const DEFAULT_TARGET_LENGTH = 43; // Arweave transaction id
+
+/** Byte size of an undername record account. */
+export function antRecordBytes(
+  undernameLength: number,
+  targetLength: number = DEFAULT_TARGET_LENGTH,
+): number {
+  return ANT_RECORD_BYTES_BASE + Math.max(undernameLength, 1) + targetLength;
+}
+
+/**
+ * Byte sizes of the accounts a bare `spawnSolanaANT` creates (asset,
+ * AntConfig, AntControllers, root `@` record) — excluding the conditional
+ * first-time ACL bootstrap, which spawn-adjacent flows quote separately.
+ */
+export function spawnAntAccountBytes(nameLength: number): number[] {
+  const nameLen = Math.min(Math.max(nameLength, 1), 51);
+  return [
+    SPAWN_ASSET_BYTES_BASE + nameLen,
+    SPAWN_ANT_CONFIG_BYTES_BASE + nameLen,
+    SPAWN_ANT_CONTROLLERS_BYTES,
+    SPAWN_ROOT_RECORD_BYTES,
+  ];
+}
+
+/**
+ * First-time ACL bootstrap account sizes (`register_acl_config` +
+ * `add_acl_page`) — also needed by `transfer` when the RECIPIENT has never
+ * owned an ANT.
+ */
+export const ACL_BOOTSTRAP_ACCOUNT_BYTES = [ACL_CONFIG_BYTES, ACL_PAGE_BYTES];
+
+export type IntentGasProfile = {
+  /** Number of transactions the intent sends. */
+  transactionCount: number;
+  /** Total signatures across those transactions. */
+  signatureCount: number;
+  /** Byte sizes of the accounts the flow creates (rent payable by buyer). */
+  accountBytes: number[];
+};
+
+/**
+ * Describe what an intent does on chain: how many transactions it sends,
+ * how many signatures those carry, and which accounts it creates.
+ *
+ * Flags:
+ * - `needsAclBootstrap` — Buy-Name only: the buyer has no ACL config yet
+ *   (first ANT), so the spawn also creates the ACL head + first page.
+ * - `needsPrimaryNameAccount` — Primary-Name-Request only: the wallet has
+ *   no PrimaryName PDA yet (setting, not changing, a primary name).
+ */
+export function getIntentGasProfile({
+  intent,
+  name = '',
+  needsAclBootstrap = false,
+  needsPrimaryNameAccount = false,
+}: {
+  intent?: Intent;
+  name?: string;
+  needsAclBootstrap?: boolean;
+  needsPrimaryNameAccount?: boolean;
+}): IntentGasProfile {
+  const nameLen = Math.min(Math.max(name.length, 1), 51);
+  switch (intent) {
+    case 'Buy-Name':
+    case 'Buy-Record':
+      return {
+        // spawn (fee payer + fresh mint keypair) then buy (fee payer)
+        transactionCount: 2,
+        signatureCount: 3,
+        accountBytes: [
+          ...spawnAntAccountBytes(nameLen),
+          ARNS_RECORD_BYTES_BASE + nameLen,
+          ...(needsAclBootstrap ? [ACL_CONFIG_BYTES, ACL_PAGE_BYTES] : []),
+        ],
+      };
+    case 'Primary-Name-Request':
+      return {
+        // request_primary_name then approve_primary_name_request. The
+        // transient request PDA is included so the estimate reflects the
+        // upfront balance requirement; its rent comes back on approval.
+        transactionCount: 2,
+        signatureCount: 2,
+        accountBytes: [
+          PRIMARY_NAME_BYTES_BASE + nameLen,
+          ...(needsPrimaryNameAccount
+            ? [PRIMARY_NAME_BYTES_BASE + nameLen]
+            : []),
+        ],
+      };
+    // Mutate-in-place intents: a single transaction, no accounts created.
+    case 'Extend-Lease':
+    case 'Upgrade-Name':
+    case 'Increase-Undername-Limit':
+    default:
+      return { transactionCount: 1, signatureCount: 1, accountBytes: [] };
+  }
+}
+
+/**
+ * Lamports per (128 + size) byte of rent-exempt deposit — the cluster
+ * default since genesis (`lamports_per_byte_year` 3480 × 2-year exemption
+ * threshold). Used only as the fallback when the RPC quote fails.
+ */
+const FALLBACK_RENT_LAMPORTS_PER_BYTE = 6960;
+const RENT_ACCOUNT_OVERHEAD_BYTES = 128;
+
+/**
+ * Quote the total rent-exempt deposit for a set of to-be-created accounts
+ * in ONE RPC call. Solana rent is linear in account size with a flat
+ * 128-byte per-account overhead, so the sum over N accounts equals the
+ * exemption for a single account of `Σbytes + 128×(N−1)`.
+ *
+ * Never throws: if the RPC query fails, falls back to computing the same
+ * linear formula locally with the long-standing cluster constants.
+ */
+export async function estimateRentLamports(
+  rpc: SolanaRpc,
+  accountBytes: number[],
+): Promise<number> {
+  if (accountBytes.length === 0) return 0;
+  const totalBytes =
+    accountBytes.reduce((sum, b) => sum + b, 0) +
+    RENT_ACCOUNT_OVERHEAD_BYTES * (accountBytes.length - 1);
+  try {
+    const rent = await rpc
+      .getMinimumBalanceForRentExemption(BigInt(totalBytes))
+      .send();
+    return Number(rent);
+  } catch {
+    return (
+      (totalBytes + RENT_ACCOUNT_OVERHEAD_BYTES) *
+      FALLBACK_RENT_LAMPORTS_PER_BYTE
+    );
+  }
+}

--- a/src/solana/gas.ts
+++ b/src/solana/gas.ts
@@ -80,10 +80,14 @@ const ACL_PAGE_BYTES = 8504;
 
 /**
  * PrimaryName PDA created on approve — fixed allocation (verified
- * size-identical for 5- and 39-char names). The request flow also creates
- * a transient PrimaryNameRequest PDA that is closed (rent refunded) on
- * approve — approximated with the same size so the wallet is gated on
- * what it must hold UPFRONT, not the net cost.
+ * size-identical for 5- and 39-char names). No codama size export exists:
+ * the codec embeds a length-prefixed `name` string, so it's variable-size
+ * to codama, and `get*Size()` is only emitted for fixed-size codecs — the
+ * program's max-capacity allocation is only observable on chain.
+ *
+ * The request flow also creates a transient PrimaryNameRequest PDA that is
+ * closed (rent refunded) on approve — approximated with the same size so
+ * the wallet is gated on what it must hold UPFRONT, not the net cost.
  */
 const PRIMARY_NAME_BYTES = 119;
 
@@ -144,6 +148,14 @@ const GAR_REDELEGATION_RECORD_BYTES = getRedelegationRecordSize();
  */
 export const GAR_COMPUTE_UNIT_LIMIT = 1_000_000;
 
+/**
+ * User-facing GAR workflows the estimator can quote. Deliberately NOT the
+ * codama `ArioGarInstruction` enum: that enumerates all ~50 instructions
+ * (including admin/epoch/migration ops that aren't quotable user actions),
+ * is numeric, and is per-instruction — whereas a workflow here can span
+ * several ('decrease-delegate-stake' + instant runs decrease_delegate_stake
+ * THEN instant_withdrawal). Names follow the SDK CLI command spelling.
+ */
 export type GarGasWorkflow =
   | 'join-network'
   | 'leave-network'

--- a/src/solana/gas.ts
+++ b/src/solana/gas.ts
@@ -23,64 +23,77 @@
  * ArNS record PDA) — and the spawn alone deposits ~0.012 SOL of rent, three
  * orders of magnitude more than the fees.
  *
- * Account byte sizes below were measured against mainnet accounts created by
- * the current program deployments (see the `(measured)` notes per constant).
- * Sizes that embed the (Arweave-normalized, ≤51 char) name carry a
- * `+ nameLen` linear term. Rent itself is NOT hardcoded — it's quoted from
- * the cluster via `getMinimumBalanceForRentExemption` so validator rent
- * parameter changes are picked up automatically.
+ * Account byte sizes come from the codama clients where the account is
+ * fixed-size; the ario programs additionally allocate their string-bearing
+ * accounts at FIXED max-capacity space (verified size-identical across
+ * mainnet names of widely different lengths), so those carry measured
+ * constants. The only content-sized account is the MPL Core asset
+ * (~2 bytes per name character). Rent itself is NOT hardcoded — it's
+ * quoted from the cluster via `getMinimumBalanceForRentExemption` so
+ * validator rent parameter changes are picked up automatically.
  */
+import { getAclConfigSize } from '@ar.io/solana-contracts/ant';
+import {
+  getDelegationSize,
+  getObserverLookupSize,
+  getRedelegationRecordSize,
+  getWithdrawalCounterSize,
+  getWithdrawalSize,
+} from '@ar.io/solana-contracts/gar';
 import type { Intent } from '../types/io.js';
 import type { SolanaRpc } from './types.js';
 
 /**
  * Per-account byte sizes created by `spawnSolanaANT` (one transaction:
  * MPL Core `CreateV1` + `ario_ant::initialize` + ACL bootstrap).
- * Measured from a mainnet spawn of a 12-char name (asset
- * 2ZUspD5DUv4mPVvVg5XMt1sNTN9jnMUXTCPGUNDTmmyh):
- *   asset=302, antConfig=452, antControllers=176, rootRecord=316.
+ *
+ * The ario-program accounts (AntConfig, AntControllers, AntRecord,
+ * ArnsRecord, PrimaryName) are allocated at FIXED max-capacity space —
+ * verified identical across mainnet names of length 4, 12, and 28 — so the
+ * codama content encoders (which measure current content, not allocation)
+ * can't supply these; the measured constants below ARE the allocation.
+ * Only the MPL Core asset is content-sized at runtime: it grows ~2 bytes
+ * per name character (the name appears in both `AssetV1.name` and the
+ * `ARNS Name` attribute written at purchase), plus a few bytes of variance
+ * from other attribute values.
  */
-const SPAWN_ASSET_BYTES_BASE = 290; // + nameLen
-const SPAWN_ANT_CONFIG_BYTES_BASE = 440; // + nameLen
+const SPAWN_ASSET_BYTES_BASE = 281; // + 2 × nameLen
+const SPAWN_ANT_CONFIG_BYTES = 452;
 const SPAWN_ANT_CONTROLLERS_BYTES = 176;
 const SPAWN_ROOT_RECORD_BYTES = 316;
 
-/** ArNS record PDA created by `buy_record` (measured: 191 for 12 chars). */
-const ARNS_RECORD_BYTES_BASE = 179; // + nameLen
+/**
+ * ArNS record PDA created by `buy_record` — fixed allocation (stores the
+ * 32-byte name hash, not the name; verified size-identical across names).
+ */
+const ARNS_RECORD_BYTES = 191;
 
 /**
- * First-time ACL bootstrap: `register_acl_config` + `add_acl_page`
- * (measured: 60 + 8504). Only created when the buyer has never owned an
- * ANT before (or, rarely, when every existing page is at capacity — that
- * edge is ignored here; pages hold hundreds of entries).
+ * First-time ACL bootstrap: `register_acl_config` + `add_acl_page`. Only
+ * created when the buyer has never owned an ANT before (or, rarely, when
+ * every existing page is at capacity — that edge is ignored here; pages
+ * hold hundreds of entries). The config is fixed-size (codama); the page
+ * is pre-allocated at its measured 8504 bytes.
  */
-const ACL_CONFIG_BYTES = 60;
+const ACL_CONFIG_BYTES = getAclConfigSize();
 const ACL_PAGE_BYTES = 8504;
 
 /**
- * PrimaryName PDA created on approve (measured: 119 for a 14-char name).
- * The request flow also creates a transient PrimaryNameRequest PDA that is
- * closed (rent refunded) on approve — approximated with the same size so
- * the wallet is gated on what it must hold UPFRONT, not the net cost.
+ * PrimaryName PDA created on approve — fixed allocation (verified
+ * size-identical for 5- and 39-char names). The request flow also creates
+ * a transient PrimaryNameRequest PDA that is closed (rent refunded) on
+ * approve — approximated with the same size so the wallet is gated on
+ * what it must hold UPFRONT, not the net cost.
  */
-const PRIMARY_NAME_BYTES_BASE = 105; // + nameLen
+const PRIMARY_NAME_BYTES = 119;
 
 /**
- * Undername `AntRecord` PDA created by `set_record`. Derived from the
- * measured root record (316 bytes for a 1-char `@` undername and a 43-char
- * Arweave target): base excludes both variable strings. IPFS CID targets
- * run longer (~46–59 chars) — pass the actual target length when known.
+ * Undername `AntRecord` PDA created by `set_record` — fixed allocation
+ * like every other ario-program account (the root `@` record measures 316
+ * regardless of name; undername/target capacity is part of the fixed
+ * space).
  */
-const ANT_RECORD_BYTES_BASE = 272; // + undernameLen + targetLen
-const DEFAULT_TARGET_LENGTH = 43; // Arweave transaction id
-
-/** Byte size of an undername record account. */
-export function antRecordBytes(
-  undernameLength: number,
-  targetLength: number = DEFAULT_TARGET_LENGTH,
-): number {
-  return ANT_RECORD_BYTES_BASE + Math.max(undernameLength, 1) + targetLength;
-}
+export const ANT_RECORD_BYTES = 316;
 
 /**
  * Byte sizes of the accounts a bare `spawnSolanaANT` creates (asset,
@@ -90,8 +103,8 @@ export function antRecordBytes(
 export function spawnAntAccountBytes(nameLength: number): number[] {
   const nameLen = Math.min(Math.max(nameLength, 1), 51);
   return [
-    SPAWN_ASSET_BYTES_BASE + nameLen,
-    SPAWN_ANT_CONFIG_BYTES_BASE + nameLen,
+    SPAWN_ASSET_BYTES_BASE + 2 * nameLen,
+    SPAWN_ANT_CONFIG_BYTES,
     SPAWN_ANT_CONTROLLERS_BYTES,
     SPAWN_ROOT_RECORD_BYTES,
   ];
@@ -104,6 +117,132 @@ export function spawnAntAccountBytes(nameLength: number): number[] {
  */
 export const ACL_BOOTSTRAP_ACCOUNT_BYTES = [ACL_CONFIG_BYTES, ACL_PAGE_BYTES];
 
+// =========================================
+// GAR (gateway registry) workflows
+// =========================================
+
+/**
+ * GAR account sizes. The fixed-size accounts come straight from the codama
+ * clients (verified byte-identical against live mainnet accounts), so they
+ * track program upgrades with the `@ar.io/solana-contracts` dependency.
+ * Only two need measured values: the Gateway account is variable-size
+ * (964 measured for a typical label/fqdn — varies a few tens of bytes),
+ * and the gateway registry grows by one 32-byte pubkey per join (realloc
+ * on a long-lived account, not a creation).
+ */
+const GAR_GATEWAY_BYTES = 964;
+const GAR_OBSERVER_LOOKUP_BYTES = getObserverLookupSize();
+const GAR_REGISTRY_ENTRY_REALLOC_BYTES = 32;
+const GAR_DELEGATION_BYTES = getDelegationSize();
+const GAR_WITHDRAWAL_BYTES = getWithdrawalSize();
+const GAR_WITHDRAWAL_COUNTER_BYTES = getWithdrawalCounterSize();
+const GAR_REDELEGATION_RECORD_BYTES = getRedelegationRecordSize();
+
+/**
+ * Every GAR write in the SDK pins a 1M compute-unit limit (vs the 400k
+ * ArNS default) — fee quotes for GAR workflows must assume the same.
+ */
+export const GAR_COMPUTE_UNIT_LIMIT = 1_000_000;
+
+export type GarGasWorkflow =
+  | 'join-network'
+  | 'leave-network'
+  | 'update-gateway-settings'
+  | 'increase-operator-stake'
+  | 'decrease-operator-stake'
+  | 'delegate-stake'
+  | 'decrease-delegate-stake'
+  | 'redelegate-stake'
+  | 'instant-withdrawal'
+  | 'cancel-withdrawal'
+  | 'claim-withdrawal';
+
+/**
+ * Describe what a GAR workflow does on chain. Conditional flags mirror the
+ * ANT/ArNS profiles: callers resolve them from live account checks (or
+ * leave the conservative defaults when the actor is unknown).
+ *
+ * - `needsDelegation` — delegate/redelegate to a gateway the delegator has
+ *   no Delegation PDA with yet.
+ * - `needsWithdrawalCounter` — the actor's first-ever withdrawal also
+ *   creates their WithdrawalCounter PDA.
+ * - `needsRedelegationRecord` — first redelegation in the fee window.
+ * - `instant` — decrease-delegate-stake with instant payout: a second
+ *   transaction closes the just-created vault (its rent comes back).
+ *
+ * Withdrawal-closing workflows (claim/cancel/instant) report no created
+ * accounts here — the reclaimed deposit is read live by the estimator.
+ */
+export function getGarWorkflowGasProfile({
+  workflow,
+  needsDelegation = false,
+  needsWithdrawalCounter = false,
+  needsRedelegationRecord = false,
+  instant = false,
+}: {
+  workflow: GarGasWorkflow;
+  needsDelegation?: boolean;
+  needsWithdrawalCounter?: boolean;
+  needsRedelegationRecord?: boolean;
+  instant?: boolean;
+}): IntentGasProfile {
+  switch (workflow) {
+    case 'join-network':
+      return {
+        transactionCount: 1,
+        signatureCount: 1,
+        accountBytes: [GAR_GATEWAY_BYTES, GAR_OBSERVER_LOOKUP_BYTES],
+        reallocBytes: GAR_REGISTRY_ENTRY_REALLOC_BYTES,
+      };
+    case 'leave-network':
+      // Protected exit vault + (conservatively) the excess vault — the
+      // contract only consumes the second when post-stake excess exists.
+      return {
+        transactionCount: 1,
+        signatureCount: 1,
+        accountBytes: [
+          GAR_WITHDRAWAL_BYTES,
+          GAR_WITHDRAWAL_BYTES,
+          ...(needsWithdrawalCounter ? [GAR_WITHDRAWAL_COUNTER_BYTES] : []),
+        ],
+      };
+    case 'delegate-stake':
+      return {
+        transactionCount: 1,
+        signatureCount: 1,
+        accountBytes: needsDelegation ? [GAR_DELEGATION_BYTES] : [],
+      };
+    case 'decrease-operator-stake':
+    case 'decrease-delegate-stake':
+      return {
+        // instant payout sends a follow-up instant_withdrawal transaction
+        transactionCount: instant ? 2 : 1,
+        signatureCount: instant ? 2 : 1,
+        accountBytes: [
+          GAR_WITHDRAWAL_BYTES,
+          ...(needsWithdrawalCounter ? [GAR_WITHDRAWAL_COUNTER_BYTES] : []),
+        ],
+      };
+    case 'redelegate-stake':
+      return {
+        transactionCount: 1,
+        signatureCount: 1,
+        accountBytes: [
+          ...(needsDelegation ? [GAR_DELEGATION_BYTES] : []),
+          ...(needsRedelegationRecord ? [GAR_REDELEGATION_RECORD_BYTES] : []),
+        ],
+      };
+    // Mutate-in-place or close-only workflows: no accounts created.
+    case 'update-gateway-settings':
+    case 'increase-operator-stake':
+    case 'instant-withdrawal':
+    case 'cancel-withdrawal':
+    case 'claim-withdrawal':
+    default:
+      return { transactionCount: 1, signatureCount: 1, accountBytes: [] };
+  }
+}
+
 export type IntentGasProfile = {
   /** Number of transactions the intent sends. */
   transactionCount: number;
@@ -111,6 +250,12 @@ export type IntentGasProfile = {
   signatureCount: number;
   /** Byte sizes of the accounts the flow creates (rent payable by buyer). */
   accountBytes: number[];
+  /**
+   * Extra bytes added to EXISTING accounts via realloc (e.g. the gateway
+   * registry growing on join) — rent is owed per byte but without the
+   * per-account overhead a fresh account carries.
+   */
+  reallocBytes?: number;
 };
 
 /**
@@ -144,7 +289,7 @@ export function getIntentGasProfile({
         signatureCount: 3,
         accountBytes: [
           ...spawnAntAccountBytes(nameLen),
-          ARNS_RECORD_BYTES_BASE + nameLen,
+          ARNS_RECORD_BYTES,
           ...(needsAclBootstrap ? [ACL_CONFIG_BYTES, ACL_PAGE_BYTES] : []),
         ],
       };
@@ -156,10 +301,8 @@ export function getIntentGasProfile({
         transactionCount: 2,
         signatureCount: 2,
         accountBytes: [
-          PRIMARY_NAME_BYTES_BASE + nameLen,
-          ...(needsPrimaryNameAccount
-            ? [PRIMARY_NAME_BYTES_BASE + nameLen]
-            : []),
+          PRIMARY_NAME_BYTES,
+          ...(needsPrimaryNameAccount ? [PRIMARY_NAME_BYTES] : []),
         ],
       };
     // Mutate-in-place intents: a single transaction, no accounts created.
@@ -181,9 +324,10 @@ const RENT_ACCOUNT_OVERHEAD_BYTES = 128;
 
 /**
  * Quote the total rent-exempt deposit for a set of to-be-created accounts
- * in ONE RPC call. Solana rent is linear in account size with a flat
- * 128-byte per-account overhead, so the sum over N accounts equals the
- * exemption for a single account of `Σbytes + 128×(N−1)`.
+ * (plus any realloc growth of existing accounts) in ONE RPC call. Solana
+ * rent is linear in account size with a flat 128-byte per-account overhead,
+ * so the sum over N accounts equals the exemption for a single account of
+ * `Σbytes + 128×(N−1)`; realloc bytes ride along without extra overhead.
  *
  * Never throws: if the RPC query fails, falls back to computing the same
  * linear formula locally with the long-standing cluster constants.
@@ -191,11 +335,13 @@ const RENT_ACCOUNT_OVERHEAD_BYTES = 128;
 export async function estimateRentLamports(
   rpc: SolanaRpc,
   accountBytes: number[],
+  reallocBytes = 0,
 ): Promise<number> {
-  if (accountBytes.length === 0) return 0;
+  if (accountBytes.length === 0 && reallocBytes === 0) return 0;
   const totalBytes =
     accountBytes.reduce((sum, b) => sum + b, 0) +
-    RENT_ACCOUNT_OVERHEAD_BYTES * (accountBytes.length - 1);
+    RENT_ACCOUNT_OVERHEAD_BYTES * Math.max(accountBytes.length - 1, 0) +
+    reallocBytes;
   try {
     const rent = await rpc
       .getMinimumBalanceForRentExemption(BigInt(totalBytes))

--- a/src/solana/index.ts
+++ b/src/solana/index.ts
@@ -274,12 +274,14 @@ export {
 } from './send.js';
 export {
   ACL_BOOTSTRAP_ACCOUNT_BYTES,
-  antRecordBytes,
+  ANT_RECORD_BYTES,
+  GAR_COMPUTE_UNIT_LIMIT,
   estimateRentLamports,
+  getGarWorkflowGasProfile,
   getIntentGasProfile,
   spawnAntAccountBytes,
 } from './gas.js';
-export type { IntentGasProfile } from './gas.js';
+export type { GarGasWorkflow, IntentGasProfile } from './gas.js';
 
 // Types
 export type {

--- a/src/solana/index.ts
+++ b/src/solana/index.ts
@@ -257,6 +257,30 @@ export type {
 export { withRetry, isRetryableError } from './retry.js';
 export type { RetryOptions } from './retry.js';
 
+// Gas (network cost) estimation utilities. `estimateGasFee` quotes the
+// lamports a flow needs (transaction fees + rent deposits) without building
+// anything; `getIntentGasProfile`/`estimateRentLamports` model what each
+// ArNS intent creates on chain (Buy-Name = ANT spawn + buy, with rent for
+// the spawned accounts). `SolanaARIOReadable.getCostDetails` includes the
+// combined quote as `gasEstimate`. The `GasEstimate` result type is
+// exported via `../types/index.js` above.
+export {
+  BASE_FEE_LAMPORTS_PER_SIGNATURE,
+  DEFAULT_COMPUTE_UNIT_LIMIT,
+  estimateGasFee,
+  estimatePriorityFeeMicroLamports,
+  estimateQuotePriorityFeeMicroLamports,
+  estimateWalletPriorityFeeMicroLamports,
+} from './send.js';
+export {
+  ACL_BOOTSTRAP_ACCOUNT_BYTES,
+  antRecordBytes,
+  estimateRentLamports,
+  getIntentGasProfile,
+  spawnAntAccountBytes,
+} from './gas.js';
+export type { IntentGasProfile } from './gas.js';
+
 // Types
 export type {
   SolanaConfig,

--- a/src/solana/io-readable.test.ts
+++ b/src/solana/io-readable.test.ts
@@ -1,0 +1,53 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import bs58 from 'bs58';
+
+import { Logger } from '../common/logger.js';
+import { SolanaARIOReadable } from './io-readable.js';
+
+type Counts = { gma: number; gmaAccts: number };
+
+function countingRpc(counts: Counts) {
+  return {
+    getMultipleAccounts: (addrs: unknown[]) => ({
+      send: async () => {
+        counts.gma++;
+        counts.gmaAccts += addrs.length;
+        return { value: addrs.map(() => null) };
+      },
+    }),
+  };
+}
+
+function mint(n: number): string {
+  return bs58.encode(Buffer.alloc(32, n));
+}
+
+class TestReadable extends SolanaARIOReadable {
+  async readAccumulators(operatorAddresses: string[]) {
+    return this.getGatewayAccumulators(operatorAddresses);
+  }
+}
+
+function makeReadable(counts: Counts) {
+  return new TestReadable({
+    // biome-ignore lint/suspicious/noExplicitAny: minimal stub rpc for counting
+    rpc: countingRpc(counts) as any,
+    logger: new Logger({ level: 'none' }),
+  });
+}
+
+describe('SolanaARIOReadable accumulator batching', () => {
+  it('chunks getGatewayAccumulators into 100-account getMultipleAccounts calls', async () => {
+    const counts: Counts = { gma: 0, gmaAccts: 0 };
+    const readable = makeReadable(counts);
+
+    const operators = Array.from({ length: 250 }, (_, i) => mint(i + 1));
+    const accumulators = await readable.readAccumulators(operators);
+
+    assert.equal(counts.gma, 3, '250 gateways should be split into 3 calls');
+    assert.equal(counts.gmaAccts, 250, 'all 250 accounts should be requested');
+    assert.deepEqual(accumulators, new Map());
+  });
+});

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -150,7 +150,13 @@ import {
   deserializeVault,
   deserializeWithdrawal,
 } from './deserialize.js';
-import { estimateRentLamports, getIntentGasProfile } from './gas.js';
+import {
+  GAR_COMPUTE_UNIT_LIMIT,
+  type GarGasWorkflow,
+  estimateRentLamports,
+  getGarWorkflowGasProfile,
+  getIntentGasProfile,
+} from './gas.js';
 import { TOKEN_PROGRAM_ADDRESS } from './instruction.js';
 import {
   getAclConfigPDA,
@@ -158,6 +164,7 @@ import {
   getArnsRecordPDA,
   getArnsRecordPDAFromHash,
   getArnsSettingsPDA,
+  getDelegationPDA,
   getDemandFactorPDA,
   getEpochPDA,
   getEpochSettingsPDA,
@@ -167,9 +174,12 @@ import {
   getObserverLookupPDA,
   getPrimaryNamePDA,
   getPrimaryNameRequestPDA,
+  getRedelegationRecordPDA,
   getReservedNamePDA,
   getReturnedNamePDA,
   getVaultPDA,
+  getWithdrawalCounterPDA,
+  getWithdrawalPDA,
 } from './pda.js';
 import { withRetry } from './retry.js';
 import {
@@ -1889,6 +1899,171 @@ export class SolanaARIOReadable {
       signatureCount: profile.signatureCount,
       transactionCount: profile.transactionCount,
       rentLamports,
+      priorityFeeMicroLamports: this._priorityFeeCache.microLamports,
+    });
+  }
+
+  /**
+   * Estimate the Solana network cost ("gas") of a GAR (gateway registry)
+   * workflow, in lamports — fees on the 1M compute-unit limit every GAR
+   * write pins, plus rent for the accounts the workflow creates, plus the
+   * deposit refunded when it closes a withdrawal vault:
+   *
+   * - `join-network`: gateway + observer-lookup accounts and the registry
+   *   growing by one entry — ~0.009 SOL.
+   * - `leave-network`: up to two withdrawal vaults (~0.0035 SOL,
+   *   conservative — the excess vault is only consumed when post-stake
+   *   excess exists). The gateway account's own deposit returns at prune
+   *   time, far later, and is not quoted.
+   * - `delegate-stake` / `redelegate-stake`: a Delegation PDA (~0.0016 SOL)
+   *   when the delegator has none with that gateway yet (pass
+   *   `fromAddress` + `gatewayAddress` to check live; unknown → assumed).
+   * - `decrease-*-stake`: a withdrawal vault (~0.0017 SOL, refunded when
+   *   later claimed/cancelled) plus the one-time withdrawal counter on the
+   *   actor's first-ever withdrawal. With `instant: true` the follow-up
+   *   transaction closes the vault again — reported as reclaimed.
+   * - `claim-withdrawal` / `cancel-withdrawal` / `instant-withdrawal`:
+   *   refunds the vault's live deposit (pass `fromAddress` + `vaultId` for
+   *   the exact number).
+   * - `update-gateway-settings` / `increase-operator-stake`: fees only.
+   */
+  async getGarGasEstimate(opts: {
+    workflow: GarGasWorkflow;
+    /** The acting wallet (operator or delegator). Enables live checks. */
+    fromAddress?: WalletAddress;
+    /** Target gateway for delegate/redelegate-stake delegation checks. */
+    gatewayAddress?: WalletAddress;
+    /** Vault id for withdrawal-closing workflows (exact reclaim quote). */
+    vaultId?: string | number | bigint;
+    /** decrease-delegate-stake with instant payout (second transaction). */
+    instant?: boolean;
+  }): Promise<GasEstimate> {
+    const now = Date.now();
+    if (!this._priorityFeeCache || this._priorityFeeCache.expiresAt <= now) {
+      this._priorityFeeCache = {
+        microLamports: await estimateQuotePriorityFeeMicroLamports(this.rpc),
+        expiresAt: now + PRIORITY_FEE_CACHE_TTL_MS,
+      };
+    }
+
+    // Conditional accounts — checked live when the actor is known,
+    // conservative (assume creation) otherwise. All best-effort.
+    let needsDelegation = true;
+    let needsWithdrawalCounter = true;
+    let needsRedelegationRecord = true;
+    let rentReclaimedLamports = 0;
+
+    const isDelegationWorkflow =
+      opts.workflow === 'delegate-stake' ||
+      opts.workflow === 'redelegate-stake';
+    if (isDelegationWorkflow && opts.fromAddress && opts.gatewayAddress) {
+      try {
+        const [delegationPda] = await getDelegationPDA(
+          address(opts.gatewayAddress),
+          address(opts.fromAddress),
+          this.garProgram,
+        );
+        needsDelegation = !(await this.getCachedAccount(delegationPda)).exists;
+      } catch {
+        // keep the conservative default
+      }
+    }
+
+    const isWithdrawalCreatingWorkflow =
+      opts.workflow === 'leave-network' ||
+      opts.workflow === 'decrease-operator-stake' ||
+      opts.workflow === 'decrease-delegate-stake';
+    if (isWithdrawalCreatingWorkflow && opts.fromAddress) {
+      try {
+        const [counterPda] = await getWithdrawalCounterPDA(
+          address(opts.fromAddress),
+          this.garProgram,
+        );
+        needsWithdrawalCounter = !(await this.getCachedAccount(counterPda))
+          .exists;
+      } catch {
+        // keep the conservative default
+      }
+    }
+
+    if (opts.workflow === 'redelegate-stake' && opts.fromAddress) {
+      try {
+        const [recordPda] = await getRedelegationRecordPDA(
+          address(opts.fromAddress),
+          this.garProgram,
+        );
+        needsRedelegationRecord = !(await this.getCachedAccount(recordPda))
+          .exists;
+      } catch {
+        // keep the conservative default
+      }
+    }
+
+    // Withdrawal-closing workflows refund the vault's actual deposit —
+    // read it live when the caller identifies the vault.
+    const isWithdrawalClosingWorkflow =
+      opts.workflow === 'claim-withdrawal' ||
+      opts.workflow === 'cancel-withdrawal' ||
+      opts.workflow === 'instant-withdrawal';
+    if (
+      isWithdrawalClosingWorkflow &&
+      opts.fromAddress &&
+      opts.vaultId !== undefined
+    ) {
+      try {
+        const [withdrawalPda] = await getWithdrawalPDA(
+          address(opts.fromAddress),
+          BigInt(opts.vaultId),
+          this.garProgram,
+        );
+        const account = await this.getAccount(withdrawalPda);
+        if (account.exists) {
+          rentReclaimedLamports = Number(account.lamports);
+        }
+      } catch {
+        // quote stays fees-only; the refund still happens on chain
+      }
+    }
+
+    const profile = getGarWorkflowGasProfile({
+      workflow: opts.workflow,
+      needsDelegation,
+      needsWithdrawalCounter,
+      needsRedelegationRecord,
+      instant: opts.instant,
+    });
+
+    const reallocBytes = profile.reallocBytes ?? 0;
+    const rentKey =
+      profile.accountBytes.reduce((sum, b) => sum + b, 0) +
+      reallocBytes +
+      profile.accountBytes.length;
+    let rentLamports = this._rentCache.get(rentKey);
+    if (rentLamports === undefined) {
+      rentLamports = await estimateRentLamports(
+        this.rpc,
+        profile.accountBytes,
+        reallocBytes,
+      );
+      this._rentCache.set(rentKey, rentLamports);
+    }
+
+    // Instant decrease: the second transaction immediately closes the
+    // vault created by the first — its deposit round-trips back.
+    if (
+      opts.instant &&
+      (opts.workflow === 'decrease-delegate-stake' ||
+        opts.workflow === 'decrease-operator-stake')
+    ) {
+      rentReclaimedLamports = rentLamports;
+    }
+
+    return estimateGasFee(this.rpc, {
+      computeUnitLimit: GAR_COMPUTE_UNIT_LIMIT,
+      signatureCount: profile.signatureCount,
+      transactionCount: profile.transactionCount,
+      rentLamports,
+      rentReclaimedLamports,
       priorityFeeMicroLamports: this._priorityFeeCache.microLamports,
     });
   }

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -92,6 +92,7 @@ import type {
   EpochSettings,
   FundFrom,
   FundingPlan,
+  GasEstimate,
   Gateway,
   GatewayDelegateWithAddress,
   GatewayRegistrySettings,
@@ -100,6 +101,7 @@ import type {
   GatewayWithAddress,
   GetArNSRecordsParams,
   GetCostDetailsParams,
+  Intent,
   PaginatedAddressParams,
   PaginationParams,
   PaginationResult,
@@ -148,8 +150,10 @@ import {
   deserializeVault,
   deserializeWithdrawal,
 } from './deserialize.js';
+import { estimateRentLamports, getIntentGasProfile } from './gas.js';
 import { TOKEN_PROGRAM_ADDRESS } from './instruction.js';
 import {
+  getAclConfigPDA,
   getArioConfigPDA,
   getArnsRecordPDA,
   getArnsRecordPDAFromHash,
@@ -168,6 +172,10 @@ import {
   getVaultPDA,
 } from './pda.js';
 import { withRetry } from './retry.js';
+import {
+  estimateGasFee,
+  estimateQuotePriorityFeeMicroLamports,
+} from './send.js';
 import type { SolanaReadConfig, SolanaRpc } from './types.js';
 
 const addressDecoder = getAddressDecoder();
@@ -265,6 +273,15 @@ function arnsRecordToWithName(
  */
 const CONFIG_CACHE_TTL_MS = 30_000;
 
+/**
+ * TTL for the memoized priority-fee (compute-unit price) estimate used by
+ * {@link SolanaARIOReadable.getGasEstimate}. The fee market moves slot to
+ * slot, but a quote tolerates seconds of staleness — and a price table
+ * calling `getCostDetails` per row shouldn't re-query
+ * `getRecentPrioritizationFees` for every name.
+ */
+const PRIORITY_FEE_CACHE_TTL_MS = 10_000;
+
 function paginate<T>(
   items: T[],
   params?: { cursor?: string; limit?: number; sortOrder?: 'asc' | 'desc' },
@@ -325,6 +342,14 @@ export class SolanaARIOReadable {
       expiresAt: number;
     }
   >();
+
+  // Short-TTL memo of the estimated compute-unit price (priority fee), so
+  // burst `getCostDetails` calls share one getRecentPrioritizationFees query.
+  private _priorityFeeCache?: { microLamports: bigint; expiresAt: number };
+
+  // Memo of getMinimumBalanceForRentExemption results keyed by byte size.
+  // Rent parameters are cluster constants in practice, so no TTL.
+  private _rentCache = new Map<number, number>();
 
   constructor(
     config: SolanaReadConfig & {
@@ -1773,6 +1798,101 @@ export class SolanaARIOReadable {
    * Mirrors the Rust pricing functions in ario-arns/src/pricing.rs.
    * Uses BigInt for u128-equivalent overflow-safe arithmetic.
    */
+  /**
+   * Estimate the Solana network cost ("gas") for executing an intent, in
+   * lamports — transaction fees PLUS rent-exempt deposits for the accounts
+   * the flow creates. The intent matters: Buy-Name runs two transactions
+   * (ANT spawn + buy) and deposits rent for the spawned asset/PDAs and the
+   * ArNS record — ~0.015 SOL, vs ~0.00001 SOL of fees. First-time buyers
+   * (no ACL config yet) additionally pay for the ACL bootstrap accounts
+   * (~0.06 SOL); pass `fromAddress` so that check can be made — without it
+   * the estimate conservatively assumes a first-time buyer.
+   *
+   * Fees mirror what the writeable client's `sendAndConfirm` will attach:
+   * the default 400k compute-unit limit every ArNS purchase write uses, and
+   * a compute-unit price quoted from recent on-chain prioritization fees
+   * (memoized for {@link PRIORITY_FEE_CACHE_TTL_MS}). Rent is quoted from
+   * the cluster's `getMinimumBalanceForRentExemption` (memoized per size).
+   *
+   * See {@link GasEstimate} for the breakdown shape and why the fee side is
+   * a conservative upper bound.
+   */
+  async getGasEstimate(
+    opts: {
+      intent?: Intent;
+      name?: string;
+      fromAddress?: WalletAddress;
+      computeUnitLimit?: number;
+    } = {},
+  ): Promise<GasEstimate> {
+    const now = Date.now();
+    if (!this._priorityFeeCache || this._priorityFeeCache.expiresAt <= now) {
+      this._priorityFeeCache = {
+        // Quote-grade rate: covers what a browser wallet will attach, not
+        // just the (near-floor) base estimate keypair sends pay.
+        microLamports: await estimateQuotePriorityFeeMicroLamports(this.rpc),
+        expiresAt: now + PRIORITY_FEE_CACHE_TTL_MS,
+      };
+    }
+
+    // Conditional accounts: only created when the buyer doesn't already
+    // have them. Unknown buyer → assume they're needed (over-quote rather
+    // than under-gate). Both checks are best-effort: an RPC failure falls
+    // back to the conservative assumption instead of failing the quote.
+    let needsAclBootstrap = false;
+    let needsPrimaryNameAccount = false;
+    if (opts.intent === 'Buy-Name' || opts.intent === 'Buy-Record') {
+      needsAclBootstrap = true;
+      if (opts.fromAddress) {
+        try {
+          const [aclPda] = await getAclConfigPDA(
+            address(opts.fromAddress),
+            this.antProgram,
+          );
+          needsAclBootstrap = !(await this.getCachedAccount(aclPda)).exists;
+        } catch {
+          // keep the conservative default
+        }
+      }
+    } else if (opts.intent === 'Primary-Name-Request') {
+      needsPrimaryNameAccount = true;
+      if (opts.fromAddress) {
+        try {
+          const [pnPda] = await getPrimaryNamePDA(
+            address(opts.fromAddress),
+            this.coreProgram,
+          );
+          needsPrimaryNameAccount = !(await this.getCachedAccount(pnPda))
+            .exists;
+        } catch {
+          // keep the conservative default
+        }
+      }
+    }
+
+    const profile = getIntentGasProfile({
+      intent: opts.intent,
+      name: opts.name,
+      needsAclBootstrap,
+      needsPrimaryNameAccount,
+    });
+
+    const rentKey = profile.accountBytes.reduce((sum, b) => sum + b, 0);
+    let rentLamports = this._rentCache.get(rentKey);
+    if (rentLamports === undefined) {
+      rentLamports = await estimateRentLamports(this.rpc, profile.accountBytes);
+      this._rentCache.set(rentKey, rentLamports);
+    }
+
+    return estimateGasFee(this.rpc, {
+      computeUnitLimit: opts.computeUnitLimit,
+      signatureCount: profile.signatureCount,
+      transactionCount: profile.transactionCount,
+      rentLamports,
+      priorityFeeMicroLamports: this._priorityFeeCache.microLamports,
+    });
+  }
+
   async getTokenCost(params: TokenCostParams): Promise<number> {
     const [dfPda] = await getDemandFactorPDA(this.arnsProgram);
     const dfAccount = await this.getCachedAccount(dfPda);
@@ -1928,6 +2048,14 @@ export class SolanaARIOReadable {
   async getCostDetails(
     params: GetCostDetailsParams,
   ): Promise<CostDetailsResult> {
+    // Network-cost quote runs concurrently with the pricing reads. It never
+    // rejects (the fee and rent queries fall back internally), so kicking it
+    // off before the awaits below can't leave an unhandled rejection behind.
+    const gasEstimatePromise = this.getGasEstimate({
+      intent: params.intent,
+      name: params.name,
+      fromAddress: params.fromAddress,
+    });
     const tokenCost = await this.getTokenCost(params);
 
     const discounts: Array<{
@@ -2010,6 +2138,7 @@ export class SolanaARIOReadable {
     return {
       tokenCost: finalCost,
       discounts,
+      gasEstimate: await gasEstimatePromise,
       ...(fundingPlan ? { fundingPlan } : {}),
     };
   }

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -29,8 +29,6 @@ import {
   fetchEncodedAccounts,
   getAddressDecoder,
 } from '@solana/kit';
-import bs58 from 'bs58';
-
 import {
   ARNS_RECORD_DISCRIMINATOR,
   DEMAND_FACTOR_DOWN_ADJUSTMENT,
@@ -442,9 +440,11 @@ export class SolanaARIOReadable {
    * Helper for `getProgramAccounts` with a discriminator memcmp filter.
    *
    * Pass the Codama-generated `<NAME>_DISCRIMINATOR: Uint8Array` constant
-   * directly — kit's RPC requires a base58 string for `memcmp.bytes`, so
-   * we bs58-encode here to keep call sites from doing it inline (and to
-   * keep the IDL-derived bytes as the single source of truth).
+   * directly — we base64-encode here to keep call sites from doing it
+   * inline (and to keep the IDL-derived bytes as the single source of
+   * truth). Uses base64 rather than base58 because some browser
+   * environments / RPC proxies mishandle base58-encoded memcmp filters
+   * when multiple filters are present.
    */
   private async getAccountsByDiscriminator(
     programId: Address,
@@ -455,8 +455,8 @@ export class SolanaARIOReadable {
       {
         memcmp: {
           offset: 0n,
-          bytes: bs58.encode(discriminator as Uint8Array),
-          encoding: 'base58',
+          bytes: Buffer.from(discriminator as Uint8Array).toString('base64'),
+          encoding: 'base64',
         },
       },
       ...extraFilters,
@@ -1657,8 +1657,8 @@ export class SolanaARIOReadable {
         {
           memcmp: {
             offset: 8n,
-            bytes: bs58.encode(epochIndexBuf),
-            encoding: 'base58',
+            bytes: Buffer.from(epochIndexBuf).toString('base64'),
+            encoding: 'base64',
           },
         },
       ],
@@ -1717,8 +1717,8 @@ export class SolanaARIOReadable {
         {
           memcmp: {
             offset: 8n,
-            bytes: bs58.encode(epochIndexBuf),
-            encoding: 'base58',
+            bytes: Buffer.from(epochIndexBuf).toString('base64'),
+            encoding: 'base64',
           },
         },
       ],

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -324,6 +324,21 @@ function paginate<T>(
  * const record = await ario.getArNSRecord({ name: 'ardrive' });
  * ```
  */
+
+/**
+ * Fixed leave cooldown (seconds) a `Leaving` gateway must wait before
+ * `finalize_gone` can GC it. Mirrors the on-chain `GATEWAY_LEAVE_PERIOD`
+ * (90 days) in ar-io-solana-contracts (`programs/ario-gar/src/lib.rs`).
+ */
+const GATEWAY_LEAVE_PERIOD_SECONDS = 90 * 86_400; // 7_776_000
+
+/**
+ * Epoch-retention multiplier in the on-chain finalize_gone window
+ * (`leave_timestamp + GATEWAY_LEAVE_PERIOD + 7 * epoch_duration`), mirroring
+ * the GAR-006 epoch retention.
+ */
+const FINALIZE_GONE_EPOCH_RETENTION = 7;
+
 export class SolanaARIOReadable {
   protected readonly rpc: SolanaRpc;
   protected readonly commitment: Commitment;
@@ -3022,25 +3037,45 @@ export class SolanaARIOReadable {
 
   /**
    * Enumerate `Leaving` Gateway PDAs that are ACTUALLY eligible for
-   * `finalizeGone` at `now` — i.e. their leave window has fully elapsed
-   * (`now >= leaveTimestamp`) AND no delegated stake remains
-   * (`totalDelegatedStake === 0`). These are exactly the two preconditions the
-   * on-chain `finalize_gone` enforces: it reverts `LeaveWindowNotExpired`
-   * before the window elapses, and will not GC a gateway that still has live
-   * delegations (programs/ario-gar/src/instructions/gateway.rs::finalize_gone).
+   * `finalizeGone` at `now`. The on-chain GC window
+   * (`programs/ario-gar/src/instructions/gateway.rs::finalize_gone`) is:
    *
-   * {@link getLeavingGateways} over-returns *every* `Leaving` gateway and
-   * relies on those reverts happening on-chain. A cranker that calls
-   * `finalizeGone` per result therefore burns a tx attempt — and logs a
-   * simulation failure — on every not-yet-eligible gateway, every tick. Prefer
-   * this method in cranker loops so only finalizable gateways are attempted.
-   * Mirrors the expiry-filtered discovery pattern of {@link getExpiredVaults}.
+   * ```
+   * eligibleAt = leaveTimestamp
+   *            + GATEWAY_LEAVE_PERIOD                 // 90 days, fixed
+   *            + 7 * max(leaveEpochDuration, epoch_settings.epoch_duration)
+   * ```
+   *
+   * The 7-epoch term mirrors GAR-006 epoch retention; the `max` is the
+   * program's defense against an admin shortening `epoch_duration` after a
+   * gateway left (`leaveEpochDuration` is the snapshot taken at leave time).
+   * A gateway is finalizable only once `now >= eligibleAt` AND it holds no
+   * delegated stake (`totalDelegatedStake === 0`) — `finalize_gone` reverts
+   * `LeaveWindowNotExpired` before the window and won't GC a gateway with live
+   * delegations.
+   *
+   * {@link getLeavingGateways} over-returns *every* `Leaving` gateway; a cranker
+   * that calls `finalizeGone` on those burns a reverting tx (and a logged
+   * simulation failure) on every not-yet-eligible gateway each tick. Prefer
+   * this method in cranker loops so only truly-finalizable gateways are tried.
    *
    * @param now Unix seconds (e.g. `Math.floor(Date.now() / 1000)`).
    */
   async getFinalizableGoneGateways(
     now: number,
   ): Promise<Array<{ pubkey: Address; operator: Address }>> {
+    // Current epoch_duration (seconds) for the on-chain `max(snapshot, current)`.
+    // If the settings read fails, fall back to 0 so only the per-gateway
+    // snapshot is used — the dominant GATEWAY_LEAVE_PERIOD term still applies.
+    let currentEpochDuration = 0;
+    try {
+      currentEpochDuration = Number(
+        (await this.getEpochSettings()).epochDuration,
+      );
+    } catch {
+      // settings unavailable — snapshot-only window
+    }
+
     const accounts = await this.getAccountsByDiscriminator(
       this.garProgram,
       GATEWAY_DISCRIMINATOR,
@@ -3051,13 +3086,19 @@ export class SolanaARIOReadable {
       try {
         const g = decoder.decode(data);
         if (g.status !== GatewayStatus.Leaving) continue;
-        // `leaveTimestamp` is the leave-window END in on-chain seconds; it is
-        // `Some` for a Leaving gateway. Skip until the window has elapsed.
         if (g.leaveTimestamp.__option !== 'Some') continue;
-        if (Number(g.leaveTimestamp.value) > now) continue;
         // Live delegations must be cranked out first (separate GC path), else
         // finalize_gone reverts.
         if (g.totalDelegatedStake !== 0n) continue;
+        const epochDuration = Math.max(
+          Number(g.leaveEpochDuration),
+          currentEpochDuration,
+        );
+        const eligibleAt =
+          Number(g.leaveTimestamp.value) +
+          GATEWAY_LEAVE_PERIOD_SECONDS +
+          FINALIZE_GONE_EPOCH_RETENTION * epochDuration;
+        if (eligibleAt > now) continue;
         out.push({ pubkey, operator: g.operator });
       } catch {
         // skip malformed

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -33,6 +33,13 @@ import bs58 from 'bs58';
 
 import {
   ARNS_RECORD_DISCRIMINATOR,
+  DEMAND_FACTOR_DOWN_ADJUSTMENT,
+  DEMAND_FACTOR_MIN,
+  DEMAND_FACTOR_SCALE,
+  DEMAND_FACTOR_UP_ADJUSTMENT,
+  MAX_PERIODS_AT_MIN_DEMAND_FACTOR,
+  MOVING_AVG_PERIOD_COUNT,
+  PERIOD_LENGTH_SECONDS,
   RESERVED_NAME_DISCRIMINATOR,
   RETURNED_NAME_DISCRIMINATOR,
   getArnsConfigDecoder,
@@ -2070,15 +2077,30 @@ export class SolanaARIOReadable {
     }
     const df = deserializeDemandFactor(Buffer.from(account.data));
 
+    // Derive every static setting from the on-chain program constants
+    // (`@ar.io/solana-contracts/arns`, lifted from the Rust source-of-truth)
+    // rather than hand-copied literals, which had drifted: the down-adjustment
+    // was hardcoded `25` (2.5%) while the program uses
+    // DEMAND_FACTOR_DOWN_ADJUSTMENT = 985_000 → 0.985× → 1.5% (`15`), and
+    // `maxPeriodsAtMinDemandFactor` returned the live consecutive-period
+    // counter instead of the MAX_PERIODS_AT_MIN_DEMAND_FACTOR threshold.
+    //
+    // The `*AdjustmentRate` fields are the per-period step magnitude scaled by
+    // 1000 (up: 1.05× → 50; down: 0.985× → 15), matching the existing units.
+    const scale = DEMAND_FACTOR_SCALE;
     return {
       periodZeroStartTimestamp: df.periodZeroStartTimestamp,
-      movingAvgPeriodCount: 7,
-      periodLengthMs: 86_400 * 1000,
+      movingAvgPeriodCount: MOVING_AVG_PERIOD_COUNT,
+      periodLengthMs: Number(PERIOD_LENGTH_SECONDS) * 1000,
       demandFactorBaseValue: 1,
-      demandFactorMin: 0.5,
-      demandFactorUpAdjustmentRate: 50,
-      demandFactorDownAdjustmentRate: 25,
-      maxPeriodsAtMinDemandFactor: df.consecutivePeriodsWithMinDemandFactor,
+      demandFactorMin: Number(DEMAND_FACTOR_MIN) / Number(scale),
+      demandFactorUpAdjustmentRate: Number(
+        ((DEMAND_FACTOR_UP_ADJUSTMENT - scale) * 1000n) / scale,
+      ),
+      demandFactorDownAdjustmentRate: Number(
+        ((scale - DEMAND_FACTOR_DOWN_ADJUSTMENT) * 1000n) / scale,
+      ),
+      maxPeriodsAtMinDemandFactor: MAX_PERIODS_AT_MIN_DEMAND_FACTOR,
       criteria: 'revenue',
     };
   }

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -3069,9 +3069,10 @@ export class SolanaARIOReadable {
     // snapshot is used — the dominant GATEWAY_LEAVE_PERIOD term still applies.
     let currentEpochDuration = 0;
     try {
-      currentEpochDuration = Number(
-        (await this.getEpochSettings()).epochDuration,
-      );
+      // getEpochSettings() exposes the duration as `durationMs`; the on-chain
+      // window math is in seconds (matching leaveTimestamp/leaveEpochDuration).
+      currentEpochDuration =
+        Number((await this.getEpochSettings()).durationMs) / 1000;
     } catch {
       // settings unavailable — snapshot-only window
     }

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -219,6 +219,14 @@ function toMsTimestamps<T extends Record<string, unknown>>(obj: T): T {
   return out as T;
 }
 
+function chunk<T>(items: ReadonlyArray<T>, size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size) as T[]);
+  }
+  return chunks;
+}
+
 /**
  * Drop the SDK-internal extras (`name`, `owner`) and the `processId` re-key
  * that `deserializeArnsRecord` adds, projecting back to the cross-backend
@@ -423,28 +431,30 @@ export class SolanaARIOReadable {
   ): Promise<Map<string, bigint>> {
     const unique = Array.from(new Set(operatorAddresses));
     if (unique.length === 0) return new Map();
-    const pdas = await Promise.all(
-      unique.map(
-        async (op) => (await getGatewayPDA(address(op), this.garProgram))[0],
-      ),
-    );
-    const accounts = await withRetry(() =>
-      fetchEncodedAccounts(this.rpc, pdas, {
-        commitment: this.commitment,
-      }),
-    );
     const out = new Map<string, bigint>();
-    for (let i = 0; i < accounts.length; i++) {
-      const acct = accounts[i];
-      if (!acct.exists) continue;
-      try {
-        // Internal variant: surfaces the u128 accumulator that the public
-        // `deserializeGateway` deliberately drops (BigInt is not
-        // JSON-serializable and would leak through getGateway).
-        const gw = deserializeGatewayWithAccumulator(Buffer.from(acct.data));
-        out.set(unique[i], gw.cumulativeRewardPerToken);
-      } catch {
-        // Skip malformed; the caller will fall back to the raw delegation amount.
+    for (const group of chunk(unique, 100)) {
+      const pdas = await Promise.all(
+        group.map(
+          async (op) => (await getGatewayPDA(address(op), this.garProgram))[0],
+        ),
+      );
+      const accounts = await withRetry(() =>
+        fetchEncodedAccounts(this.rpc, pdas, {
+          commitment: this.commitment,
+        }),
+      );
+      for (let i = 0; i < accounts.length; i++) {
+        const acct = accounts[i];
+        if (!acct.exists) continue;
+        try {
+          // Internal variant: surfaces the u128 accumulator that the public
+          // `deserializeGateway` deliberately drops (BigInt is not
+          // JSON-serializable and would leak through getGateway).
+          const gw = deserializeGatewayWithAccumulator(Buffer.from(acct.data));
+          out.set(group[i], gw.cumulativeRewardPerToken);
+        } catch {
+          // Skip malformed; the caller will fall back to the raw delegation amount.
+        }
       }
     }
     return out;

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -3021,6 +3021,52 @@ export class SolanaARIOReadable {
   }
 
   /**
+   * Enumerate `Leaving` Gateway PDAs that are ACTUALLY eligible for
+   * `finalizeGone` at `now` — i.e. their leave window has fully elapsed
+   * (`now >= leaveTimestamp`) AND no delegated stake remains
+   * (`totalDelegatedStake === 0`). These are exactly the two preconditions the
+   * on-chain `finalize_gone` enforces: it reverts `LeaveWindowNotExpired`
+   * before the window elapses, and will not GC a gateway that still has live
+   * delegations (programs/ario-gar/src/instructions/gateway.rs::finalize_gone).
+   *
+   * {@link getLeavingGateways} over-returns *every* `Leaving` gateway and
+   * relies on those reverts happening on-chain. A cranker that calls
+   * `finalizeGone` per result therefore burns a tx attempt — and logs a
+   * simulation failure — on every not-yet-eligible gateway, every tick. Prefer
+   * this method in cranker loops so only finalizable gateways are attempted.
+   * Mirrors the expiry-filtered discovery pattern of {@link getExpiredVaults}.
+   *
+   * @param now Unix seconds (e.g. `Math.floor(Date.now() / 1000)`).
+   */
+  async getFinalizableGoneGateways(
+    now: number,
+  ): Promise<Array<{ pubkey: Address; operator: Address }>> {
+    const accounts = await this.getAccountsByDiscriminator(
+      this.garProgram,
+      GATEWAY_DISCRIMINATOR,
+    );
+    const decoder = getGatewayDecoder();
+    const out: Array<{ pubkey: Address; operator: Address }> = [];
+    for (const { pubkey, data } of accounts) {
+      try {
+        const g = decoder.decode(data);
+        if (g.status !== GatewayStatus.Leaving) continue;
+        // `leaveTimestamp` is the leave-window END in on-chain seconds; it is
+        // `Some` for a Leaving gateway. Skip until the window has elapsed.
+        if (g.leaveTimestamp.__option !== 'Some') continue;
+        if (Number(g.leaveTimestamp.value) > now) continue;
+        // Live delegations must be cranked out first (separate GC path), else
+        // finalize_gone reverts.
+        if (g.totalDelegatedStake !== 0n) continue;
+        out.push({ pubkey, operator: g.operator });
+      } catch {
+        // skip malformed
+      }
+    }
+    return out;
+  }
+
+  /**
    * Enumerate Joined Gateway PDAs whose delegation has been DISABLED
    * (`allow_delegated_staking == false`) yet still hold delegated stake
    * (`total_delegated_stake > 0`) — i.e. delegates that an operator's disable

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -1,34 +1,3 @@
-/**
- * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-/**
- * Solana implementation of the ARIORead interface.
- *
- * Reads AR.IO protocol state directly from Solana PDAs using RPC,
- * returning the same types that the AO implementation returns.
- * This allows consumers to switch backends transparently.
- */
-import {
-  type Address,
-  type Commitment,
-  type ReadonlyUint8Array,
-  address,
-  fetchEncodedAccount,
-  fetchEncodedAccounts,
-  getAddressDecoder,
-} from '@solana/kit';
 import {
   ARNS_RECORD_DISCRIMINATOR,
   DEMAND_FACTOR_DOWN_ADJUSTMENT,
@@ -63,6 +32,37 @@ import {
   getGatewayDecoder,
   getWithdrawalDecoder,
 } from '@ar.io/solana-contracts/gar';
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Solana implementation of the ARIORead interface.
+ *
+ * Reads AR.IO protocol state directly from Solana PDAs using RPC,
+ * returning the same types that the AO implementation returns.
+ * This allows consumers to switch backends transparently.
+ */
+import {
+  type Address,
+  type Commitment,
+  type ReadonlyUint8Array,
+  address,
+  fetchEncodedAccount,
+  fetchEncodedAccounts,
+  getAddressDecoder,
+} from '@solana/kit';
 import { type ILogger, Logger } from '../common/logger.js';
 import type {
   PrimaryName,

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -1768,10 +1768,16 @@ export class SolanaARIOReadable {
             const elapsed = now - returned.startTimestamp;
             const duration = 14 * 86_400_000;
             if (elapsed < duration) {
-              const remaining = BigInt(duration - elapsed);
+              // Returned Name Premium (RNP) decays linearly from 50x to 1x
+              // over the window, matching the whitepaper (RNP = 50 - 49/14*t)
+              // and the on-chain ario-arns pricing
+              // (calculate_returned_name_premium):
+              //   multiplier = (50*dur - 49*elapsed) * scale / dur
+              // Floors at 1x at window close (NOT 0x) — at which point the
+              // name reverts to standard pricing.
               const dur = BigInt(duration);
-              const pctRemaining = (remaining * scale) / dur;
-              const multiplier = 50n * pctRemaining;
+              const el = BigInt(elapsed);
+              const multiplier = ((50n * dur - 49n * el) * scale) / dur;
               cost = (cost * multiplier) / scale;
             }
           }

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -375,6 +375,35 @@ export class SolanaARIOReadable {
   }
 
   /**
+   * The Solana cluster's `unix_timestamp` (in SECONDS), read read-only.
+   *
+   * On-chain handlers measure time against the cluster clock
+   * (`Clock::get()?.unix_timestamp`), NOT the client wall clock. For any
+   * pricing math that must agree with what the program will charge (e.g. the
+   * Dutch-auction premium for returned names, whose elapsed time gates the
+   * multiplier), the SDK must compare against this same clock — `Date.now()`
+   * drifts from `unix_timestamp` (the cluster clock famously lags real
+   * wall-clock by seconds-to-minutes), which would make the SDK over-estimate
+   * elapsed time and therefore UNDER-quote the premium.
+   *
+   * Sourced via the latest slot's block time (`getSlot` → `getBlockTime`),
+   * which the runtime derives from the same stake-weighted clock the on-chain
+   * `Clock` sysvar exposes. Read-only: no signer, no transaction.
+   */
+  private async getClusterUnixTimestampSeconds(): Promise<number> {
+    const slot = await withRetry(() =>
+      this.rpc.getSlot({ commitment: this.commitment }).send(),
+    );
+    const blockTime = await withRetry(() => this.rpc.getBlockTime(slot).send());
+    if (blockTime == null) {
+      throw new Error(
+        `Cluster block time unavailable for slot ${slot}; cannot match on-chain Clock::get().unix_timestamp`,
+      );
+    }
+    return Number(blockTime);
+  }
+
+  /**
    * Helper for `getProgramAccounts` with a discriminator memcmp filter.
    *
    * Pass the Codama-generated `<NAME>_DISCRIMINATOR: Uint8Array` constant
@@ -1750,6 +1779,51 @@ export class SolanaARIOReadable {
     if (!dfAccount.exists) throw new Error('DemandFactor account not found');
     const df = deserializeDemandFactor(Buffer.from(dfAccount.data));
 
+    // Match the on-chain clock: the program measures time against the Solana
+    // cluster's `Clock::get().unix_timestamp`, not the client wall clock.
+    // Fetch it ONCE here and thread it through both the demand-factor
+    // staleness check and the returned-name premium math below. (Seconds.)
+    const clusterNowSeconds = await this.getClusterUnixTimestampSeconds();
+
+    // Demand-factor staleness warning.
+    //
+    // The handlers that actually charge roll the demand factor INLINE to the
+    // current period before pricing, whereas this read uses the STORED factor —
+    // which is stale whenever a demand period has rolled but no crank (or
+    // buy/extend) has landed to roll it. When that happens the chain prices
+    // against the rolled factor (a +5%/-1.5% step), so this quote can be off by
+    // one demand adjustment.
+    //
+    // We deliberately do NOT replicate the roll client-side: the authoritative
+    // roll math (multi-period catch-up, consecutive-min fee-halving) lives in
+    // the Rust program and depends on inputs a read-only client can't reproduce
+    // faithfully, so guessing would risk replacing a known small error with a
+    // wrong-direction one. The byte-exact path is the writeable
+    // `getCostDetails`, which simulates the on-chain instruction (rolling the
+    // factor inline). Here we just detect the rollover against the cluster
+    // clock and surface it as a debug warning.
+    const PERIOD_LENGTH_SECONDS = 86_400; // mirrors PERIOD_LENGTH_SECONDS in ario-arns
+    const elapsedSincePeriodZero =
+      clusterNowSeconds - df.periodZeroStartTimestamp;
+    const periodForNow =
+      elapsedSincePeriodZero < 0
+        ? 1
+        : Math.floor(elapsedSincePeriodZero / PERIOD_LENGTH_SECONDS) + 1;
+    if (periodForNow > df.currentPeriod) {
+      this.logger.debug(
+        '[pricing] demand factor period has rolled but stored factor is stale; ' +
+          'quote may be off by one demand adjustment until a crank rolls it. ' +
+          'Use the writeable simulated getCostDetails for a byte-exact quote.',
+        {
+          name: params.name,
+          intent: params.intent,
+          storedPeriod: df.currentPeriod,
+          clusterPeriod: periodForNow,
+          storedDemandFactor: df.currentDemandFactor,
+        },
+      );
+    }
+
     const name = params.name.toLowerCase();
     const nameLen = Math.min(Math.max(name.length, 1), 51);
     const baseFee = df.fees[nameLen - 1] ?? df.fees[df.fees.length - 1];
@@ -1781,7 +1855,15 @@ export class SolanaARIOReadable {
           if (returned) {
             // returned.startTimestamp is in ms (public API convention),
             // so the rest of this comparison is in ms too.
-            const now = Date.now();
+            //
+            // CRITICAL: "now" must be the Solana cluster clock, NOT
+            // `Date.now()`. The on-chain returned-name handler measures
+            // premium-elapsed against `Clock::get().unix_timestamp`; because
+            // that clock lags real wall-clock, using `Date.now()` here
+            // over-estimates elapsed time, under-estimates the remaining
+            // premium, and quotes LOW versus what the chain charges. Convert
+            // the cluster seconds to ms to match `startTimestamp`'s units.
+            const now = clusterNowSeconds * 1000;
             const elapsed = now - returned.startTimestamp;
             const duration = 14 * 86_400_000;
             if (elapsed < duration) {
@@ -1871,6 +1953,10 @@ export class SolanaARIOReadable {
             // Match on-chain eligibility from ario-arns pricing.rs
             // `try_apply_gateway_discount`:
             // 1. Tenure: gateway running >= 180 days (15_552_000 seconds)
+            // (This is a coarse 180-day eligibility gate, not the
+            // premium/auction math fixed above; sub-minute cluster-clock drift
+            // is immaterial at this granularity, so the client wall clock is
+            // fine here and we avoid an extra RPC round trip.)
             const GATEWAY_DISCOUNT_MIN_TENURE_S = 15_552_000;
             const nowSeconds = Math.floor(Date.now() / 1000);
             const timeRunning = nowSeconds - gw.startTimestamp;

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -1,3 +1,25 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Solana implementation of the ARIORead interface.
+ *
+ * Reads AR.IO protocol state directly from Solana PDAs using RPC,
+ * returning the same types that the AO implementation returns.
+ * This allows consumers to switch backends transparently.
+ */
 import {
   ARNS_RECORD_DISCRIMINATOR,
   DEMAND_FACTOR_DOWN_ADJUSTMENT,
@@ -32,28 +54,6 @@ import {
   getGatewayDecoder,
   getWithdrawalDecoder,
 } from '@ar.io/solana-contracts/gar';
-/**
- * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-/**
- * Solana implementation of the ARIORead interface.
- *
- * Reads AR.IO protocol state directly from Solana PDAs using RPC,
- * returning the same types that the AO implementation returns.
- * This allows consumers to switch backends transparently.
- */
 import {
   type Address,
   type Commitment,

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -2387,11 +2387,27 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
         extend: CostIntent.ExtendLease,
         increaseUndername: CostIntent.IncreaseUndernameLimit,
       } as const;
+      // IncreaseUndernameLimit pricing requires the record's purchase type
+      // (lease vs permabuy) — undername cost differs by type, and the on-chain
+      // instruction reads it from the record. `get_token_cost` can't read the
+      // record (it only gets demandFactor + payer), so it prices from params and
+      // REQUIRES `purchase_type` for this intent (else InvalidParameter #6039).
+      // Pass the record's actual type so the estimate matches what the
+      // instruction will charge.
+      let purchaseType: PurchaseType | undefined;
+      if (args.operation === 'increaseUndername') {
+        const record = await this.getArNSRecord({ name: args.params.name });
+        purchaseType =
+          record.type === 'permabuy'
+            ? PurchaseType.Permabuy
+            : PurchaseType.Lease;
+      }
       const cost = await this._simulateTokenCost({
         intent: intentMap[args.operation],
         name: args.params.name,
         years: args.years,
         quantity: args.quantity,
+        purchaseType,
       });
       const plan = await this._resolveFundingPlan(args.params, cost);
       const buyerATA = await getAssociatedTokenAddressKit(

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -2784,9 +2784,22 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
      *  validationAccounts. Ignored for the `request` variant. */
     antProgramId?: Address;
   }) {
+    // The primary-name fee is purchase-type-aware: the on-chain handler
+    // (ario-core `primary_name_base_fee`) reads the base record's purchase_type
+    // and charges 5x for permabuy vs lease. `get_token_cost` defaults a missing
+    // purchase_type to Lease, so for a permabuy base name the estimate would be
+    // 5x too low → FundingPlanAmountMismatch (#6066). Pass the base record's
+    // actual type so the plan total matches what the program charges.
+    const baseRecord = await this.getArNSRecord({
+      name: splitPrimaryName(args.params.name).baseName,
+    });
     const fee = await this._simulateTokenCost({
       intent: CostIntent.PrimaryNameRequest,
       name: args.params.name,
+      purchaseType:
+        baseRecord.type === 'permabuy'
+          ? PurchaseType.Permabuy
+          : PurchaseType.Lease,
     });
 
     const plan = await this._resolveFundingPlan(args.params, fee);

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -235,6 +235,7 @@ import {
   predictPrescribedObservers,
 } from './predict-prescribed-observers.js';
 import {
+  DEFAULT_COMPUTE_UNIT_LIMIT,
   reclaimLookupTablesForSigner,
   sendAndConfirm,
   sendWithEphemeralLookupTable,
@@ -599,7 +600,7 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
 
   protected async sendTransaction(
     instructions: Instruction[],
-    computeUnitLimit = 400_000,
+    computeUnitLimit = DEFAULT_COMPUTE_UNIT_LIMIT,
   ): Promise<string> {
     return sendAndConfirm({
       rpc: this.rpc,

--- a/src/solana/prune-discovery.test.ts
+++ b/src/solana/prune-discovery.test.ts
@@ -299,6 +299,7 @@ function makeGatewayBytes(
     allowDelegatedStaking?: boolean;
     totalDelegatedStake?: bigint;
     leaveTimestamp?: bigint | null;
+    leaveEpochDuration?: bigint;
   } = {},
 ): Uint8Array {
   const enc = getGatewayEncoder();
@@ -315,7 +316,7 @@ function makeGatewayBytes(
     status,
     startTimestamp: 0n,
     leaveTimestamp: opts.leaveTimestamp ?? null,
-    leaveEpochDuration: 0n,
+    leaveEpochDuration: opts.leaveEpochDuration ?? 0n,
     stats: {
       passedEpochs: 0,
       failedEpochs: failedConsecutive,
@@ -432,13 +433,19 @@ describe('SolanaARIOReadable.getLeavingGateways', () => {
 });
 
 describe('SolanaARIOReadable.getFinalizableGoneGateways', () => {
-  // Leave window timestamps are on-chain seconds; fix `now` to test the boundary.
-  const NOW = 1_000_000;
+  // On-chain seconds. finalize_gone window =
+  //   leaveTimestamp + GATEWAY_LEAVE_PERIOD (90d) + 7 * max(leaveEpochDuration, epoch_duration).
+  // The stubbed rpc has no epoch-settings account, so getEpochSettings() throws
+  // and the method falls back to currentEpochDuration = 0 (snapshot-only window).
+  const NOW = 1_700_000_000;
+  const LEAVE_PERIOD = 7_776_000; // 90 days
+  const DAY = 86_400;
 
-  it('includes a Leaving gateway whose leave window elapsed and has no delegations', async () => {
+  it('includes a Leaving gateway past the full 90d window with no delegations', async () => {
     const joined = makeGatewayBytes(PUBKEY_1, GatewayStatus.Joined, 0);
     const eligible = makeGatewayBytes(PUBKEY_2, GatewayStatus.Leaving, 0, {
-      leaveTimestamp: BigInt(NOW - 1), // window already elapsed
+      leaveTimestamp: BigInt(NOW - LEAVE_PERIOD - 100), // window fully elapsed
+      leaveEpochDuration: 0n,
       totalDelegatedStake: 0n,
     });
     const r = buildReadable(
@@ -454,20 +461,10 @@ describe('SolanaARIOReadable.getFinalizableGoneGateways', () => {
     assert.equal(out[0].operator, PUBKEY_2);
   });
 
-  it('excludes a Leaving gateway whose leave window has NOT elapsed (would revert LeaveWindowNotExpired)', async () => {
-    const notYet = makeGatewayBytes(PUBKEY_1, GatewayStatus.Leaving, 0, {
-      leaveTimestamp: BigInt(NOW + 1), // window ends in the future
-      totalDelegatedStake: 0n,
-    });
-    const r = buildReadable(
-      stubRpcReturning([{ pubkey: ADDR_A, bytes: notYet }]),
-    );
-    assert.deepEqual(await r.getFinalizableGoneGateways(NOW), []);
-  });
-
-  it('treats the boundary (now === leaveTimestamp) as eligible', async () => {
+  it('treats exactly leaveTimestamp + 90d (epochDuration 0) as eligible (boundary)', async () => {
     const atBoundary = makeGatewayBytes(PUBKEY_1, GatewayStatus.Leaving, 0, {
-      leaveTimestamp: BigInt(NOW),
+      leaveTimestamp: BigInt(NOW - LEAVE_PERIOD),
+      leaveEpochDuration: 0n,
       totalDelegatedStake: 0n,
     });
     const r = buildReadable(
@@ -476,13 +473,43 @@ describe('SolanaARIOReadable.getFinalizableGoneGateways', () => {
     assert.equal((await r.getFinalizableGoneGateways(NOW)).length, 1);
   });
 
+  it('excludes a recently-left gateway still inside the 90d window (the LeaveWindowNotExpired case)', async () => {
+    // Left 1000s ago — far short of the 90d cooldown. This is the production
+    // scenario the leaveTimestamp-only filter wrongly admitted.
+    const recent = makeGatewayBytes(PUBKEY_1, GatewayStatus.Leaving, 0, {
+      leaveTimestamp: BigInt(NOW - 1000),
+      leaveEpochDuration: BigInt(DAY),
+      totalDelegatedStake: 0n,
+    });
+    const r = buildReadable(
+      stubRpcReturning([{ pubkey: ADDR_A, bytes: recent }]),
+    );
+    assert.deepEqual(await r.getFinalizableGoneGateways(NOW), []);
+  });
+
+  it('accounts for the 7*epoch_duration term — past 90d but not past 90d + 7 epochs is NOT eligible', async () => {
+    // 100s past the 90d mark, but 7 * 1-day epochs (7 days) has not elapsed →
+    // finalize_gone would still revert, so it must be excluded. This is the
+    // case the original leaveTimestamp-only filter got wrong.
+    const within7Epochs = makeGatewayBytes(PUBKEY_1, GatewayStatus.Leaving, 0, {
+      leaveTimestamp: BigInt(NOW - LEAVE_PERIOD - 100),
+      leaveEpochDuration: BigInt(DAY), // 7 * 86400 = 7 days >> 100s remaining
+      totalDelegatedStake: 0n,
+    });
+    const r = buildReadable(
+      stubRpcReturning([{ pubkey: ADDR_A, bytes: within7Epochs }]),
+    );
+    assert.deepEqual(await r.getFinalizableGoneGateways(NOW), []);
+  });
+
   it('excludes a Leaving gateway that still holds delegated stake', async () => {
     const stillDelegated = makeGatewayBytes(
       PUBKEY_1,
       GatewayStatus.Leaving,
       0,
       {
-        leaveTimestamp: BigInt(NOW - 1),
+        leaveTimestamp: BigInt(NOW - LEAVE_PERIOD - 100), // window elapsed
+        leaveEpochDuration: 0n,
         totalDelegatedStake: 5_000n,
       },
     );
@@ -505,7 +532,7 @@ describe('SolanaARIOReadable.getFinalizableGoneGateways', () => {
 
   it('excludes Joined gateways regardless of timestamps', async () => {
     const joined = makeGatewayBytes(PUBKEY_1, GatewayStatus.Joined, 0, {
-      leaveTimestamp: BigInt(NOW - 1),
+      leaveTimestamp: BigInt(NOW - LEAVE_PERIOD - 100),
       totalDelegatedStake: 0n,
     });
     const r = buildReadable(

--- a/src/solana/prune-discovery.test.ts
+++ b/src/solana/prune-discovery.test.ts
@@ -295,7 +295,11 @@ function makeGatewayBytes(
   operator: Address,
   status: GatewayStatus,
   failedConsecutive: number,
-  opts: { allowDelegatedStaking?: boolean; totalDelegatedStake?: bigint } = {},
+  opts: {
+    allowDelegatedStaking?: boolean;
+    totalDelegatedStake?: bigint;
+    leaveTimestamp?: bigint | null;
+  } = {},
 ): Uint8Array {
   const enc = getGatewayEncoder();
   return enc.encode({
@@ -310,7 +314,7 @@ function makeGatewayBytes(
     totalDelegatedStake: opts.totalDelegatedStake ?? 0n,
     status,
     startTimestamp: 0n,
-    leaveTimestamp: null,
+    leaveTimestamp: opts.leaveTimestamp ?? null,
     leaveEpochDuration: 0n,
     stats: {
       passedEpochs: 0,
@@ -424,6 +428,90 @@ describe('SolanaARIOReadable.getLeavingGateways', () => {
     assert.equal(out.length, 1);
     assert.equal(out[0].pubkey, ADDR_B);
     assert.equal(out[0].operator, PUBKEY_2);
+  });
+});
+
+describe('SolanaARIOReadable.getFinalizableGoneGateways', () => {
+  // Leave window timestamps are on-chain seconds; fix `now` to test the boundary.
+  const NOW = 1_000_000;
+
+  it('includes a Leaving gateway whose leave window elapsed and has no delegations', async () => {
+    const joined = makeGatewayBytes(PUBKEY_1, GatewayStatus.Joined, 0);
+    const eligible = makeGatewayBytes(PUBKEY_2, GatewayStatus.Leaving, 0, {
+      leaveTimestamp: BigInt(NOW - 1), // window already elapsed
+      totalDelegatedStake: 0n,
+    });
+    const r = buildReadable(
+      stubRpcReturning([
+        { pubkey: ADDR_A, bytes: joined },
+        { pubkey: ADDR_B, bytes: eligible },
+      ]),
+    );
+
+    const out = await r.getFinalizableGoneGateways(NOW);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].pubkey, ADDR_B);
+    assert.equal(out[0].operator, PUBKEY_2);
+  });
+
+  it('excludes a Leaving gateway whose leave window has NOT elapsed (would revert LeaveWindowNotExpired)', async () => {
+    const notYet = makeGatewayBytes(PUBKEY_1, GatewayStatus.Leaving, 0, {
+      leaveTimestamp: BigInt(NOW + 1), // window ends in the future
+      totalDelegatedStake: 0n,
+    });
+    const r = buildReadable(
+      stubRpcReturning([{ pubkey: ADDR_A, bytes: notYet }]),
+    );
+    assert.deepEqual(await r.getFinalizableGoneGateways(NOW), []);
+  });
+
+  it('treats the boundary (now === leaveTimestamp) as eligible', async () => {
+    const atBoundary = makeGatewayBytes(PUBKEY_1, GatewayStatus.Leaving, 0, {
+      leaveTimestamp: BigInt(NOW),
+      totalDelegatedStake: 0n,
+    });
+    const r = buildReadable(
+      stubRpcReturning([{ pubkey: ADDR_A, bytes: atBoundary }]),
+    );
+    assert.equal((await r.getFinalizableGoneGateways(NOW)).length, 1);
+  });
+
+  it('excludes a Leaving gateway that still holds delegated stake', async () => {
+    const stillDelegated = makeGatewayBytes(
+      PUBKEY_1,
+      GatewayStatus.Leaving,
+      0,
+      {
+        leaveTimestamp: BigInt(NOW - 1),
+        totalDelegatedStake: 5_000n,
+      },
+    );
+    const r = buildReadable(
+      stubRpcReturning([{ pubkey: ADDR_A, bytes: stillDelegated }]),
+    );
+    assert.deepEqual(await r.getFinalizableGoneGateways(NOW), []);
+  });
+
+  it('excludes a Leaving gateway with no leaveTimestamp set', async () => {
+    const noWindow = makeGatewayBytes(PUBKEY_1, GatewayStatus.Leaving, 0, {
+      leaveTimestamp: null,
+      totalDelegatedStake: 0n,
+    });
+    const r = buildReadable(
+      stubRpcReturning([{ pubkey: ADDR_A, bytes: noWindow }]),
+    );
+    assert.deepEqual(await r.getFinalizableGoneGateways(NOW), []);
+  });
+
+  it('excludes Joined gateways regardless of timestamps', async () => {
+    const joined = makeGatewayBytes(PUBKEY_1, GatewayStatus.Joined, 0, {
+      leaveTimestamp: BigInt(NOW - 1),
+      totalDelegatedStake: 0n,
+    });
+    const r = buildReadable(
+      stubRpcReturning([{ pubkey: ADDR_A, bytes: joined }]),
+    );
+    assert.deepEqual(await r.getFinalizableGoneGateways(NOW), []);
   });
 });
 

--- a/src/solana/send.ts
+++ b/src/solana/send.ts
@@ -39,6 +39,7 @@ import {
   type Commitment,
   type Instruction,
   type TransactionSigner,
+  address,
   appendTransactionMessageInstructions,
   compileTransaction,
   compressTransactionMessageUsingAddressLookupTables,
@@ -54,6 +55,7 @@ import {
   signTransactionMessageWithSigners,
 } from '@solana/kit';
 
+import type { GasEstimate } from '../types/io.js';
 import type { SolanaRpc, SolanaRpcSubscriptions } from './types.js';
 
 /**
@@ -80,33 +82,137 @@ const MIN_COMPUTE_UNIT_LIMIT = 10_000;
 /** Solana's hard per-transaction compute-unit ceiling. */
 const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
 
+/** Flat base fee Solana charges per signature, in lamports. */
+export const BASE_FEE_LAMPORTS_PER_SIGNATURE = 5_000;
+/**
+ * Compute-unit limit {@link sendAndConfirm} pins when the caller doesn't pass
+ * one — and therefore the default a fee quote should assume. Every ArNS
+ * purchase write (buy/extend/upgrade/undername/primary-name) uses this
+ * default; only GAR/epoch operations pass a higher explicit limit.
+ */
+export const DEFAULT_COMPUTE_UNIT_LIMIT = 400_000;
+
+/** Clamped percentile over the non-zero per-slot fees of a fee response. */
+function clampedFeePercentile(
+  recent: ReadonlyArray<{ prioritizationFee: bigint | number }>,
+  percentile: number,
+): bigint {
+  const fees = recent
+    .map((r) => BigInt(r.prioritizationFee))
+    .filter((f) => f > 0n)
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  if (fees.length === 0) return MIN_PRIORITY_FEE_MICRO_LAMPORTS;
+  const value =
+    fees[Math.min(fees.length - 1, Math.floor(fees.length * percentile))];
+  if (value < MIN_PRIORITY_FEE_MICRO_LAMPORTS)
+    return MIN_PRIORITY_FEE_MICRO_LAMPORTS;
+  if (value > MAX_PRIORITY_FEE_MICRO_LAMPORTS)
+    return MAX_PRIORITY_FEE_MICRO_LAMPORTS;
+  return value;
+}
+
 /**
  * Estimate a compute-unit price from recent on-chain prioritization fees: the
  * 75th percentile of recent non-zero per-slot fees, clamped to
  * [{@link MIN_PRIORITY_FEE_MICRO_LAMPORTS}, {@link MAX_PRIORITY_FEE_MICRO_LAMPORTS}].
- * Falls back to the floor when there's no data or the query fails. Matching the
- * going rate both lands the tx and keeps Phantom from bumping (and thus
- * rewriting) the fee.
+ * Falls back to the floor when there's no data or the query fails.
+ *
+ * NOTE: the unscoped query reports each slot's MINIMUM landed fee, which on
+ * mainnet is almost always 0 (every block lands zero-fee txs) — so in
+ * practice this returns the floor. That's fine for keypair sends (they land),
+ * but it is NOT what browser wallets charge; see
+ * {@link estimateWalletPriorityFeeMicroLamports} for the wallet-rate quote.
  */
 export async function estimatePriorityFeeMicroLamports(
   rpc: SolanaRpc,
 ): Promise<bigint> {
   try {
     const recent = await rpc.getRecentPrioritizationFees().send();
-    const fees = recent
-      .map((r) => BigInt(r.prioritizationFee))
-      .filter((f) => f > 0n)
-      .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-    if (fees.length === 0) return MIN_PRIORITY_FEE_MICRO_LAMPORTS;
-    const p75 = fees[Math.min(fees.length - 1, Math.floor(fees.length * 0.75))];
-    if (p75 < MIN_PRIORITY_FEE_MICRO_LAMPORTS)
-      return MIN_PRIORITY_FEE_MICRO_LAMPORTS;
-    if (p75 > MAX_PRIORITY_FEE_MICRO_LAMPORTS)
-      return MAX_PRIORITY_FEE_MICRO_LAMPORTS;
-    return p75;
+    return clampedFeePercentile(recent, 0.75);
   } catch {
     return MIN_PRIORITY_FEE_MICRO_LAMPORTS;
   }
+}
+
+/**
+ * Busy, long-lived mainnet accounts (USDC + USDT mints) used as fee-market
+ * references. Scoping `getRecentPrioritizationFees` to a contended account
+ * surfaces what fee-paying transactions actually attach, instead of the
+ * all-zero per-slot minimums the unscoped query reports. Two references are
+ * pooled because either alone is a thin sample (~10–20 fee-paying slots per
+ * 150) whose tail percentiles swing several-fold minute to minute. On
+ * clusters where these accounts don't exist (devnet/localnet) the queries
+ * return no signal and the estimate falls back to the floor.
+ */
+const MARKET_FEE_REFERENCE_ACCOUNTS = [
+  address('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'), // USDC mint
+  address('Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB'), // USDT mint
+] as const;
+
+/**
+ * The compute-unit price Phantom's fee recommendation typically lands on
+ * for ordinary transactions under normal mainnet conditions (calibrated
+ * against its fee display). The sampled market percentile is shrunk toward
+ * this prior because the reference accounts yield only ~10–40 fee-paying
+ * slots per query — too thin for a stable tail percentile on its own.
+ */
+const WALLET_FEE_PRIOR_MICRO_LAMPORTS = 500_000n;
+
+/**
+ * Estimate the compute-unit price a browser wallet (Phantom et al.) will
+ * attach: the 85th percentile of the POOLED recent fees scoped to the
+ * {@link MARKET_FEE_REFERENCE_ACCOUNTS}, averaged with
+ * {@link WALLET_FEE_PRIOR_MICRO_LAMPORTS} to damp thin-sample swings, and
+ * clamped like the base estimator. Calibrated against Phantom's fee
+ * display: Phantom rewrites the priority fee to its own (deliberately
+ * generous, smoothed) recommendation no matter what the transaction pins —
+ * see the wallet-bridge notes in consumers.
+ *
+ * On clusters with no fee market at all (devnet/localnet — zero fee-paying
+ * slots on the references) this returns the plain floor, not the prior:
+ * wallets have nothing to price against there either.
+ *
+ * Used for gas QUOTES (so the UI shows what a wallet flow will actually
+ * pay) and pinned for message-modifying signers in {@link sendAndConfirm}
+ * (honoring wallets then pay the quoted rate; Phantom replaces it with its
+ * own near-identical rate, which the modifying-signer bridge captures).
+ * Keypair sends keep the cheap base estimate.
+ */
+export async function estimateWalletPriorityFeeMicroLamports(
+  rpc: SolanaRpc,
+): Promise<bigint> {
+  const samples = await Promise.all(
+    MARKET_FEE_REFERENCE_ACCOUNTS.map(async (account) => {
+      try {
+        return await rpc.getRecentPrioritizationFees([account]).send();
+      } catch {
+        return [];
+      }
+    }),
+  );
+  const pooled = samples.flat();
+  const hasSignal = pooled.some((r) => BigInt(r.prioritizationFee) > 0n);
+  if (!hasSignal) return MIN_PRIORITY_FEE_MICRO_LAMPORTS;
+  const sampled = clampedFeePercentile(pooled, 0.85);
+  const shrunk = (sampled + WALLET_FEE_PRIOR_MICRO_LAMPORTS) / 2n;
+  return shrunk > MAX_PRIORITY_FEE_MICRO_LAMPORTS
+    ? MAX_PRIORITY_FEE_MICRO_LAMPORTS
+    : shrunk;
+}
+
+/**
+ * The price a gas QUOTE should assume: the higher of the base estimate and
+ * the wallet-rate estimate — whichever path signs (keypair or wallet), the
+ * quote covers it. Both legs fall back internally, so this never throws.
+ */
+export async function estimateQuotePriorityFeeMicroLamports(
+  rpc: SolanaRpc,
+): Promise<bigint> {
+  const [base, wallet] = await Promise.all([
+    estimatePriorityFeeMicroLamports(rpc),
+    estimateWalletPriorityFeeMicroLamports(rpc),
+  ]);
+  return base > wallet ? base : wallet;
 }
 
 /**
@@ -154,6 +260,70 @@ export async function estimateComputeUnitLimit(
 }
 
 /**
+ * Quote the network cost ("gas") for an intent without building or sending
+ * anything: `BASE_FEE_LAMPORTS_PER_SIGNATURE × signatureCount` plus a
+ * per-transaction priority fee `ceil(computeUnitLimit × pricePerCU / 1e6)`,
+ * plus any caller-supplied `rentLamports` for accounts the flow creates.
+ * The compute-unit price comes from {@link estimatePriorityFeeMicroLamports}
+ * unless pinned by the caller.
+ *
+ * The fee side mirrors what {@link sendAndConfirm} will actually attach: the
+ * same default CU limit and the same auto price estimate. It's a conservative
+ * upper bound — the runtime charges the priority fee on the pinned LIMIT, and
+ * `sendAndConfirm` tightens that limit from a pre-send simulation for keypair
+ * signers, so the landed fee is usually lower. Never throws: the only RPC
+ * call is the priority-fee query, which falls back to its floor internally.
+ */
+export async function estimateGasFee(
+  rpc: SolanaRpc,
+  {
+    computeUnitLimit = DEFAULT_COMPUTE_UNIT_LIMIT,
+    signatureCount = 1,
+    transactionCount = 1,
+    rentLamports = 0,
+    rentReclaimedLamports = 0,
+    priorityFeeMicroLamports,
+  }: {
+    /** Compute-unit limit assumed for EACH transaction. */
+    computeUnitLimit?: number;
+    /** Total signatures across all transactions. */
+    signatureCount?: number;
+    /** Number of transactions the intent sends. */
+    transactionCount?: number;
+    /** Rent-exempt deposits for accounts the flow creates, in lamports. */
+    rentLamports?: number;
+    /** Rent refunded to the caller by accounts the flow closes, in lamports. */
+    rentReclaimedLamports?: number;
+    /** Pin a compute-unit price instead of estimating from recent fees. */
+    priorityFeeMicroLamports?: bigint | number;
+  } = {},
+): Promise<GasEstimate> {
+  const microLamports =
+    priorityFeeMicroLamports !== undefined
+      ? BigInt(priorityFeeMicroLamports)
+      : await estimateQuotePriorityFeeMicroLamports(rpc);
+  const baseFeeLamports = BASE_FEE_LAMPORTS_PER_SIGNATURE * signatureCount;
+  // Ceil-divide micro-lamports → lamports per transaction; the runtime
+  // rounds the prioritization fee up to whole lamports.
+  const priorityFeeLamports =
+    transactionCount *
+    Number((BigInt(computeUnitLimit) * microLamports + 999_999n) / 1_000_000n);
+  const feeLamports = baseFeeLamports + priorityFeeLamports;
+  return {
+    totalLamports: feeLamports + rentLamports,
+    feeLamports,
+    baseFeeLamports,
+    priorityFeeLamports,
+    rentLamports,
+    rentReclaimedLamports,
+    priorityFeeMicroLamports: Number(microLamports),
+    computeUnitLimit,
+    signatureCount,
+    transactionCount,
+  };
+}
+
+/**
  * Build, sign, send, and confirm a transaction in one call.
  *
  * The caller supplies the core instructions; a compute-unit-limit instruction
@@ -165,7 +335,7 @@ export async function sendAndConfirm({
   signer,
   instructions,
   commitment = 'confirmed',
-  computeUnitLimit = 400_000,
+  computeUnitLimit = DEFAULT_COMPUTE_UNIT_LIMIT,
   autoComputeUnitLimit = true,
   priorityFeeMicroLamports = 'auto',
   addressLookupTables,
@@ -212,9 +382,18 @@ export async function sendAndConfirm({
    */
   addressLookupTables?: Record<string, Address[]>;
 }): Promise<string> {
+  // 'auto' pricing is signer-aware: keypair signers pay the cheap base rate
+  // (their txs land fine and bot flows send many), while message-modifying
+  // wallets get the market rate the SDK's gas quotes assume. Wallets that
+  // honor pinned budgets (Solflare/Backpack) then pay exactly the quoted
+  // rate; Phantom rewrites the fee to its own near-identical market rate
+  // regardless (see the wallet-bridge notes), and the modifying-signer
+  // bridge captures that rewrite.
   const microLamports =
     priorityFeeMicroLamports === 'auto'
-      ? await estimatePriorityFeeMicroLamports(rpc)
+      ? isTransactionModifyingSigner(signer)
+        ? await estimateQuotePriorityFeeMicroLamports(rpc)
+        : await estimatePriorityFeeMicroLamports(rpc)
       : priorityFeeMicroLamports === false
         ? 0n
         : BigInt(priorityFeeMicroLamports);

--- a/src/solana/send.ts
+++ b/src/solana/send.ts
@@ -46,6 +46,7 @@ import {
   getAddressDecoder,
   getBase64EncodedWireTransaction,
   getSignatureFromTransaction,
+  isTransactionModifyingSigner,
   pipe,
   sendAndConfirmTransactionFactory,
   setTransactionMessageFeePayerSigner,
@@ -64,6 +65,20 @@ import type { SolanaRpc, SolanaRpcSubscriptions } from './types.js';
 const MIN_PRIORITY_FEE_MICRO_LAMPORTS = 10_000n;
 /** Cap so a spiky fee market can't blow up the fee unexpectedly. */
 const MAX_PRIORITY_FEE_MICRO_LAMPORTS = 2_000_000n;
+
+/**
+ * Multiplier applied to the simulated `unitsConsumed` to derive the pinned
+ * compute-unit limit, giving headroom for run-to-run variance (account state
+ * the simulation didn't see, slightly different inputs at land time).
+ */
+const COMPUTE_UNIT_LIMIT_BUFFER = 1.3;
+/**
+ * Floor for the auto-sized compute-unit limit. Keeps tiny instructions from
+ * being pinned so tight that benign variance trips a "exceeded CUs" failure.
+ */
+const MIN_COMPUTE_UNIT_LIMIT = 10_000;
+/** Solana's hard per-transaction compute-unit ceiling. */
+const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
 
 /**
  * Estimate a compute-unit price from recent on-chain prioritization fees: the
@@ -95,6 +110,50 @@ export async function estimatePriorityFeeMicroLamports(
 }
 
 /**
+ * Simulate `message` (sig-verify off) to learn its actual `unitsConsumed`, then
+ * return a tight compute-unit limit: `unitsConsumed * COMPUTE_UNIT_LIMIT_BUFFER`,
+ * clamped to [{@link MIN_COMPUTE_UNIT_LIMIT}, `fallback`].
+ *
+ * Why this matters: a wildly over-provisioned CU limit (e.g. the blanket
+ * `1_000_000` several writes pass) is exactly what message-modifying wallets
+ * like Phantom *rewrite* — they tighten the limit to lower the fee
+ * (fee = price × limit), sign their modified message, and the SDK's already-
+ * attached signatures no longer match the submitted bytes →
+ * "Transaction did not pass signature verification" even though simulation
+ * (sig-verify off) passes. Pinning a realistic limit leaves the wallet nothing
+ * to optimize, so the signed bytes are the submitted bytes.
+ *
+ * Best-effort: on any simulation error (including a program error — let the real
+ * send surface it) we fall back to `fallback` so behavior never regresses.
+ */
+export async function estimateComputeUnitLimit(
+  rpc: SolanaRpc,
+  message: unknown,
+  fallback: number,
+): Promise<number> {
+  try {
+    const compiled = compileTransaction(message as never);
+    const wire = getBase64EncodedWireTransaction(compiled as never);
+    const sim = await rpc
+      .simulateTransaction(wire, {
+        sigVerify: false,
+        replaceRecentBlockhash: true,
+        encoding: 'base64',
+      })
+      .send();
+    const consumed = sim.value.unitsConsumed;
+    if (sim.value.err != null || consumed == null) return fallback;
+    const sized = Math.ceil(Number(consumed) * COMPUTE_UNIT_LIMIT_BUFFER);
+    return Math.min(
+      Math.max(sized, MIN_COMPUTE_UNIT_LIMIT),
+      Math.min(fallback, MAX_COMPUTE_UNIT_LIMIT),
+    );
+  } catch {
+    return fallback;
+  }
+}
+
+/**
  * Build, sign, send, and confirm a transaction in one call.
  *
  * The caller supplies the core instructions; a compute-unit-limit instruction
@@ -107,6 +166,7 @@ export async function sendAndConfirm({
   instructions,
   commitment = 'confirmed',
   computeUnitLimit = 400_000,
+  autoComputeUnitLimit = true,
   priorityFeeMicroLamports = 'auto',
   addressLookupTables,
 }: {
@@ -115,7 +175,20 @@ export async function sendAndConfirm({
   signer: TransactionSigner;
   instructions: Instruction[];
   commitment?: Commitment;
+  /**
+   * Upper bound for the compute-unit limit. By default the limit is auto-sized
+   * from a pre-send simulation (see {@link estimateComputeUnitLimit}) and this
+   * value is only the ceiling/fallback. Pass `autoComputeUnitLimit: false` to
+   * pin exactly this value instead (e.g. localnet, or when simulation is
+   * unavailable).
+   */
   computeUnitLimit?: number;
+  /**
+   * When `true` (default), simulate before signing and pin a tight CU limit so
+   * message-modifying wallets (Phantom) don't rewrite the over-provisioned limit
+   * and invalidate signatures. When `false`, pin `computeUnitLimit` verbatim.
+   */
+  autoComputeUnitLimit?: boolean;
   /**
    * Compute-unit price (priority fee), in micro-lamports per CU.
    * - `'auto'` (default): estimate from recent on-chain fees (see
@@ -148,36 +221,65 @@ export async function sendAndConfirm({
 
   const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
-  const baseMessage = pipe(
-    createTransactionMessage({ version: 0 }),
-    (tx) => setTransactionMessageFeePayerSigner(signer, tx),
-    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-    (tx) =>
-      appendTransactionMessageInstructions(
-        [
-          getSetComputeUnitLimitInstruction({ units: computeUnitLimit }),
-          // Pin an explicit, NON-ZERO priority fee so wallets like Phantom
-          // don't rewrite the message to inject their own compute-budget
-          // instructions. Phantom treats a missing/zero fee as "unset" and
-          // overrides it on mainnet — that mutation invalidates the already-
-          // attached signatures (→ "Transaction did not pass signature
-          // verification" / preflight #-32002). A real, network-rate fee
-          // (see `microLamports` above) makes the wallet leave the message
-          // alone, so signatures over the original bytes still verify.
-          getSetComputeUnitPriceInstruction({ microLamports }),
-          ...instructions,
-        ],
-        tx,
-      ),
-  );
+  // Build the (optionally ALT-compressed) message for a given CU limit. We may
+  // build it twice: once with the ceiling limit to simulate, once with the
+  // tight limit we actually sign.
+  const buildMessage = (units: number) => {
+    const baseMessage = pipe(
+      createTransactionMessage({ version: 0 }),
+      (tx) => setTransactionMessageFeePayerSigner(signer, tx),
+      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+      (tx) =>
+        appendTransactionMessageInstructions(
+          [
+            getSetComputeUnitLimitInstruction({ units }),
+            // Pin an explicit, NON-ZERO priority fee so wallets like Phantom
+            // don't rewrite the message to inject their own compute-budget
+            // instructions. Phantom treats a missing/zero fee as "unset" and
+            // overrides it on mainnet — that mutation invalidates the already-
+            // attached signatures (→ "Transaction did not pass signature
+            // verification" / preflight #-32002). A real, network-rate fee
+            // (see `microLamports` above) makes the wallet leave the message
+            // alone, so signatures over the original bytes still verify.
+            getSetComputeUnitPriceInstruction({ microLamports }),
+            ...instructions,
+          ],
+          tx,
+        ),
+    );
 
-  // Compress against any supplied lookup tables (v0). No-op when none given.
-  const message = addressLookupTables
-    ? compressTransactionMessageUsingAddressLookupTables(
-        baseMessage,
-        addressLookupTables as never,
+    // Compress against any supplied lookup tables (v0). No-op when none given.
+    return addressLookupTables
+      ? compressTransactionMessageUsingAddressLookupTables(
+          baseMessage,
+          addressLookupTables as never,
+        )
+      : baseMessage;
+  };
+
+  // Right-size the CU limit from a pre-send simulation — but ONLY for
+  // non-modifying (keypair) signers, where it saves fees and nothing will
+  // rewrite the message.
+  //
+  // Message-modifying wallets (Phantom etc.) re-optimize the compute budget
+  // themselves AND attach simulation-based guards (e.g. Lighthouse) keyed to
+  // the budget/state they expect. Handing them a tightly-sized limit interferes
+  // with that and trips the guard at execution time (observed: Lighthouse
+  // `AssertionFailed` 0x1900 on `joinNetwork`, even though the tx itself
+  // simulates clean). The modifying-signer bridge already captures whatever the
+  // wallet rewrites, so sizing the limit for them is both unnecessary and
+  // harmful — leave the generous `computeUnitLimit` and let the wallet tune it.
+  const shouldAutoSize =
+    autoComputeUnitLimit && !isTransactionModifyingSigner(signer);
+  const units = shouldAutoSize
+    ? await estimateComputeUnitLimit(
+        rpc,
+        buildMessage(computeUnitLimit),
+        computeUnitLimit,
       )
-    : baseMessage;
+    : computeUnitLimit;
+
+  const message = buildMessage(units);
 
   const signedTx = await signTransactionMessageWithSigners(message);
   const sendAndConfirmFactory = sendAndConfirmTransactionFactory({

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -35,11 +35,15 @@ import {
   type Commitment,
   type Instruction,
   type KeyPairSigner,
+  type TransactionModifyingSigner,
   addSignersToTransactionMessage,
   appendTransactionMessageInstructions,
+  compileTransaction,
   createTransactionMessage,
   generateKeyPairSigner,
   getSignatureFromTransaction,
+  isTransactionModifyingSigner,
+  partiallySignTransaction,
   pipe,
   sendAndConfirmTransactionFactory,
   setTransactionMessageFeePayerSigner,
@@ -59,6 +63,7 @@ import {
 import { SolanaANTRegistryWriteable } from './ant-registry-writeable.js';
 import { ARIO_ANT_PROGRAM_ID } from './constants.js';
 import { getAntRecordPDA } from './pda.js';
+import { estimatePriorityFeeMicroLamports } from './send.js';
 import type {
   SolanaRpc,
   SolanaRpcSubscriptions,
@@ -347,7 +352,10 @@ export async function spawnSolanaANT(
   // them up from the account metadata roles: accounts marked as SIGNER roles
   // must have a matching `TransactionSigner` attached. We do that by placing
   // the mint signer on the message alongside the fee payer signer.
-  const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+  const [{ value: latestBlockhash }, microLamports] = await Promise.all([
+    rpc.getLatestBlockhash().send(),
+    estimatePriorityFeeMicroLamports(rpc),
+  ]);
 
   const message = pipe(
     createTransactionMessage({ version: 0 }),
@@ -357,11 +365,11 @@ export async function spawnSolanaANT(
       appendTransactionMessageInstructions(
         [
           getSetComputeUnitLimitInstruction({ units: computeUnitLimit }),
-          // Pin the priority fee (at 0) so wallets like Phantom don't
-          // silently append their own compute-budget instructions and
-          // invalidate the paired mint keypair signer's signature. See
-          // `sendAndConfirm` in `./send.js` for the full rationale.
-          getSetComputeUnitPriceInstruction({ microLamports: 0n }),
+          // Pin a non-zero priority fee (see `estimatePriorityFeeMicroLamports`).
+          // A real fee both lands the tx and, per Phantom's docs, stops the
+          // wallet from injecting its own fee. The paired mint-keypair signing
+          // is handled below.
+          getSetComputeUnitPriceInstruction({ microLamports }),
           createIx,
           initIx,
           ...aclIxs,
@@ -376,7 +384,30 @@ export async function spawnSolanaANT(
   // `signTransactionMessageWithSigners` then looks up to produce signatures.
   const withMintSigner = addSignersToTransactionMessage([mintSigner], message);
 
-  const signedTx = await signTransactionMessageWithSigners(withMintSigner);
+  // Multi-signer spawn (fee-payer wallet + fresh mint keypair). Browser wallets
+  // like Phantom REWRITE transactions that carry no signature yet (injecting
+  // priority-fee / Lighthouse-guard instructions) — which invalidates the mint
+  // keypair's signature → "address is not a signer" (#5663015). Per Phantom's
+  // docs it leaves a transaction alone once it already has a signature. So when
+  // the wallet is a modifying signer, sign with the mint keypair FIRST, then let
+  // the wallet sign: it sees the existing mint signature and won't rewrite,
+  // keeping both signatures valid. kit's own pipeline can't express this order
+  // (it always runs modifying signers before partial ones), so we orchestrate
+  // it manually here. Non-modifying signers (keypairs in node/tests) carry no
+  // rewrite risk and use kit's normal pipeline.
+  let signedTx;
+  if (isTransactionModifyingSigner(signer)) {
+    const compiled = compileTransaction(withMintSigner);
+    const mintPreSigned = await partiallySignTransaction(
+      [mintSigner.keyPair],
+      compiled,
+    );
+    [signedTx] = await (
+      signer as unknown as TransactionModifyingSigner
+    ).modifyAndSignTransactions([mintPreSigned]);
+  } else {
+    signedTx = await signTransactionMessageWithSigners(withMintSigner);
+  }
   const sendAndConfirmFactory = sendAndConfirmTransactionFactory({
     rpc,
     rpcSubscriptions,

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -66,6 +66,7 @@ import { getAntRecordPDA } from './pda.js';
 import {
   estimateComputeUnitLimit,
   estimatePriorityFeeMicroLamports,
+  estimateQuotePriorityFeeMicroLamports,
 } from './send.js';
 import type {
   SolanaRpc,
@@ -355,9 +356,13 @@ export async function spawnSolanaANT(
   // them up from the account metadata roles: accounts marked as SIGNER roles
   // must have a matching `TransactionSigner` attached. We do that by placing
   // the mint signer on the message alongside the fee payer signer.
+  // Signer-aware fee (see sendAndConfirm): wallet signers get the market
+  // rate their own estimator would pick; keypairs keep the cheap base rate.
   const [{ value: latestBlockhash }, microLamports] = await Promise.all([
     rpc.getLatestBlockhash().send(),
-    estimatePriorityFeeMicroLamports(rpc),
+    isTransactionModifyingSigner(signer)
+      ? estimateQuotePriorityFeeMicroLamports(rpc)
+      : estimatePriorityFeeMicroLamports(rpc),
   ]);
 
   const buildMessage = (units: number) =>

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -63,7 +63,10 @@ import {
 import { SolanaANTRegistryWriteable } from './ant-registry-writeable.js';
 import { ARIO_ANT_PROGRAM_ID } from './constants.js';
 import { getAntRecordPDA } from './pda.js';
-import { estimatePriorityFeeMicroLamports } from './send.js';
+import {
+  estimateComputeUnitLimit,
+  estimatePriorityFeeMicroLamports,
+} from './send.js';
 import type {
   SolanaRpc,
   SolanaRpcSubscriptions,
@@ -357,26 +360,43 @@ export async function spawnSolanaANT(
     estimatePriorityFeeMicroLamports(rpc),
   ]);
 
-  const message = pipe(
-    createTransactionMessage({ version: 0 }),
-    (tx) => setTransactionMessageFeePayerSigner(signer, tx),
-    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-    (tx) =>
-      appendTransactionMessageInstructions(
-        [
-          getSetComputeUnitLimitInstruction({ units: computeUnitLimit }),
-          // Pin a non-zero priority fee (see `estimatePriorityFeeMicroLamports`).
-          // A real fee both lands the tx and, per Phantom's docs, stops the
-          // wallet from injecting its own fee. The paired mint-keypair signing
-          // is handled below.
-          getSetComputeUnitPriceInstruction({ microLamports }),
-          createIx,
-          initIx,
-          ...aclIxs,
-        ],
-        tx,
-      ),
-  );
+  const buildMessage = (units: number) =>
+    pipe(
+      createTransactionMessage({ version: 0 }),
+      (tx) => setTransactionMessageFeePayerSigner(signer, tx),
+      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+      (tx) =>
+        appendTransactionMessageInstructions(
+          [
+            getSetComputeUnitLimitInstruction({ units }),
+            // Pin a non-zero priority fee (see `estimatePriorityFeeMicroLamports`).
+            // A real fee both lands the tx and, per Phantom's docs, stops the
+            // wallet from injecting its own fee. The paired mint-keypair signing
+            // is handled below.
+            getSetComputeUnitPriceInstruction({ microLamports }),
+            createIx,
+            initIx,
+            ...aclIxs,
+          ],
+          tx,
+        ),
+    );
+
+  // Right-size the CU limit from a pre-send simulation — but ONLY for
+  // non-modifying (keypair) signers. Message-modifying wallets (Phantom etc.)
+  // re-optimize the compute budget themselves and attach simulation-based
+  // guards (Lighthouse) keyed to the budget they expect; a tightly-sized limit
+  // interferes with that and trips the guard. The wallet rewrite is captured by
+  // the modifying-signer flow below, so `computeUnitLimit` (the ceiling) is left
+  // generous for them.
+  const units = isTransactionModifyingSigner(signer)
+    ? computeUnitLimit
+    : await estimateComputeUnitLimit(
+        rpc,
+        buildMessage(computeUnitLimit),
+        computeUnitLimit,
+      );
+  const message = buildMessage(units);
 
   // Attach the mint signer so kit can satisfy the WRITABLE_SIGNER role on the
   // mint account. `addSignersToTransactionMessage` walks the message's account

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -546,6 +546,60 @@ export type CostDiscount = {
   multiplier: number;
 };
 
+/**
+ * Estimated network ("gas") cost for executing an intent on the underlying
+ * chain — separate from `tokenCost`, which is the protocol price in mARIO.
+ * Currently populated only by the Solana implementations, where amounts are
+ * denominated in lamports (1 SOL = 1e9 lamports).
+ *
+ * `totalLamports` is what the wallet must hold in SOL:
+ * `feeLamports` (transaction fees across every transaction the intent
+ * sends) plus `rentLamports` (rent-exempt deposits for accounts the flow
+ * creates — for Buy-Name that includes the ANT spawn's MPL Core asset,
+ * config/controllers/root-record PDAs, first-time ACL bootstrap accounts,
+ * and the ArNS record itself; rent dwarfs the fees by ~3 orders of
+ * magnitude).
+ *
+ * The fee side is conservative: the priority fee is charged on the
+ * compute-unit LIMIT each transaction pins, and the write path auto-tightens
+ * that limit from a pre-send simulation, so the fee actually paid is usually
+ * lower.
+ */
+export type GasEstimate = {
+  /** Grand total in lamports the wallet needs: `feeLamports + rentLamports`. */
+  totalLamports: number;
+  /** Transaction fees across all transactions (base + priority). */
+  feeLamports: number;
+  /** Flat per-signature fee: 5000 lamports × `signatureCount`. */
+  baseFeeLamports: number;
+  /**
+   * Prioritization fee: `transactionCount` × ceil(`computeUnitLimit` × price
+   * ÷ 1e6) lamports.
+   */
+  priorityFeeLamports: number;
+  /**
+   * Rent-exempt deposits (lamports) for accounts the intent creates. Zero
+   * for intents that only mutate existing accounts (Extend-Lease,
+   * Upgrade-Name, Increase-Undername-Limit).
+   */
+  rentLamports: number;
+  /**
+   * Rent (lamports) returned to the caller by accounts the action CLOSES —
+   * e.g. removing an undername record refunds that record's deposit. Not
+   * subtracted from `totalLamports`, which stays the upfront requirement;
+   * the net cost of the action is `totalLamports − rentReclaimedLamports`.
+   */
+  rentReclaimedLamports: number;
+  /** Compute-unit price used for the quote, in micro-lamports per CU. */
+  priorityFeeMicroLamports: number;
+  /** Compute-unit limit the quote assumes EACH transaction will pin. */
+  computeUnitLimit: number;
+  /** Total signatures across all transactions. */
+  signatureCount: number;
+  /** Number of transactions the intent sends (Buy-Name: spawn ANT + buy). */
+  transactionCount: number;
+};
+
 export type CostDetailsResult = {
   tokenCost: number;
   discounts: CostDiscount[];
@@ -554,6 +608,11 @@ export type CostDetailsResult = {
   };
   fundingPlan?: FundingPlan;
   wincQty?: string;
+  /**
+   * Network-fee quote for executing the action on chain. Solana-only;
+   * `undefined` on backends without per-transaction gas (e.g. AO).
+   */
+  gasEstimate?: GasEstimate;
 };
 
 export type GetVaultParams = {

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.0.2-alpha.3';
+export const version = '4.0.2-alpha.4';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.0.2-alpha.9';
+export const version = '4.0.2-alpha.10';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.0.2-alpha.5';
+export const version = '4.0.2-alpha.6';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.0.2-alpha.2';
+export const version = '4.0.2-alpha.3';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.0.1';
+export const version = '4.0.2-alpha.1';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.0.2-alpha.1';
+export const version = '4.0.2-alpha.2';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.0.2-alpha.4';
+export const version = '4.0.2-alpha.5';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.0.2-alpha.6';
+export const version = '4.0.2-alpha.7';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.0.2-alpha.7';
+export const version = '4.0.2-alpha.8';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.0.2';
+export const version = '4.0.3-alpha.1';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.0.2-alpha.8';
+export const version = '4.0.2-alpha.9';

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,10 @@
   resolved "https://registry.yarnpkg.com/@actions/io/-/io-3.0.2.tgz#6f89b27a159d109836d983efa283997c23b92284"
   integrity sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==
 
-"@ar.io/solana-contracts@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.0.0.tgz#56ec1354542991899c5d641a8221ee2b33b8b99d"
-  integrity sha512-/rmxIyViK9USkedcn4zrHWkg+tGBE160PSbJ2xwEcugtXDSOf5Cc0E6R8YoG7HT5oKkU0QY1QEeSeVvcYgMYBQ==
+"@ar.io/solana-contracts@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@ar.io/solana-contracts/-/solana-contracts-1.0.1.tgz#1a16958d54540222b77def81d5d39e7402b8b69c"
+  integrity sha512-zD7OepkzzWb1SIHRDxSo3y+dzRh9gu+43eI2DBJLtQ+7EkT3Py8v9kHQ40UcRC8CReHHTO74RDty6Hwx5JYVGA==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
Promote the `alpha` channel to a stable `main` release. On merge, the push to `main` runs semantic-release, which will cut the next stable version (`4.0.3` from the `fix:` commits) and publish to npm.

### What this stabilizes (alpha not yet on main)
- `fix(solana)`: finalize_gone eligibility uses the full leave window + epoch duration in seconds (the cranker correctness fix the observer needs)
- `fix(solana)`: base64 encoding for memcmp filters in `getProgramAccounts`
- `fix(solana)`: source demand-factor settings from program constants; price returned-name premium against the cluster clock
- `fix(gas)`: gas-estimation utils + logic
- `fix(cli)`: normalize argv path separators for Windows

### Why now
r81 of ar-io-node wants the latest observer, which depends on these SDK fixes. Stabilizing here lets the observer pin a release `@ar.io/sdk` instead of an alpha, then ar-io-node pins that observer.

Opening to verify CI before merge; merge triggers the npm publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive gas estimation for Solana transactions, including transaction fees, priority fees, and rent-exempt deposits.
  * Solana gas estimates now visible in `getCostDetails` results with detailed cost breakdowns.

* **Bug Fixes**
  * Fixed Windows CLI path separator handling for proper binary detection.
  * Corrected ArNS pricing premium flooring calculations.
  * Fixed primary names funding plan cost estimation.
  * Improved chunk delegates batching.
  * Fixed multiple Solana operation issues including finalization and filtering logic.

* **Documentation**
  * Updated README with gas estimate field documentation for Solana results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->