### PR TITLE
fix(solana): getVaults returns numeric vaultId so release/revoke work

### DIFF
--- a/src/solana/deserialize.ts
+++ b/src/solana/deserialize.ts
@@ -498,12 +498,18 @@ export function deserializeArnsRecord(
 // Vault deserialization
 // =========================================
 
-export function deserializeVault(data: Buffer): VaultData & { owner: string } {
+export function deserializeVault(
+  data: Buffer,
+): VaultData & { owner: string; vaultId: string } {
   const d = getVaultDecoder().decode(new Uint8Array(data));
   const controller = optionToValue(d.controller as any) as Address | undefined;
 
   return {
     owner: d.owner as string,
+    // Numeric per-owner vault id (u64 as string) — this is what
+    // releaseVault/revokeVault expect, NOT the PDA address. Mirrors
+    // deserializeWithdrawal's `vaultId`.
+    vaultId: String(Number(d.vaultId)),
     balance: Number(d.amount),
     startTimestamp: Number(d.startTimestamp),
     endTimestamp: Number(d.endTimestamp),

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -869,7 +869,11 @@ export class SolanaARIOReadable {
         const vault = deserializeVault(data);
         items.push({
           address: vault.owner,
-          vaultId: pubkey as string,
+          // PDA address — stable globally-unique handle for list keys /
+          // explorer links. NOT accepted by releaseVault/revokeVault.
+          cursorId: pubkey as string,
+          // Numeric per-owner vault id — pass THIS to releaseVault/revokeVault.
+          vaultId: vault.vaultId,
           balance: vault.balance,
           startTimestamp: secToMs(vault.startTimestamp),
           endTimestamp: secToMs(vault.endTimestamp),

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -2967,7 +2967,19 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       { programAddress: this.coreProgram },
     );
 
-    const sig = await this.sendTransaction([ix]);
+    // The on-chain handler transfers into ownerTokenAccount but does NOT
+    // init it (it's a plain `mut` TokenAccount constraint). A holder who only
+    // ever held vaults (e.g. migrated investor/team allocations) may have no
+    // ARIO ATA yet — bundle an idempotent create so the release can't fail on
+    // a missing destination. Same pattern as createVault/vaultedTransfer.
+    const createOwnerAtaIx = buildCreateAtaIdempotentIx(
+      this.signer.address,
+      ownerATA,
+      this.signer.address,
+      mint,
+    );
+
+    const sig = await this.sendTransaction([createOwnerAtaIx, ix]);
     return { id: sig };
   }
 

--- a/src/solana/prune-discovery.test.ts
+++ b/src/solana/prune-discovery.test.ts
@@ -252,6 +252,41 @@ describe('SolanaARIOReadable.getExpiredVaults', () => {
 });
 
 // ---------------------------------------------------------------
+// Vault: getVaults surfaces the NUMERIC vaultId (not the PDA address).
+// Regression guard — releaseVault/revokeVault do BigInt(vaultId) to derive
+// the PDA, so a pubkey here makes every release/revoke throw.
+// ---------------------------------------------------------------
+
+describe('SolanaARIOReadable.getVaults', () => {
+  it('returns numeric vaultId in `vaultId` and the PDA in `cursorId`', async () => {
+    const enc = getVaultEncoder();
+    const bytes = enc.encode({
+      owner: PUBKEY_1,
+      vaultId: 27n,
+      amount: 2_961_491_000_000n,
+      startTimestamp: 1_000n,
+      endTimestamp: 2_000n,
+      controller: null,
+      revocable: false,
+      bump: 252,
+      version: VERSION,
+    });
+    const rpc = stubRpcReturning([{ pubkey: ADDR_A, bytes }]);
+    const r = buildReadable(rpc);
+
+    const { items } = await r.getVaults({ limit: 10 });
+    assert.equal(items.length, 1);
+    // The numeric id BigInt() can parse — NOT the base58 PDA.
+    assert.equal(items[0].vaultId, '27');
+    assert.doesNotThrow(() => BigInt(items[0].vaultId));
+    // The PDA address is preserved separately for keys/links.
+    assert.equal(items[0].cursorId, ADDR_A);
+    assert.equal(items[0].address, PUBKEY_1);
+    assert.equal(items[0].balance, 2_961_491_000_000);
+  });
+});
+
+// ---------------------------------------------------------------
 // PrimaryNameRequest: getExpiredPrimaryNameRequests filters expiresAt <= now
 // ---------------------------------------------------------------
 

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -249,6 +249,16 @@ export type GatewayDelegateAllowList = WalletAddress[];
 
 export type WalletVault = VaultData & {
   address: WalletAddress;
+  /**
+   * Vault PDA address — globally-unique, stable handle for React keys /
+   * explorer links. Mirrors `GatewayVault.cursorId`. This is NOT a valid
+   * argument to `releaseVault`/`revokeVault`; use `vaultId` for those.
+   */
+  cursorId: string;
+  /**
+   * Numeric per-owner vault id (u64 as string). Pass this to
+   * `releaseVault({ vaultId })` / `revokeVault({ vaultId })`.
+   */
   vaultId: string;
 };
 


### PR DESCRIPTION
## Problem

`getVaults()` returned the vault **PDA pubkey** in `WalletVault.vaultId`. But `releaseVault({ vaultId })` and `revokeVault({ vaultId })` derive the vault PDA via `getVaultPDA(owner, BigInt(vaultId))` — so passing a base58 pubkey throws (`Cannot convert … to a BigInt`).

Impact: migrated investor/team vaults that reached their unlock date could not be released, and the network-portal's existing "Claim All Rewards" release loop and per-vault Revoke were both dead on arrival.

Withdrawals already did this correctly (`deserializeWithdrawal` returns a numeric `vaultId` plus a separate `cursorId` pubkey) — this brings vaults in line with that pattern.

## Changes

- **`deserializeVault`** — surface the numeric per-owner `vaultId`.
- **`getVaults`** — return the **numeric** `vaultId`; add `cursorId` (the PDA pubkey) for React keys / explorer links, mirroring `GatewayVault`.
- **`WalletVault`** type — document `vaultId` (numeric, pass to release/revoke) vs `cursorId` (PDA).
- **`releaseVault`** — prepend an idempotent create-owner-ATA. The on-chain handler transfers into `ownerTokenAccount` but does not init it; a holder who only ever held vaults (migrated allocations) may have no ARIO ATA yet. Matches `createVault`/`vaultedTransfer`.
- **test** — `getVaults` regression guard in `prune-discovery.test.ts` (numeric `vaultId`, pubkey in `cursorId`, `BigInt()`-parseable).

## Verification

- `yarn test:unit` — 402/402 pass
- `tsc -p tsconfig.json --noEmit` — clean
- `biome check` — clean
- `yarn build` — clean (fix present in built `lib/`)

## Downstream

`ar-io/network-portal` consumes this — the portal PR's `@ar.io/sdk` bump should target the version published from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6EYzND97UZFweq4gNxjQ4
