### PR TITLE
feat(solana): mint ANTs with program-controlled UpdateAuthority (ADR-028)

### DIFF
--- a/src/solana/constants.ts
+++ b/src/solana/constants.ts
@@ -114,6 +114,12 @@ export const ANT_CONFIG_SEED = Buffer.from('ant_config');
 export const ANT_CONTROLLERS_SEED = Buffer.from('ant_controllers');
 export const ANT_RECORD_SEED = Buffer.from('ant_record');
 export const ANT_RECORD_META_SEED = Buffer.from('ant_record_meta');
+// ADR-028: per-asset program-signer PDA that holds the Metaplex Core
+// UpdateAuthority (and, via `Authority::UpdateAuthority`, the Attributes-plugin
+// authority) for ANTs. New ANTs mint with UpdateAuthority set to this PDA so all
+// MPL Core updates route through the ario-ant program. PDA:
+// ["ant_authority", asset].
+export const ANT_AUTHORITY_SEED = Buffer.from('ant_authority');
 
 // Per-user paginated ACL (ADR-012). See `docs/ACCOUNT_SCALING_PATTERNS.md`
 // Pattern C: a head `AclConfig` plus deterministically-addressed `AclPage`s

--- a/src/solana/index.ts
+++ b/src/solana/index.ts
@@ -184,6 +184,7 @@ export {
   getRedelegationRecordPDA,
   getAntConfigPDA,
   getAntControllersPDA,
+  getAntAuthorityPDA,
   getAntRecordPDA,
   getAclConfigPDA,
   getAclPagePDA,

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -207,6 +207,7 @@ import { getTransferCheckedInstruction } from '@solana-program/token';
 import { ARIO_ANT_PROGRAM_ID, TOKEN_DECIMALS } from './constants.js';
 import { SolanaARIOReadable } from './io-readable.js';
 import {
+  getAntAuthorityPDA,
   getAntConfigPDA,
   getAntRecordPDA,
   getArioConfigPDA,
@@ -2162,11 +2163,16 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     asset: Address,
   ): Promise<Instruction> {
     const [arnsRecord] = await getArnsRecordPDA(name, this.arnsProgram);
+    // ADR-028: the `authority` signer is gone. Program-controlled ANTs are
+    // synced permissionlessly (the program signs UpdatePluginV1 with the
+    // per-asset `ant_authority` PDA); legacy ANTs still require the owner as
+    // `payer`. Either way we pass the derived PDA.
+    const [antAuthority] = await getAntAuthorityPDA(asset, this.antProgram);
     return getSyncAttributesInstruction(
       {
         asset,
         payer: this.signer,
-        authority: this.signer,
+        antAuthority,
         arnsRecord,
         name,
       },

--- a/src/solana/pda.ts
+++ b/src/solana/pda.ts
@@ -34,6 +34,7 @@ import {
   ACL_CONFIG_SEED,
   ACL_PAGE_SEED,
   ALLOWLIST_SEED,
+  ANT_AUTHORITY_SEED,
   ANT_CONFIG_SEED,
   ANT_CONTROLLERS_SEED,
   ANT_RECORD_META_SEED,
@@ -399,6 +400,21 @@ export async function getAntControllersPDA(
   return getProgramDerivedAddress({
     programAddress: programId,
     seeds: [ANT_CONTROLLERS_SEED, addressEncoder.encode(mint)],
+  });
+}
+
+/**
+ * ADR-028: per-asset program-signer PDA that holds the Metaplex Core
+ * UpdateAuthority for an ANT. New ANTs mint with UpdateAuthority set to this
+ * address so all MPL Core updates route through the ario-ant program.
+ */
+export async function getAntAuthorityPDA(
+  mint: Address,
+  programId: Address = ARIO_ANT_PROGRAM_ID,
+): Promise<Pda> {
+  return getProgramDerivedAddress({
+    programAddress: programId,
+    seeds: [ANT_AUTHORITY_SEED, addressEncoder.encode(mint)],
   });
 }
 

--- a/src/solana/spawn-ant.test.ts
+++ b/src/solana/spawn-ant.test.ts
@@ -5,12 +5,13 @@
  * change to MPL Core's `CreateV1` schema or our default attribute-plugin
  * shape is caught at the unit-test level instead of at deploy time.
  *
- * The migration import package emits the same `CreateV1` payload via the
- * legacy @solana/web3.js path (`migration/import/src/instructions/mint-nft.ts`).
- * The byte fixtures below were captured from that path before this PR and
- * must stay byte-identical — divergence would mean migration-minted ANTs
- * and SDK-minted ANTs no longer share a shape, which would in turn break
- * `purchase`'s `UpdatePluginV1` CPI on the SDK-minted side (or vice-versa).
+ * ADR-028: fresh ANTs now mint with the Attributes-plugin authority =
+ * `UpdateAuthority` (plugin authority byte `02`, was `01` = Owner) and the
+ * asset `updateAuthority` set to the per-asset `ant_authority` PDA. This is an
+ * intentional divergence from legacy (pre-ADR-028) mints — including historical
+ * migration-import ANTs, which are `adopt_authority`-adoptable onto the new
+ * model. The `authority` byte is the only data-level change; the account list
+ * gains the explicit `updateAuthority` at kinobi position 5.
  */
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
@@ -22,6 +23,8 @@ import { buildCreateAntInstruction } from './spawn-ant.js';
 const FIXED_MINT: Address = address('11111111111111111111111111111112');
 const FIXED_AUTH: Address = address('11111111111111111111111111111113');
 const FIXED_PAY: Address = address('11111111111111111111111111111114');
+// ADR-028: the per-asset `ant_authority` PDA. Fixed placeholder for byte-pinning.
+const FIXED_UA: Address = address('11111111111111111111111111111115');
 
 function hex(b: Uint8Array | ReadonlyUint8Array | undefined): string {
   assert.ok(b, 'instruction data must be defined');
@@ -43,11 +46,12 @@ function assertIxAccounts(ix: {
 }
 
 describe('buildCreateAntInstruction (CreateV1 wire format)', () => {
-  it('emits an empty Attributes plugin (Owner authority) by default', () => {
+  it('emits an empty Attributes plugin (UpdateAuthority) by default', () => {
     const ix = buildCreateAntInstruction({
       mint: FIXED_MINT,
       authority: FIXED_AUTH,
       payer: FIXED_PAY,
+      updateAuthority: FIXED_UA,
       name: 'test-ant',
       uri: 'ar://abc',
     });
@@ -64,7 +68,7 @@ describe('buildCreateAntInstruction (CreateV1 wire format)', () => {
     //   06          Plugin::Attributes
     //   00000000    attribute_list len = 0
     //   01          plugin authority Option = Some
-    //   01          PluginAuthority::Owner
+    //   02          PluginAuthority::UpdateAuthority (ADR-028; was Owner=01)
     const expected =
       '0000' +
       '08000000' +
@@ -74,12 +78,12 @@ describe('buildCreateAntInstruction (CreateV1 wire format)', () => {
       '0101000000' +
       '06' +
       '00000000' +
-      '0101';
+      '0102';
 
     assertIxData(ix);
     assert.equal(hex(ix.data), expected);
-    // 38 bytes — captured before this PR from the migration mint's
-    // backwards-compat path. Locks future regressions.
+    // 38 bytes — only the trailing plugin-authority variant changed (01 → 02);
+    // the payload length is unchanged.
     assert.equal(ix.data.length, 38);
   });
 
@@ -88,6 +92,7 @@ describe('buildCreateAntInstruction (CreateV1 wire format)', () => {
       mint: FIXED_MINT,
       authority: FIXED_AUTH,
       payer: FIXED_PAY,
+      updateAuthority: FIXED_UA,
       name: 'test-ant',
       uri: 'ar://abc',
       attributes: [
@@ -121,29 +126,34 @@ describe('buildCreateAntInstruction (CreateV1 wire format)', () => {
       '556e6465726e616d65204c696d6974' + // "Undername Limit"
       '02000000' +
       '3130' + // "10"
-      '0101'; // PluginAuthority Some + Owner
+      '0102'; // PluginAuthority Some + UpdateAuthority (ADR-028)
 
     assertIxData(ix);
     assert.equal(hex(ix.data), expected);
     assert.equal(ix.data.length, 108);
   });
 
-  it('places mint+authority+payer in the correct kinobi account positions', () => {
+  it('places mint+authority+payer+updateAuthority in the correct kinobi account positions', () => {
     const ix = buildCreateAntInstruction({
       mint: FIXED_MINT,
       authority: FIXED_AUTH,
       payer: FIXED_PAY,
+      updateAuthority: FIXED_UA,
       name: 'x',
       uri: 'y',
     });
 
     assertIxAccounts(ix);
-    // 8 accounts in kinobi createV1 order; positions 1, 4, 5, 7 are
-    // optional placeholders (= MPL Core program id).
+    // 8 accounts in kinobi createV1 order; positions 1 and 7 are optional
+    // placeholders (= MPL Core program id).
     assert.equal(ix.accounts.length, 8);
     assert.equal(ix.accounts[0]!.address, FIXED_MINT, 'pos 0 = asset');
     assert.equal(ix.accounts[2]!.address, FIXED_AUTH, 'pos 2 = authority');
     assert.equal(ix.accounts[3]!.address, FIXED_PAY, 'pos 3 = payer');
+    // pos 4 = owner (ADR-028: explicit = authority, so the PDA never becomes owner)
+    assert.equal(ix.accounts[4]!.address, FIXED_AUTH, 'pos 4 = owner');
+    // pos 5 = updateAuthority (ADR-028: the ant_authority PDA)
+    assert.equal(ix.accounts[5]!.address, FIXED_UA, 'pos 5 = updateAuthority');
     // pos 6 = system_program
     assert.equal(
       ix.accounts[6]!.address,
@@ -160,6 +170,7 @@ describe('buildCreateAntInstruction (CreateV1 wire format)', () => {
       mint: FIXED_MINT,
       authority: FIXED_AUTH,
       payer: FIXED_PAY,
+      updateAuthority: FIXED_UA,
       name: 'a',
       uri: 'b',
     });
@@ -176,7 +187,7 @@ describe('buildCreateAntInstruction (CreateV1 wire format)', () => {
         '0101000000' +
         '06' +
         '00000000' +
-        '0101',
+        '0102',
     );
   });
 });

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -62,7 +62,7 @@ import {
 } from '@solana-program/compute-budget';
 import { SolanaANTRegistryWriteable } from './ant-registry-writeable.js';
 import { ARIO_ANT_PROGRAM_ID } from './constants.js';
-import { getAntRecordPDA } from './pda.js';
+import { getAntAuthorityPDA, getAntRecordPDA } from './pda.js';
 import {
   estimateComputeUnitLimit,
   estimatePriorityFeeMicroLamports,
@@ -168,17 +168,23 @@ export type AntAttribute = { key: string; value: string };
  * are bundling the mint into a larger compound transaction.
  *
  * **Why we always emit an Attributes plugin (even with an empty list):**
- * `ario_arns::buy_record` and friends CPI into `UpdatePluginV1` to populate
- * traits at purchase time. If the asset has no Attributes plugin, that CPI
+ * `ario_ant::sync_attributes` CPIs into `UpdatePluginV1` to populate traits
+ * after an ArNS purchase. If the asset has no Attributes plugin, that CPI
  * fails. Emitting an empty plugin here keeps every spawned ANT
  * `purchase`-ready and matches what `migration/import` mints — see ADR-012
- * and BD-096. Authority is `Owner` so the ANT NFT holder (= asset owner)
- * can sign their own trait updates.
+ * and BD-096.
+ *
+ * **ADR-028 — program-controlled authority:** the asset's `updateAuthority`
+ * is set to the per-asset `ant_authority` PDA and the Attributes plugin
+ * authority is `UpdateAuthority` (so it resolves to that PDA). The ario-ant
+ * program signs MPL Core updates with the PDA; the NFT holder keeps `owner`
+ * (custody). Callers derive the PDA via `getAntAuthorityPDA(mint)`.
  */
 export function buildCreateAntInstruction({
   mint,
   authority,
   payer,
+  updateAuthority,
   name,
   uri,
   attributes = [],
@@ -186,6 +192,8 @@ export function buildCreateAntInstruction({
   mint: Address;
   authority: Address;
   payer: Address;
+  /** The `ant_authority` PDA — see `getAntAuthorityPDA` (ADR-028). */
+  updateAuthority: Address;
   name: string;
   uri: string;
   attributes?: AntAttribute[];
@@ -200,6 +208,11 @@ export function buildCreateAntInstruction({
     asset: asSigner(mint),
     authority: asSigner(authority),
     payer: asSigner(payer),
+    // `owner` MUST be explicit (= the authority/holder). MPL Core defaults owner
+    // to updateAuthority when omitted, so with updateAuthority = the
+    // ant_authority PDA an omitted owner would make the PDA the NFT owner.
+    owner: authority,
+    updateAuthority,
     dataState: DataState.AccountState,
     name,
     uri,
@@ -209,7 +222,7 @@ export function buildCreateAntInstruction({
           __kind: 'Attributes',
           fields: [{ attributeList: attributes }],
         },
-        authority: { __kind: 'Owner' },
+        authority: { __kind: 'UpdateAuthority' },
       },
     ],
   });
@@ -303,10 +316,22 @@ export async function spawnSolanaANT(
   //
   // Default value is the canonical `ARIO_ANT_PROGRAM_ID`; passing
   // `antProgramId` opts into the BYO-ANT (third-party) path.
+  //
+  // ADR-028: the asset's UpdateAuthority is the per-asset `ant_authority` PDA
+  // and the Attributes plugin authority is `UpdateAuthority` (→ that PDA), so
+  // all MPL Core updates route through the ario-ant program. The owner (the
+  // spawning signer) keeps custody of the NFT.
+  const [antAuthority] = await getAntAuthorityPDA(mint, antProgramId);
   const createIx = getCreateV1Instruction({
     asset: mintSigner,
     payer: signer,
     authority: signer,
+    // `owner` MUST be explicit. MPL Core defaults owner to updateAuthority when
+    // omitted, so with updateAuthority = the ant_authority PDA an omitted owner
+    // would make the PROGRAM PDA the NFT owner (user loses custody). Pin it to
+    // the spawning wallet.
+    owner,
+    updateAuthority: antAuthority,
     dataState: DataState.AccountState,
     name: state.name,
     uri,
@@ -322,7 +347,7 @@ export async function spawnSolanaANT(
             },
           ],
         },
-        authority: { __kind: 'Owner' },
+        authority: { __kind: 'UpdateAuthority' },
       },
     ],
   });


### PR DESCRIPTION
## Summary

Spawn new ANTs with their Metaplex Core **UpdateAuthority** = the per-asset `ant_authority` PDA and the Attributes-plugin authority = `UpdateAuthority`, so MPL Core updates route through the ario-ant program (ADR-028, contracts side: ar-io/ar-io-solana-contracts#118). The user keeps **Owner** (custody).

- **`owner` is pinned explicitly** to the spawning wallet in `spawn-ant.ts` / `buildCreateAntInstruction` — MPL Core defaults `owner` to `updateAuthority`, which would otherwise make the program PDA the NFT owner and strip custody.
- New **`getAntAuthorityPDA`** helper + `ANT_AUTHORITY_SEED`.
- `getCreateV1Instruction` now sets `owner`, `updateAuthority`, and `UpdateAuthority` plugin authority; byte-pinning tests updated to the new wire format (plugin authority `02`, owner at kinobi slot 4, updateAuthority at slot 5).
- `io-writeable.ts`: `sync_attributes` builder drops `authority`, passes `antAuthority` — sync is now permissionless (program signs with the PDA).

## Dependency

Requires an `@ar.io/solana-contracts` build carrying the ADR-028 client (`adoptAuthority` instruction, `antAuthority` on `syncAttributes`, `getAntAuthorityPDA`). Validated locally by `yarn link`-ing the freshly-generated client.

## Verification (against the local ADR-028 client)

- SDK build (`web` + `esm` + types) clean.
- `spawn-ant` byte-pinning tests **4/4**.
- Solana unit tests **326/327** — the single failure (`claimVaultArweaveIx` expecting 9 vs 15 accounts) is an unrelated ADR-027 vault-relock account-count change surfaced by bumping off the pinned `1.0.1` client, not part of this change.
- arns-react (portal) typechecks clean against the linked SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)