### PR TITLE
fix(solana): make atomic spawn-and-buy fit the tx limit and record ownership reliably

### DIFF
--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -1733,6 +1733,13 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     asset: Address,
     name: string,
   ): Promise<void> {
+    // Record the owner/controller ACL entries FIRST, in their OWN transaction.
+    // This is the ownership-critical step — the app-side drift detection treats
+    // a missing ACL owner entry as "needs ownership sync". It must NOT be
+    // bundled with `sync_attributes`: if that instruction reverts (e.g. an ANT
+    // program build whose `sync_attributes` enforces an `ant_authority` PDA the
+    // client doesn't yet derive), an atomic bundle would roll the ACL records
+    // back too, silently un-recording ownership.
     try {
       const registry = new SolanaANTRegistryWriteable({
         rpc: this.rpc,
@@ -1745,16 +1752,33 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
         owner: this.signer.address,
         asset,
       });
-      const syncIx = await this._buildSyncAttributesIxIfOwner(name, asset);
-      const ixs = syncIx ? [...aclIxs, syncIx] : aclIxs;
-      if (ixs.length > 0) {
-        await this.sendTransaction(ixs);
+      if (aclIxs.length > 0) {
+        await this.sendTransaction(aclIxs);
       }
     } catch (err) {
       this.logger.warn(
-        `[buyRecord] spawned ANT ${asset} for "${name}" but post-spawn ACL ` +
-          `bootstrap / attribute sync failed; reconcile later via the sync-ACL ` +
-          `API and syncAttributes(). Purchase + mint already confirmed.`,
+        `[buyRecord] spawned ANT ${asset} for "${name}" but ACL owner/controller ` +
+          `bootstrap failed; reconcile via the sync-ACL API. Purchase + mint ` +
+          `already confirmed.`,
+        err,
+      );
+    }
+
+    // Mirror the asset's Attributes plugin (populated by `buy_name`'s CPI) into
+    // the ANT's on-chain record. Best-effort and INDEPENDENT of the ACL step
+    // above — a failure here (e.g. a program/client version skew on
+    // `sync_attributes`) must not undo the ownership records. Reconcilable later
+    // via the public `syncAttributes()`.
+    try {
+      const syncIx = await this._buildSyncAttributesIxIfOwner(name, asset);
+      if (syncIx) {
+        await this.sendTransaction([syncIx]);
+      }
+    } catch (err) {
+      this.logger.warn(
+        `[buyRecord] spawned ANT ${asset} for "${name}": ACL recorded, but ` +
+          `sync_attributes failed; ANT record traits will reconcile on a later ` +
+          `syncAttributes() call.`,
         err,
       );
     }

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -240,6 +240,8 @@ import {
 } from './predict-prescribed-observers.js';
 import {
   DEFAULT_COMPUTE_UNIT_LIMIT,
+  MAX_TX_SIZE_BYTES,
+  estimateCompiledTxSize,
   reclaimLookupTablesForSigner,
   sendAndConfirm,
   sendWithEphemeralLookupTable,
@@ -440,6 +442,39 @@ export const MAX_COMPOUND_BATCH = 6;
  * a pre-send simulation; message-modifying wallets keep this generous ceiling.
  */
 const SPAWN_AND_BUY_COMPUTE_UNIT_LIMIT = 800_000;
+/**
+ * Collect the account addresses in `instructions` that are safe to serve from
+ * an Address Lookup Table: every account meta EXCEPT signers (which must remain
+ * in the static keys) and the invoked top-level program ids (a program invoked
+ * by an instruction cannot be loaded from an ALT). `alwaysInline` pins extra
+ * addresses static — the fee payer and any bundled mint signer. CPI-target
+ * programs that appear only as account metas (e.g. system, token) ARE eligible.
+ * Deduped; order-independent.
+ */
+function altEligibleAddresses(
+  instructions: Instruction[],
+  alwaysInline: Address[],
+): Address[] {
+  const inline = new Set<string>(alwaysInline as string[]);
+  for (const ix of instructions) {
+    inline.add(ix.programAddress);
+    for (const acc of ix.accounts ?? []) {
+      if (
+        acc.role === AccountRole.READONLY_SIGNER ||
+        acc.role === AccountRole.WRITABLE_SIGNER
+      ) {
+        inline.add(acc.address);
+      }
+    }
+  }
+  const eligible = new Set<Address>();
+  for (const ix of instructions) {
+    for (const acc of ix.accounts ?? []) {
+      if (!inline.has(acc.address)) eligible.add(acc.address);
+    }
+  }
+  return [...eligible];
+}
 /** Observation PDAs closed per tx before close_epoch (each ix carries Epoch +
  *  Observation + payer + system accounts — keep well under the tx account cap). */
 const MAX_CLOSE_OBSERVATION_BATCH = 8;
@@ -1625,11 +1660,42 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     // asset's traits via CPI, so the deferred sync just mirrors them into the
     // ANT's on-chain record).
     if (mintSigner !== undefined) {
-      const sig = await this.sendTransaction(
-        [...spawnIxs, ix],
-        SPAWN_AND_BUY_COMPUTE_UNIT_LIMIT,
-        [mintSigner],
-      );
+      const spawnAndBuyIxs = [...spawnIxs, ix];
+      // Balance/credit-funded spawn-and-buy fits inline (~1.1 KB) and lands in
+      // ONE signature. But a multi-source funding plan appends per-source
+      // remaining accounts to `buy_name` (~33 bytes each) and can blow past
+      // Solana's 1232-byte limit. When that happens, route the whole
+      // spawn-and-buy through an ephemeral Address Lookup Table (create →
+      // extend → compressed v0 tx), compressing every non-signer,
+      // non-invoked-program account. The mint stays inline (it's a signer).
+      const inlineSize = estimateCompiledTxSize({
+        signer: this.signer,
+        instructions: spawnAndBuyIxs,
+        extraSigners: [mintSigner],
+        computeUnitLimit: SPAWN_AND_BUY_COMPUTE_UNIT_LIMIT,
+      });
+      let sig: string;
+      if (inlineSize <= MAX_TX_SIZE_BYTES) {
+        sig = await this.sendTransaction(
+          spawnAndBuyIxs,
+          SPAWN_AND_BUY_COMPUTE_UNIT_LIMIT,
+          [mintSigner],
+        );
+      } else {
+        sig = await sendWithEphemeralLookupTable({
+          rpc: this.rpc,
+          rpcSubscriptions: this.rpcSubscriptions,
+          signer: this.signer,
+          instructions: spawnAndBuyIxs,
+          lookupAddresses: altEligibleAddresses(spawnAndBuyIxs, [
+            this.signer.address,
+            mintSigner.address,
+          ]),
+          commitment: this.commitment,
+          computeUnitLimit: SPAWN_AND_BUY_COMPUTE_UNIT_LIMIT,
+          extraSigners: [mintSigner],
+        });
+      }
       await this._bootstrapSpawnedAntAcl(antPubkey, params.name);
       // Surface the freshly-minted ANT's id so callers don't have to re-fetch
       // the record to discover which asset the name was assigned to.
@@ -3902,7 +3968,7 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
         rpc: this.rpc,
         rpcSubscriptions: this.rpcSubscriptions,
         signer: this.signer,
-        instruction: fullIx,
+        instructions: [fullIx],
         lookupAddresses: remaining.map((a) => a.address),
         commitment: this.commitment,
         computeUnitLimit: 1_000_000,

--- a/src/solana/send.ts
+++ b/src/solana/send.ts
@@ -607,36 +607,101 @@ async function logSimulationDiagnostics(
   }
 }
 
+/** Solana's hard cap on a serialized transaction (signatures + message). */
+export const MAX_TX_SIZE_BYTES = 1232;
+
 /**
- * Submit `instruction` in a v0 transaction whose `lookupAddresses` (read-only
- * accounts) are served from a freshly-created, ephemeral Address Lookup Table,
- * so an instruction touching far more accounts than fit inline (e.g.
- * `prescribe_epoch` with ≤50 observer PDAs + NameRegistry, ~2 KB of keys) still
- * fits Solana's 1232-byte transaction-size limit.
+ * Compiled wire size (signatures + message) of the v0 transaction
+ * `sendAndConfirm` would build for `instructions` — i.e. WITH the two
+ * compute-budget instructions it always prepends and `extraSigners` attached,
+ * but WITHOUT any lookup-table compression. Lets callers decide up front
+ * (before prompting a wallet) whether a tx needs to be routed through an
+ * Address Lookup Table to fit {@link MAX_TX_SIZE_BYTES}.
+ *
+ * Uses a zero blockhash and zero-filled signatures — neither affects the byte
+ * length (blockhash is always 32 bytes, each signature 64) — so no RPC call is
+ * needed.
+ */
+export function estimateCompiledTxSize({
+  signer,
+  instructions,
+  extraSigners = [],
+  computeUnitLimit = DEFAULT_COMPUTE_UNIT_LIMIT,
+}: {
+  signer: TransactionSigner;
+  instructions: Instruction[];
+  extraSigners?: KeyPairSigner[];
+  computeUnitLimit?: number;
+}): number {
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    (tx) => setTransactionMessageFeePayerSigner(signer, tx),
+    (tx) =>
+      setTransactionMessageLifetimeUsingBlockhash(
+        {
+          blockhash: '11111111111111111111111111111111' as never,
+          lastValidBlockHeight: 0n,
+        },
+        tx,
+      ),
+    (tx) =>
+      appendTransactionMessageInstructions(
+        [
+          getSetComputeUnitLimitInstruction({ units: computeUnitLimit }),
+          getSetComputeUnitPriceInstruction({ microLamports: 1n }),
+          ...instructions,
+        ],
+        tx,
+      ),
+    (tx) =>
+      extraSigners.length > 0
+        ? addSignersToTransactionMessage(extraSigners, tx)
+        : tx,
+  );
+  const compiled = compileTransaction(message);
+  const numSigners = Object.keys(compiled.signatures).length;
+  // wire tx = [compact-u16 sig count (1 byte for < 128 sigs)][sigs][message]
+  return 1 + numSigners * 64 + compiled.messageBytes.length;
+}
+
+/**
+ * Submit `instructions` in a v0 transaction whose `lookupAddresses` (non-signer,
+ * non-invoked-program accounts) are served from a freshly-created, ephemeral
+ * Address Lookup Table, so a transaction touching far more accounts than fit
+ * inline (e.g. `prescribe_epoch` with ≤50 observer PDAs, or the atomic
+ * spawn-and-buy with a large multi-source funding plan) still fits Solana's
+ * 1232-byte transaction-size limit.
  *
  * Three confirmed steps: create the table, extend it with the addresses (in
  * ≤20-address batches to stay within the extend tx size), then send
- * `instruction` compressed against the table. The sequential confirmations
+ * `instructions` compressed against the table. The sequential confirmations
  * satisfy the rule that appended addresses are only usable the slot AFTER they
  * are added. `signer` is the table's authority + payer; the table's (tiny) rent
  * is left allocated — a future cleanup pass can deactivate + close it.
+ *
+ * `extraSigners` (e.g. a freshly generated ANT mint keypair when the final
+ * transaction bundles a spawn) are attached to the compressed send. Only the
+ * final consuming transaction carries them; the create/extend txs are signed by
+ * `signer` alone.
  */
 export async function sendWithEphemeralLookupTable({
   rpc,
   rpcSubscriptions,
   signer,
-  instruction,
+  instructions,
   lookupAddresses,
   commitment = 'confirmed',
   computeUnitLimit = 1_000_000,
+  extraSigners = [],
 }: {
   rpc: SolanaRpc;
   rpcSubscriptions: SolanaRpcSubscriptions;
   signer: TransactionSigner;
-  instruction: Instruction;
+  instructions: Instruction[];
   lookupAddresses: Address[];
   commitment?: Commitment;
   computeUnitLimit?: number;
+  extraSigners?: KeyPairSigner[];
 }): Promise<string> {
   const recentSlot = await rpc.getSlot({ commitment: 'finalized' }).send();
   const createIx = await getCreateLookupTableInstructionAsync({
@@ -683,15 +748,16 @@ export async function sendWithEphemeralLookupTable({
   // them. Skipping this yields "address table lookup uses an invalid index".
   await waitForLookupTableActive(rpc, tableAddress, lookupAddresses.length);
 
-  // Send the real instruction, compressed against the now-active table.
+  // Send the real instructions, compressed against the now-active table.
   return sendAndConfirm({
     rpc,
     rpcSubscriptions,
     signer,
-    instructions: [instruction],
+    instructions,
     commitment,
     computeUnitLimit,
     addressLookupTables: { [tableAddress]: lookupAddresses },
+    extraSigners,
   });
 }
 


### PR DESCRIPTION
Two related fixes that make the atomic spawn-and-buy (`buyRecord` with no `processId`, added in #691) actually work end-to-end on Solana.

## 1. Route oversized atomic spawn-and-buy through a lookup table

The atomic spawn-and-buy sends `[CreateV1, initialize, buy_name]` in a single transaction. That fits Solana's 1232-byte limit for a **balance/credit-funded** buy (~1116 bytes, one signature), but a **multi-source funding plan** appends ~3 remaining accounts per source to `buy_name` (~33 bytes each), pushing it over the limit. The RPC then rejects it:

```
VersionedTransaction too large: 1776 bytes (max: encoded/raw 1644/1232)
```

**Fix — size-gate the atomic send:**
- Estimate the compiled size up front (`estimateCompiledTxSize`).
- Fits `MAX_TX_SIZE_BYTES` (1232) → send inline, unchanged, **one signature** (the common case).
- Overflows → route the whole spawn-and-buy through the existing ephemeral Address Lookup Table path (`sendWithEphemeralLookupTable`), compressing every non-signer, non-invoked-program account. The mint stays inline as a signer.

`sendWithEphemeralLookupTable` is generalized to accept an **instruction array** and **`extraSigners`** (to carry the mint keypair); the existing `prescribe_epoch` caller is updated to the array signature.

**Compiled-size measurement** of `[computeBudget×2, CreateV1, initialize, buy_name]` with N funding-source remaining accounts:

| Funding sources | Inline size | Gate | After ALT | Fits 1232 |
|---|---|---|---|---|
| 0 (balance) | 1116 | inline | 695 | ✅ |
| ~1 | 1215 | inline | 701 | ✅ |
| ~2 | 1314 | ALT | 707 | ✅ |
| ~7 (repro) | 1776 | ALT | 735 | ✅ |
| ~10 | 2106 | ALT | 755 | ✅ |

## 2. Don't let `sync_attributes` revert the spawned-ANT ACL records

The post-spawn bootstrap sent `[record_acl_owner, record_acl_controller, sync_attributes]` as **one** transaction. When `sync_attributes` reverts — e.g. against an ANT program build whose `sync_attributes` enforces an `ant_authority` PDA the client doesn't yet derive (`ConstraintSeeds` / 0x7d6) — the atomic bundle rolls the ACL records back too, so the new owner is never recorded and the name shows as "needs ownership sync".

**Fix:** split the bootstrap into two independent best-effort transactions — the owner/controller ACL records commit first, on their own; `sync_attributes` runs separately and is allowed to fail without undoing them. Ownership is recorded reliably; ANT record traits reconcile on a later `syncAttributes()`.

## Changes

- `send.ts`: add `MAX_TX_SIZE_BYTES` + `estimateCompiledTxSize`; generalize `sendWithEphemeralLookupTable` (`instruction` → `instructions: Instruction[]`, add `extraSigners`).
- `io-writeable.ts`: add `altEligibleAddresses`; size-gate the atomic buy; split the post-spawn ACL bootstrap from `sync_attributes`; update the `prescribe_epoch` caller.

## Testing / caveats

- ✅ Compiled-size math verified for the size gate + ALT compression (table above).
- ✅ Fixes verified against a live devnet cluster from the ArNS app: a balance-funded atomic buy now records ownership (no manual sync), and the previously-failing large-plan buy lands via the ALT path.
- ⚠️ **No localnet coverage added yet.** A `buyRecord`-without-`processId` over-1232 funding-plan case (multi-gateway) belongs in `io-writeable.localnet.test.ts` to guard the ALT branch — deferred.
- The `sync_attributes` `ant_authority` PDA itself (fix #2's underlying cause) is an ADR-028 program/client alignment tracked separately; #2 only makes its failure non-destructive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)