### PR TITLE
feat(solana): atomically spawn an ANT during buyRecord when no processId

### DIFF
--- a/src/solana/io-writeable.localnet.test.ts
+++ b/src/solana/io-writeable.localnet.test.ts
@@ -41,9 +41,11 @@ import {
 
 import { ANT } from '../common/ant.js';
 import { ARIO } from '../common/io.js';
+import { SolanaANTRegistryReadable } from './ant-registry-readable.js';
 import { getAssociatedTokenAddressKit } from './ata.js';
 import { deserializeWithdrawal } from './deserialize.js';
 import { SolanaARIOWriteable } from './io-writeable.js';
+import { fetchMplCoreOwner } from './mpl-core.js';
 import {
   getArioConfigPDA,
   getPrimaryNamePDA,
@@ -339,6 +341,62 @@ describe(
         stakeBefore - stakeAfter,
         BigInt(record.purchasePrice),
         'operator_stake must decrease by exactly the purchase price',
+      );
+    });
+
+    it('buyRecord without processId spawns a fresh ANT and assigns the name in one tx', async () => {
+      // Hermetic fresh buyer: spawn-and-buy mints a new asset (rent) + pays the
+      // ArNS price, so fund SOL + ARIO up front.
+      const buyer = await freshSigner(scratch, 'spawn-buy');
+      await airdrop(buyer.keypairPath, 5);
+      mintArio(buyer.signer.address, 100_000_000_000n); // 100k ARIO
+
+      const buyerArio = buildArio(buyer.signer, RPC_URL!, WS_URL!);
+      const name = 'spawnbuy' + Date.now().toString(36).slice(-6);
+
+      // No `processId` → the SDK spawns an ANT and assigns the name atomically
+      // in a single [CreateV1, initialize, buy_name] transaction.
+      const result = await buyerArio.buyRecord({
+        name,
+        type: 'lease',
+        years: 1,
+      });
+      assert.ok(result.id, 'spawn-and-buy buyRecord must return a tx id');
+      const spawnedProcessId = result.result?.processId as string | undefined;
+      assert.ok(
+        spawnedProcessId,
+        'buyRecord must surface the spawned ANT processId',
+      );
+
+      // The record points at the freshly-minted ANT — NOT the "no ANT" sentinel.
+      const record = await buyerArio.getArNSRecord({ name });
+      assert.equal(record.processId, spawnedProcessId);
+      assert.notEqual(record.processId, '11111111111111111111111111111111');
+      assert.equal(record.type, 'lease');
+      assert.ok(record.purchasePrice > 0, 'purchasePrice must be > 0');
+
+      // The spawned asset is a real MPL Core NFT owned by the buyer.
+      const rpc = createSolanaRpc(RPC_URL!);
+      const owner = await fetchMplCoreOwner(rpc, address(spawnedProcessId!), {
+        commitment: 'confirmed',
+      });
+      assert.equal(owner?.toLowerCase(), buyer.signer.address.toLowerCase());
+
+      // The deferred follow-up tx bootstrapped the buyer's ACL (owner + controller).
+      const registry = new SolanaANTRegistryReadable({
+        rpc,
+        antProgramId: address(ANT_ID!),
+      });
+      const acl = await registry.accessControlList({
+        address: buyer.signer.address as string,
+      });
+      assert.ok(
+        acl.Owned.includes(spawnedProcessId!),
+        'spawned ANT must appear in the owner ACL after the follow-up tx',
+      );
+      assert.ok(
+        acl.Controlled.includes(spawnedProcessId!),
+        'spawned ANT must appear in the controller ACL after the follow-up tx',
       );
     });
 

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -38,6 +38,7 @@ import {
   AccountRole,
   type Address,
   type Instruction,
+  type KeyPairSigner,
   address,
   appendTransactionMessageInstructions,
   compileTransaction,
@@ -202,6 +203,7 @@ import {
   getUpdateObserverAddressInstructionAsync,
 } from '@ar.io/solana-contracts/gar';
 import { getTransferCheckedInstruction } from '@solana-program/token';
+import { SolanaANTRegistryWriteable } from './ant-registry-writeable.js';
 import { ARIO_ANT_PROGRAM_ID, TOKEN_DECIMALS } from './constants.js';
 import { SolanaARIOReadable } from './io-readable.js';
 import {
@@ -240,6 +242,7 @@ import {
   sendAndConfirm,
   sendWithEphemeralLookupTable,
 } from './send.js';
+import { buildSpawnAntInstructions } from './spawn-ant.js';
 import type {
   SolanaRpcSubscriptions,
   SolanaSigner,
@@ -452,6 +455,14 @@ export function encodeReportTxId(reportTxId: string | undefined): Buffer {
  * `compound-crank.test.ts` asserts this invariant against the live constant.
  */
 export const MAX_COMPOUND_BATCH = 6;
+/**
+ * CU ceiling for the atomic spawn-and-buy tx (`[CreateV1, initialize,
+ * buy_name]`). buy_name CPIs into MPL Core `UpdatePluginV1` on top of the MPL
+ * Core mint + ario-ant initialize, so it needs more headroom than a plain
+ * buy (`DEFAULT_COMPUTE_UNIT_LIMIT`). Keypair signers auto-size below this from
+ * a pre-send simulation; message-modifying wallets keep this generous ceiling.
+ */
+const SPAWN_AND_BUY_COMPUTE_UNIT_LIMIT = 800_000;
 /** Observation PDAs closed per tx before close_epoch (each ix carries Epoch +
  *  Observation + payer + system accounts — keep well under the tx account cap). */
 const MAX_CLOSE_OBSERVATION_BATCH = 8;
@@ -601,6 +612,7 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
   protected async sendTransaction(
     instructions: Instruction[],
     computeUnitLimit = DEFAULT_COMPUTE_UNIT_LIMIT,
+    extraSigners: KeyPairSigner[] = [],
   ): Promise<string> {
     return sendAndConfirm({
       rpc: this.rpc,
@@ -609,6 +621,7 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       instructions,
       commitment: this.commitment,
       computeUnitLimit,
+      extraSigners,
     });
   }
 
@@ -1471,9 +1484,31 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       arnsConfig.mint,
       this.signer.address,
     );
-    const antPubkey = address(
-      params.processId ?? ('11111111111111111111111111111111' as Address),
-    );
+
+    // When no ANT (`processId`) is supplied, atomically spawn a fresh ANT and
+    // assign the name to it in the SAME transaction. `buy_name` CPIs into the
+    // new asset's Attributes plugin to write the ArNS traits — instructions
+    // execute in order, so the asset (minted by the prepended `CreateV1`)
+    // exists by the time `buy_name` runs. The owner's ACL registry bootstrap +
+    // trait sync are deferred to a follow-up tx to keep this one under the
+    // 1232-byte transaction-size limit (neither needs to be atomic with the
+    // purchase). See `_bootstrapSpawnedAntAcl`.
+    let spawnIxs: Instruction[] = [];
+    let mintSigner: KeyPairSigner | undefined;
+    let antPubkey: Address;
+    if (params.processId === undefined) {
+      const spawn = await buildSpawnAntInstructions({
+        signer: this.signer,
+        state: { name: params.name },
+        antProgramId: this.antProgram,
+      });
+      spawnIxs = spawn.instructions;
+      mintSigner = spawn.mintSigner;
+      antPubkey = spawn.mint;
+    } else {
+      antPubkey = address(params.processId);
+    }
+
     const [arnsRecord] = await getArnsRecordPDA(params.name, this.arnsProgram);
     const [reservedNameCheck] = await getReservedNamePDA(
       params.name,
@@ -1605,6 +1640,25 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       );
     }
 
+    // Spawn-and-buy: prepend `[CreateV1, initialize]` and attach the mint
+    // signer. We DON'T bundle `sync_attributes` here — the asset doesn't exist
+    // on-chain at SDK build time (it's minted in THIS tx), so the owner check
+    // in `_buildSyncAttributesIxIfOwner` would 404. The ACL bootstrap + trait
+    // sync run in a separate follow-up tx (`buy_name` already populated the
+    // asset's traits via CPI, so the deferred sync just mirrors them into the
+    // ANT's on-chain record).
+    if (mintSigner !== undefined) {
+      const sig = await this.sendTransaction(
+        [...spawnIxs, ix],
+        SPAWN_AND_BUY_COMPUTE_UNIT_LIMIT,
+        [mintSigner],
+      );
+      await this._bootstrapSpawnedAntAcl(antPubkey, params.name);
+      // Surface the freshly-minted ANT's id so callers don't have to re-fetch
+      // the record to discover which asset the name was assigned to.
+      return { id: sig, result: { processId: antPubkey as string } };
+    }
+
     // Sprint 4 / ADR-016: bundle `ant.sync_attributes` IFF the buyer
     // owns the ANT (preserves BD-096 — non-holder buys defer the trait
     // sync to a later `syncAttributes()` call by the actual owner).
@@ -1617,6 +1671,50 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     );
     const sig = await this.sendTransaction(syncIx ? [ix, syncIx] : [ix]);
     return { id: sig };
+  }
+
+  /**
+   * Post-spawn housekeeping for the atomic spawn-and-buy path: bootstrap the
+   * new owner's paginated ACL registry entries (so "ANTs I own / control"
+   * lookups resolve) and sync the ANT's on-chain record from the asset's
+   * Attributes plugin (which `buy_name` populated via CPI). Sent as a SEPARATE
+   * transaction because bundling it with `[create, initialize, buy_name]`
+   * would overflow the 1232-byte transaction-size limit — and neither step
+   * needs to be atomic with the purchase.
+   *
+   * Best-effort: the name purchase + ANT mint already confirmed in the prior
+   * tx, so a failure here is logged rather than thrown. The owner can reconcile
+   * later via the sync-ACL API and `syncAttributes()`.
+   */
+  private async _bootstrapSpawnedAntAcl(
+    asset: Address,
+    name: string,
+  ): Promise<void> {
+    try {
+      const registry = new SolanaANTRegistryWriteable({
+        rpc: this.rpc,
+        signer: this.signer,
+        commitment: this.commitment,
+        antProgramId: this.antProgram,
+        logger: this.logger,
+      });
+      const aclIxs = await registry.bootstrapOwnerOnSpawn({
+        owner: this.signer.address,
+        asset,
+      });
+      const syncIx = await this._buildSyncAttributesIxIfOwner(name, asset);
+      const ixs = syncIx ? [...aclIxs, syncIx] : aclIxs;
+      if (ixs.length > 0) {
+        await this.sendTransaction(ixs);
+      }
+    } catch (err) {
+      this.logger.warn(
+        `[buyRecord] spawned ANT ${asset} for "${name}" but post-spawn ACL ` +
+          `bootstrap / attribute sync failed; reconcile later via the sync-ACL ` +
+          `API and syncAttributes(). Purchase + mint already confirmed.`,
+        err,
+      );
+    }
   }
 
   /**

--- a/src/solana/send.ts
+++ b/src/solana/send.ts
@@ -38,7 +38,10 @@ import {
   type Address,
   type Commitment,
   type Instruction,
+  type KeyPairSigner,
+  type TransactionModifyingSigner,
   type TransactionSigner,
+  addSignersToTransactionMessage,
   address,
   appendTransactionMessageInstructions,
   compileTransaction,
@@ -48,6 +51,7 @@ import {
   getBase64EncodedWireTransaction,
   getSignatureFromTransaction,
   isTransactionModifyingSigner,
+  partiallySignTransaction,
   pipe,
   sendAndConfirmTransactionFactory,
   setTransactionMessageFeePayerSigner,
@@ -339,6 +343,7 @@ export async function sendAndConfirm({
   autoComputeUnitLimit = true,
   priorityFeeMicroLamports = 'auto',
   addressLookupTables,
+  extraSigners = [],
 }: {
   rpc: SolanaRpc;
   rpcSubscriptions: SolanaRpcSubscriptions;
@@ -381,6 +386,16 @@ export async function sendAndConfirm({
    * on-chain and active. See {@link sendWithEphemeralLookupTable}.
    */
   addressLookupTables?: Record<string, Address[]>;
+  /**
+   * Extra keypair signers (beyond the fee-payer `signer`) whose
+   * WRITABLE/READONLY_SIGNER roles the message must satisfy — e.g. a freshly
+   * generated ANT mint when bundling a spawn into the transaction. They are
+   * attached via `addSignersToTransactionMessage`, and for message-modifying
+   * wallets they are PRE-SIGNED before the wallet signs so the wallet doesn't
+   * rewrite the message and invalidate their signatures (see the ordering note
+   * below, mirrored from `spawnSolanaANT`).
+   */
+  extraSigners?: KeyPairSigner[];
 }): Promise<string> {
   // 'auto' pricing is signer-aware: keypair signers pay the cheap base rate
   // (their txs land fine and bot flows send many), while message-modifying
@@ -460,7 +475,36 @@ export async function sendAndConfirm({
 
   const message = buildMessage(units);
 
-  const signedTx = await signTransactionMessageWithSigners(message);
+  // Attach any extra keypair signers (e.g. a freshly generated ANT mint) so kit
+  // can satisfy their SIGNER roles. `addSignersToTransactionMessage` walks the
+  // message's account metas and registers each matching signer by address.
+  const messageWithSigners =
+    extraSigners.length > 0
+      ? addSignersToTransactionMessage(extraSigners, message)
+      : message;
+
+  // Signing order matters when both an extra keypair AND a message-modifying
+  // wallet (Phantom) are involved: the wallet REWRITES an unsigned tx (injecting
+  // priority-fee / Lighthouse-guard ixs), which invalidates any keypair
+  // signature added after → "address is not a signer". Per Phantom's docs it
+  // leaves a tx alone once it already carries a signature, so we pre-sign with
+  // the extra keypairs FIRST, then hand the partially-signed tx to the wallet.
+  // kit's own pipeline can't express this order (it always runs modifying
+  // signers before partial ones), so we orchestrate it manually here. Keypair
+  // fee-payers (node/tests) carry no rewrite risk and use kit's normal pipeline.
+  let signedTx;
+  if (extraSigners.length > 0 && isTransactionModifyingSigner(signer)) {
+    const compiled = compileTransaction(messageWithSigners);
+    const preSigned = await partiallySignTransaction(
+      extraSigners.map((s) => s.keyPair),
+      compiled,
+    );
+    [signedTx] = await (
+      signer as unknown as TransactionModifyingSigner
+    ).modifyAndSignTransactions([preSigned]);
+  } else {
+    signedTx = await signTransactionMessageWithSigners(messageWithSigners);
+  }
   const sendAndConfirmFactory = sendAndConfirmTransactionFactory({
     rpc,
     rpcSubscriptions,

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -258,29 +258,44 @@ async function buildInitializeAntIx({
   );
 }
 
+export type SpawnAntInstructions = {
+  /**
+   * Ordered core spawn instructions: `[CreateV1, ario_ant::initialize]`.
+   * Excludes compute-budget and ACL-bootstrap ixs — callers that want a
+   * fully-bootstrapped, ready-to-send spawn should use {@link spawnSolanaANT};
+   * this builder is for bundling the mint into a larger compound transaction
+   * (e.g. atomic spawn + ArNS `buy_name`).
+   */
+  instructions: Instruction[];
+  /**
+   * Fresh (or caller-supplied) mint keypair signer. MUST be attached to the
+   * transaction so kit can satisfy the asset's WRITABLE_SIGNER role, and — for
+   * message-modifying wallets — pre-signed BEFORE the wallet signs (see the
+   * ordering note in {@link spawnSolanaANT}).
+   */
+  mintSigner: KeyPairSigner;
+  /** The asset pubkey = the SDK-canonical `processId` for the new ANT. */
+  mint: Address;
+};
+
 /**
- * Spawn a brand-new ANT on Solana. Returns the asset address, which is the
- * SDK's stable `processId` for that ANT.
+ * Build the ordered `[CreateV1, ario_ant::initialize]` instructions for a fresh
+ * ANT without sending them. Extracted from {@link spawnSolanaANT} so the same
+ * mint can be bundled into a larger compound transaction (e.g. atomic spawn +
+ * `buy_name`). The caller is responsible for attaching `mintSigner`, prepending
+ * a compute budget, and bootstrapping the owner's ACL afterwards.
  */
-export async function spawnSolanaANT(
-  params: SpawnSolanaANTParams,
-): Promise<SpawnSolanaANTResult> {
+export async function buildSpawnAntInstructions(params: {
+  signer: SolanaSigner;
+  state: SpawnSolanaANTState;
+  antProgramId?: Address;
+  mintSigner?: KeyPairSigner;
+}): Promise<SpawnAntInstructions> {
   if (!params.state?.name || params.state.name.length === 0) {
-    throw new Error('spawnSolanaANT: state.name is required');
+    throw new Error('buildSpawnAntInstructions: state.name is required');
   }
-
-  const {
-    rpc,
-    rpcSubscriptions,
-    signer,
-    state,
-    antProgramId = ARIO_ANT_PROGRAM_ID,
-    commitment = 'confirmed',
-    computeUnitLimit = 400_000,
-  } = params;
-
+  const { signer, state, antProgramId = ARIO_ANT_PROGRAM_ID } = params;
   const mintSigner = params.mintSigner ?? (await generateKeyPairSigner());
-  const owner = signer.address;
   const mint = mintSigner.address;
 
   const uri =
@@ -332,6 +347,42 @@ export async function spawnSolanaANT(
     mint,
     signer,
     state,
+  });
+
+  return { instructions: [createIx, initIx], mintSigner, mint };
+}
+
+/**
+ * Spawn a brand-new ANT on Solana. Returns the asset address, which is the
+ * SDK's stable `processId` for that ANT.
+ */
+export async function spawnSolanaANT(
+  params: SpawnSolanaANTParams,
+): Promise<SpawnSolanaANTResult> {
+  if (!params.state?.name || params.state.name.length === 0) {
+    throw new Error('spawnSolanaANT: state.name is required');
+  }
+
+  const {
+    rpc,
+    rpcSubscriptions,
+    signer,
+    state,
+    antProgramId = ARIO_ANT_PROGRAM_ID,
+    commitment = 'confirmed',
+    computeUnitLimit = 400_000,
+  } = params;
+
+  const owner = signer.address;
+  const {
+    instructions: [createIx, initIx],
+    mintSigner,
+    mint,
+  } = await buildSpawnAntInstructions({
+    signer,
+    state,
+    antProgramId,
+    mintSigner: params.mintSigner,
   });
 
   // ADR-012 (ACL): bootstrap the new owner's paginated ACL. The


### PR DESCRIPTION
## Summary

When `buyRecord` is called **without a `processId`**, the SDK now spawns a fresh ANT and assigns the name to it in a **single atomic transaction** (`[CreateV1, initialize, buy_name]`), instead of buying the name with the `1111…` no-ANT sentinel. Instructions execute in order within the tx, so the minted asset exists by the time `buy_name` CPIs into its Attributes plugin.

This makes the CLI's existing prompt — *"a new ANT (MPL Core asset) will be spawned and assigned to this name"* — actually true.

## Approach

The combined bundle is kept under Solana's **1232-byte** transaction-size limit by deferring the non-critical work:

- **Atomic tx:** `[CreateV1, initialize, buy_name]`, signed by the fee-payer **and** the fresh mint keypair.
- **Best-effort follow-up tx:** owner ACL registry bootstrap + `sync_attributes`. Neither needs to be atomic with the purchase; a failure here is logged (not thrown) since the purchase + mint already confirmed. The owner can reconcile later via the sync-ACL API / `syncAttributes()`.
- The new ANT's id is surfaced via `result.processId` so callers don't have to re-fetch the record.

## Changes

- **`spawn-ant.ts`** — extract `buildSpawnAntInstructions()` (build-only, no send); `spawnSolanaANT` now reuses it (no behavior change).
- **`send.ts`** — add `extraSigners` to `sendAndConfirm`, including the wallet-bridge pre-sign ordering needed when a fresh mint keypair co-signs alongside a message-modifying wallet (Phantom).
- **`io-writeable.ts`** — spawn-and-buy path in `buyRecord` + `_bootstrapSpawnedAntAcl` follow-up; `sendTransaction` threads `extraSigners`; `SPAWN_AND_BUY_COMPUTE_UNIT_LIMIT` ceiling.
- **`io-writeable.localnet.test.ts`** — test for the no-`processId` path: record assignment, MPL Core asset owner, ACL bootstrap.

## Behavior change ⚠️

No `processId` now **always spawns an ANT**. Any consumer relying on buying a name with no ANT attached would see different behavior — this matches the branch intent and the CLI messaging.

## Verification

- `tsc --noEmit`: clean
- `biome check`: clean
- Unit tests pass (spawn-ant, gas-estimate, ant-readable)
- ⏳ **Localnet test (`yarn test:localnet:io-write`) not yet run** — needs a running Surfpool validator. This is also the cheapest way to confirm the combined tx actually fits in 1232 bytes for the common case; if a long name pushes it over, the fallback is the v0 + Address Lookup Table path.

## Follow-ups (not in this PR)

- `buyReturnedName` has the same no-ANT shape and could get the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)