### PR TITLE
fix(solana): drop stale getProgramAccounts ghosts before close_observations batch

### DIFF
--- a/src/solana/crank-epoch-step.test.ts
+++ b/src/solana/crank-epoch-step.test.ts
@@ -113,6 +113,19 @@ class TestCranker extends SolanaARIOWriteable {
     this.calls.push(`closeObservations:${p.epochIndex}:${p.observers.length}`);
     return { id: 'tx-close-obs' };
   }
+  // filterLiveObservations stub — mirrors the SDK's stale-ghost guard without
+  // touching RPC. Default is identity (every candidate is live); a test sets
+  // `liveObservers[i]` to simulate getProgramAccounts returning already-closed
+  // (stale-index) ghosts.
+  liveObservers: Record<number, Address[]> | null = null;
+  protected async filterLiveObservations(
+    epochIndex: number,
+    observers: string[],
+  ): Promise<string[]> {
+    this.calls.push(`filterLive:${epochIndex}:${observers.length}`);
+    if (this.liveObservers === null) return observers;
+    return this.liveObservers[epochIndex] ?? [];
+  }
   // biome-ignore lint/suspicious/noExplicitAny: test stubs
   async prescribeEpoch(p: any): Promise<any> {
     this.prescribeAttempts++;
@@ -583,6 +596,46 @@ describe('crankEpochStep — close observations before close_epoch', () => {
     );
   });
 
+  it('closes only the LIVE observers, dropping stale-index ghosts', async () => {
+    const c = new TestCranker();
+    setup(c, { observationsSubmitted: 3, observationsClosed: 0 });
+    // getProgramAccounts (getEpochObservers) returns 3 — but its index is stale.
+    c.epochObservers[2] = [pk(1), pk(2), pk(3)];
+    // Only pk(1) still exists on-chain; pk(2)/pk(3) were already closed.
+    c.liveObservers = { 2: [pk(1)] };
+    const r = await c.crankEpochStep({ now: 1900, epochRetention: 7 });
+    assert.equal(r.action, 'close_observation');
+    assert.ok(
+      c.calls.includes('closeObservations:2:1'),
+      'closes only the 1 live observer',
+    );
+    assert.ok(
+      !c.calls.includes('closeObservations:2:3'),
+      'never builds the doomed 3-wide batch that would revert AccountNotInitialized',
+    );
+  });
+
+  it('does NOT attempt a close (no wedge) when every candidate is a stale ghost', async () => {
+    const c = new TestCranker();
+    setup(c, { observationsSubmitted: 3, observationsClosed: 0 });
+    c.epochObservers[2] = [pk(1), pk(2), pk(3)];
+    c.liveObservers = { 2: [] }; // all already closed; the counter is just stale
+    const r = await c.crankEpochStep({ now: 1900, epochRetention: 7 });
+    assert.ok(
+      !c.calls.some((x) => x.startsWith('closeObservations:')),
+      'must not submit a close_observations tx that would revert + wedge',
+    );
+    assert.ok(
+      !c.calls.some((x) => x.startsWith('close:')),
+      'must not attempt close_epoch with the counter still open',
+    );
+    assert.notEqual(
+      r.action,
+      'close_observation',
+      'falls through to create-next instead of retrying a doomed batch',
+    );
+  });
+
   it('caps the observation-close batch at 8', async () => {
     const c = new TestCranker();
     setup(c, { observationsSubmitted: 20, observationsClosed: 0 });
@@ -620,5 +673,64 @@ describe('crankEpochStep — close observations before close_epoch', () => {
     assert.notEqual(r.action, 'close_observation');
     assert.notEqual(r.action, 'close');
     assert.equal(r.action, 'create'); // progression continues
+  });
+});
+
+// --- direct test of the REAL filterLiveObservations (the stale-ghost guard) ---
+//
+// Exercises the actual PDA-derive → getMultipleAccounts → `.exists` filter (not
+// the TestCranker stub), with a mock RPC whose per-index existence we control.
+function existenceRpc(exists: boolean[]) {
+  return {
+    getMultipleAccounts: (addrs: unknown[]) => ({
+      send: async () => ({
+        value: addrs.map((_a, i) =>
+          exists[i]
+            ? {
+                data: ['', 'base64'],
+                executable: false,
+                lamports: 1n,
+                owner: '11111111111111111111111111111111',
+                rentEpoch: 0n,
+                space: 0n,
+              }
+            : null,
+        ),
+      }),
+    }),
+  };
+}
+
+class LiveFilterHarness extends SolanaARIOWriteable {
+  constructor(rpc: any) {
+    super({
+      rpc,
+      rpcSubscriptions: {} as never,
+      signer: { address: pk(99) } as never,
+    } as never);
+  }
+  run(epochIndex: number, observers: string[]): Promise<string[]> {
+    return this.filterLiveObservations(epochIndex, observers);
+  }
+}
+
+describe('filterLiveObservations (stale getProgramAccounts ghost guard)', () => {
+  it('keeps only observers whose Observation PDA still exists on a fresh read', async () => {
+    const h = new LiveFilterHarness(existenceRpc([true, false, true]));
+    const live = await h.run(5, [pk(1), pk(2), pk(3)]);
+    assert.deepEqual(live, [pk(1), pk(3)]);
+  });
+
+  it('returns [] without any RPC call for an empty candidate set', async () => {
+    let called = false;
+    const rpc = {
+      getMultipleAccounts: () => {
+        called = true;
+        return { send: async () => ({ value: [] }) };
+      },
+    };
+    const h = new LiveFilterHarness(rpc as never);
+    assert.deepEqual(await h.run(5, []), []);
+    assert.equal(called, false, 'empty candidate set must not hit the RPC');
   });
 });

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -43,6 +43,7 @@ import {
   compileTransaction,
   createTransactionMessage,
   fetchEncodedAccount,
+  fetchEncodedAccounts,
   getAddressDecoder,
   getBase64EncodedWireTransaction,
   pipe,
@@ -4271,7 +4272,21 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
         if (old && old.rewardsDistributed === 1) {
           if (old.observationsSubmitted > old.observationsClosed) {
             // Open observations remain — close a batch before close_epoch.
-            const observers = await this.getEpochObservers(closeTarget);
+            //
+            // getEpochObservers discovers observers via getProgramAccounts,
+            // whose secondary index LAGS finalized state — badly under RPC 429
+            // pressure. It can return Observation PDAs that were already closed.
+            // Including a ghost in the atomic closeObservations batch reverts the
+            // WHOLE tx with AccountNotInitialized, so nothing closes, the counter
+            // never advances, and we retry the identical doomed batch every crank
+            // tick: a self-reinforcing wedge + 429 firehose. Re-validate the
+            // candidates against fresh per-account reads (read-after-write
+            // consistent, unlike getProgramAccounts) and only close live PDAs.
+            const candidates = await this.getEpochObservers(closeTarget);
+            const observers = await this.filterLiveObservations(
+              closeTarget,
+              candidates,
+            );
             if (observers.length > 0) {
               const batch = observers.slice(0, MAX_CLOSE_OBSERVATION_BATCH);
               const { id } = await this.closeObservations({
@@ -4285,9 +4300,10 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
                 progress: { index: batch.length, total: observers.length },
               };
             }
-            // Counter says open but no Observation PDA exists (orphaned counter):
-            // can't close it, so don't attempt close_epoch (it would revert) and
-            // don't wedge — fall through to create-next.
+            // Counter says open but no LIVE Observation PDA exists — an orphaned
+            // counter, or getProgramAccounts ghosts from a stale index. Can't
+            // close it, so don't attempt close_epoch (it would revert) and don't
+            // wedge — fall through to create-next.
           } else {
             const { id } = await this.closeEpoch({ epochIndex: closeTarget });
             return { action: 'close', epochIndex: closeTarget, txId: id };
@@ -4775,6 +4791,42 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
    * before closing a retention-aged epoch. Keep the batch small — each ix carries
    * the Epoch + Observation + payer + system accounts.
    */
+  /**
+   * Filter a candidate observer set down to those whose Observation PDA still
+   * exists on-chain, using fresh per-account reads.
+   *
+   * {@link getEpochObservers} discovers observers via `getProgramAccounts`,
+   * whose secondary index lags finalized state (and lags badly under RPC 429
+   * pressure), so it can return observers whose Observation PDA was already
+   * closed. Feeding those ghosts into the atomic {@link closeObservations}
+   * batch makes the whole tx revert with `AccountNotInitialized`, wedging the
+   * close and retrying the identical doomed batch every crank tick.
+   *
+   * `fetchEncodedAccounts` (getMultipleAccounts) is read-after-write consistent
+   * at this client's commitment, so it does not return ghosts — one RPC call
+   * validates the entire candidate set.
+   */
+  protected async filterLiveObservations(
+    epochIndex: number,
+    observers: string[],
+  ): Promise<string[]> {
+    if (observers.length === 0) return [];
+    const pdas = await Promise.all(
+      observers.map(async (obs) => {
+        const [pda] = await getObservationPDA(
+          epochIndex,
+          address(obs),
+          this.garProgram,
+        );
+        return pda;
+      }),
+    );
+    const accounts = await fetchEncodedAccounts(this.rpc, pdas, {
+      commitment: this.commitment,
+    });
+    return observers.filter((_obs, i) => accounts[i]?.exists);
+  }
+
   async closeObservations(
     params: { epochIndex: number; observers: string[] },
     _options?: WriteOptions,


### PR DESCRIPTION
## Problem

`crankEpochStep`'s close path sources observers via `getEpochObservers`, which reads through `getProgramAccounts`. That secondary index **lags finalized state** — badly under RPC 429 pressure — so it can return Observation PDAs that were **already closed**.

Those ghosts go straight into the **atomic** `closeObservations` batch, where a single already-closed account reverts the **whole** tx with `AccountNotInitialized`. Nothing closes, `observationsClosed` never advances, and the next crank tick retries the identical doomed batch — a self-reinforcing wedge.

## Fix

Add `filterLiveObservations()`: re-validate the candidate observers with a fresh `fetchEncodedAccounts` (`getMultipleAccounts` is read-after-write consistent at the client commitment, unlike `getProgramAccounts`) and only close PDAs that still exist. If the live set is empty (orphaned counter / all-ghosts), fall through to create-next instead of submitting a doomed batch.

## Tests (38/38)

- `filterLiveObservations` keeps only live PDAs (mock-RPC existence: `[live, ghost, live] → [live, live]`; empty set hits no RPC).
- Close path drops ghosts (`closeObservations` called with the live subset only).
- No close attempted when every candidate is a ghost (no wedge, falls through to `create`).

## Context

Paired with an observer-side fix (`ar-io-observer` Phase 4) that was the dominant source of the on-chain `close_observation` firehose; this SDK change hardens the lifecycle close path against the same stale-index class. Validated read-only against mainnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)