### PR TITLE
docs: rename ArNS heading to "ar.io Name System"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1296,7 +1296,7 @@ const delegates = await ario.getAllDelegates({
 
 </details>
 
-### Arweave Name System (ArNS)
+### ar.io Name System (ArNS)
 
 #### `resolveArNSName({ name })`
 


### PR DESCRIPTION
ArNS is the **ar.io** Name System. This heading was the last `Arweave Name System` reference anywhere in the published docs — every other occurrence (18 of them, including the glossary) already says "Ar.io Name System".

```diff
-### Arweave Name System (ArNS)
+### ar.io Name System (ArNS)
```

## ⚠️ This changes a published URL

This README is the source for the ar.io SDK reference on docs.ar.io (via `generate-sdk-docs`), and the page **filename is derived from this heading**. So merging this moves:

```
/sdks/ar-io-sdk/arweave-name-system-arns   →   /sdks/ar-io-sdk/ar-io-name-system-arns
```

To avoid breaking that link, the docs side needs a follow-up **after** this merges and `generate-sdk-docs` runs:

1. Add a `redirects.mjs` entry from the old path to the new one.
2. Update the link in `content/build/access/arns.mdx:53`.

I'll open that docs PR once this lands — flagging it here so the sequencing is explicit and the URL doesn't 404 in between.

Companion docs work: ar-io/docs#124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUArqiyP9GbfJrqNFVkUBr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the ArNS documentation heading to refer to the ar.io Name System (ArNS).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->