### PR TITLE
feat(solana): set ANT metadata + @ target atomically in buyRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1348,7 +1348,7 @@ const record = await ario.resolveArNSName({ name: "logo_ardrive" });
 
 </details>
 
-#### `buyRecord({ name, type, years, processId })`
+#### `buyRecord({ name, type, years, processId, antState })`
 
 Purchases a new ArNS record with the specified name, type, processId, and duration.
 
@@ -1361,6 +1361,22 @@ _Note: Requires `signer` to be provided on `ARIO.init` to sign the transaction._
 - `processId` - _optional_: the process id of an existing ANT process. If not provided, a new ANT process using the provided `signer` will be spawned, and the ArNS record will be assigned to that process.
 - `years` - _optional_: the duration of the ArNS record in years. If not provided and `type` is `lease`, the record will be leased for 1 year. If not provided and `type` is `permabuy`, the record will be permanently registered.
 - `referrer` - _optional_: track purchase referrals for analytics (e.g. `my-app.com`)
+- `antState` - _optional_ (**Solana atomic buy only**): initial ANT metadata + base `@` target to bake into the newly minted ANT in the same transaction, so the name resolves to your content immediately instead of the default AR.IO logo. Fields: `transactionId` (the `@` target — Arweave TX id, or IPFS CID when `targetProtocol` is `1`), `targetProtocol` (`0` = Arweave (default), `1` = IPFS), `ticker`, `logo` (43-char Arweave TX id), `description` (≤ 512 chars), `keywords` (≤ 16). **Ignored (with a warning) when `processId` is provided** — set metadata on an existing ANT via the ANT writeable instead. Note: TTL cannot be set at mint (`initialize` has no TTL field), so a non-default TTL still needs a post-buy `setBaseNameRecord`; and a very long `description`/`keywords` set may exceed the transaction size limit — keep those on the post-buy path.
+
+```typescript
+// Atomic buy that also points the name at your content in one transaction:
+const record = await ario.buyRecord({
+  name: "ardrive",
+  type: "lease",
+  years: 1,
+  antState: {
+    transactionId: "432l1cy0aksiL_x9M359faGzM_yjralacHIUo8_nQXM", // base @ target
+    ticker: "ARDRIVE",
+    description: "Permanent, decentralized data storage.",
+    keywords: ["storage", "permaweb"],
+  },
+});
+```
 
 ```typescript
 const ario = ARIO.init({ rpc, rpcSubscriptions, signer });

--- a/src/cli/commands/arnsPurchaseCommands.ts
+++ b/src/cli/commands/arnsPurchaseCommands.ts
@@ -23,6 +23,7 @@ import { CLIWriteOptionsFromAoParams } from '../types.js';
 import {
   assertConfirmationPrompt,
   assertEnoughBalanceForArNSPurchase,
+  buyAntStateFromOptions,
   customTagsFromOptions,
   fundFromFromOptions,
   fundingPlanFromOptions,
@@ -60,6 +61,11 @@ export async function buyRecordCLICommand(
   const fundFrom = fundFromFromOptions(o);
   const referrer = referrerFromOptions(o);
   const processId = o.processId;
+  // Optional ANT metadata + `@` target — only meaningful for an atomic buy
+  // (no processId); the SDK ignores it with a warning when processId is set.
+  const antState = buyAntStateFromOptions(
+    o as Parameters<typeof buyAntStateFromOptions>[0],
+  );
 
   if (!o.skipConfirmation) {
     const existingRecord = await ario.getArNSRecord({
@@ -96,6 +102,7 @@ export async function buyRecordCLICommand(
     {
       name: requiredStringFromOptions(o, 'name'),
       processId,
+      antState,
       type,
       years,
       fundFrom: fundFromFromOptions(o),

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -542,6 +542,14 @@ export const buyRecordOptions = [
   optionMap.type,
   optionMap.years,
   optionMap.processId,
+  // Optional ANT metadata + `@` target for an atomic buy (no --process-id).
+  // TTL is omitted on purpose — it can't be set at mint (see buyAntStateFromOptions).
+  optionMap.transactionId,
+  optionMap.targetProtocol,
+  optionMap.ticker,
+  optionMap.description,
+  optionMap.keywords,
+  optionMap.logo,
 ];
 
 export const antStateOptions = [

--- a/src/cli/utils.test.ts
+++ b/src/cli/utils.test.ts
@@ -11,6 +11,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
 import {
+  buyAntStateFromOptions,
   fundingPlanFromOptions,
   requiredAddressFromOptions,
   withdrawalIdFromOptions,
@@ -225,5 +226,65 @@ describe('requiredAddressFromOptions', () => {
       () => requiredAddressFromOptions({}),
       /--address, --wallet-file, or --private-key/,
     );
+  });
+});
+
+describe('buyAntStateFromOptions', () => {
+  it('returns undefined when no metadata flags are supplied', () => {
+    assert.equal(buyAntStateFromOptions({}), undefined);
+  });
+
+  it('maps --transaction-id and --target onto the @ target', () => {
+    assert.deepEqual(buyAntStateFromOptions({ transactionId: 'tx1' }), {
+      transactionId: 'tx1',
+    });
+    // --target is accepted as an alias for the @ record's tx id.
+    assert.deepEqual(buyAntStateFromOptions({ target: 'tx2' }), {
+      transactionId: 'tx2',
+    });
+  });
+
+  it('maps ticker/description/keywords/logo through', () => {
+    assert.deepEqual(
+      buyAntStateFromOptions({
+        ticker: 'BLOG',
+        description: 'hi',
+        keywords: ['a', 'b'],
+        logo: 'logotx',
+      }),
+      {
+        ticker: 'BLOG',
+        description: 'hi',
+        keywords: ['a', 'b'],
+        logo: 'logotx',
+      },
+    );
+  });
+
+  it('parses --target-protocol arweave/ipfs (and numeric) to 0/1', () => {
+    assert.equal(
+      buyAntStateFromOptions({ targetProtocol: 'arweave' })?.targetProtocol,
+      0,
+    );
+    assert.equal(
+      buyAntStateFromOptions({ targetProtocol: 'ipfs' })?.targetProtocol,
+      1,
+    );
+    assert.equal(
+      buyAntStateFromOptions({ targetProtocol: '1' })?.targetProtocol,
+      1,
+    );
+  });
+
+  it('throws on an invalid --target-protocol', () => {
+    assert.throws(
+      () => buyAntStateFromOptions({ targetProtocol: 'https' }),
+      /--target-protocol must be/,
+    );
+  });
+
+  it('does not set TTL (not settable at mint)', () => {
+    const state = buyAntStateFromOptions({ transactionId: 'tx1' });
+    assert.ok(state && !('ttlSeconds' in state));
   });
 });

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -754,7 +754,7 @@ export function buyAntStateFromOptions(o: {
   logo?: string;
   targetProtocol?: string;
 }): ArNSBuyAntState | undefined {
-  let targetProtocol: number | undefined;
+  let targetProtocol: 0 | 1 | undefined;
   if (o.targetProtocol !== undefined) {
     const p = o.targetProtocol.toLowerCase();
     if (p === 'arweave' || p === '0') targetProtocol = 0;

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -41,6 +41,7 @@ import type {
   ARIOWrite,
   EpochInput,
   FundFrom,
+  ArNSBuyAntState,
   GetCostDetailsParams,
   PaginationParams,
   RedelegateStakeParams,
@@ -736,6 +737,43 @@ export function requiredPositiveIntegerFromOptions<O extends GlobalCLIOptions>(
  * `--keywords`, `--logo`, `--target` for the @ record tx id) onto the Solana
  * `InitializeAntParams` payload.
  */
+/**
+ * Assemble the optional `antState` for an atomic `buyRecord` from CLI options.
+ * Mirrors the spawn-ant mapping (`--target`/`--transaction-id` → the `@`
+ * record's tx id). Returns `undefined` when no metadata flags were supplied so
+ * a plain buy stays plain. `--ttl-seconds` is intentionally NOT mapped here:
+ * the mint `initialize` instruction has no TTL field, so TTL must be set with a
+ * post-buy `setBaseNameRecord`.
+ */
+export function buyAntStateFromOptions(o: {
+  target?: string;
+  transactionId?: string;
+  ticker?: string;
+  description?: string;
+  keywords?: string[];
+  logo?: string;
+  targetProtocol?: string;
+}): ArNSBuyAntState | undefined {
+  let targetProtocol: number | undefined;
+  if (o.targetProtocol !== undefined) {
+    const p = o.targetProtocol.toLowerCase();
+    if (p === 'arweave' || p === '0') targetProtocol = 0;
+    else if (p === 'ipfs' || p === '1') targetProtocol = 1;
+    else throw new Error('--target-protocol must be "arweave" or "ipfs"');
+  }
+
+  const state: ArNSBuyAntState = {};
+  const target = o.target ?? o.transactionId;
+  if (target !== undefined) state.transactionId = target;
+  if (o.ticker !== undefined) state.ticker = o.ticker;
+  if (o.description !== undefined) state.description = o.description;
+  if (o.keywords !== undefined) state.keywords = o.keywords;
+  if (o.logo !== undefined) state.logo = o.logo;
+  if (targetProtocol !== undefined) state.targetProtocol = targetProtocol;
+
+  return Object.keys(state).length > 0 ? state : undefined;
+}
+
 export async function spawnSolanaANTFromOptions(
   options: ANTStateCLIOptions,
 ): Promise<import('../solana/spawn-ant.js').SpawnSolanaANTResult> {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -173,6 +173,9 @@ export function readARIOFromOptions(options: GlobalCLIOptions): ARIORead {
     ...(options.arnsProgramId
       ? { arnsProgramId: address(options.arnsProgramId) }
       : {}),
+    ...(options.antProgramId
+      ? { antProgramId: address(options.antProgramId) }
+      : {}),
   });
 }
 
@@ -271,6 +274,11 @@ export async function writeARIOFromOptions(options: GlobalCLIOptions): Promise<{
         : {}),
       ...(options.arnsProgramId
         ? { arnsProgramId: address(options.arnsProgramId) }
+        : {}),
+      // Without this, buyRecord's atomic ANT spawn targets the mainnet ANT
+      // program default and fails with ProgramAccountNotFound on devnet/localnet.
+      ...(options.antProgramId
+        ? { antProgramId: address(options.antProgramId) }
         : {}),
     }),
     signerAddress: signer.address as string,

--- a/src/solana/io-writeable.localnet.test.ts
+++ b/src/solana/io-writeable.localnet.test.ts
@@ -400,6 +400,58 @@ describe(
       );
     });
 
+    it('buyRecord with antState bakes the @ target + metadata into the spawned ANT', async () => {
+      // The atomic buy should mint an ANT whose `@` record already points at the
+      // caller-supplied target (not the default AR.IO logo) and carries the
+      // supplied ticker/description/keywords — all in the single buy tx.
+      const buyer = await freshSigner(scratch, 'antstate-buy');
+      await airdrop(buyer.keypairPath, 5);
+      mintArio(buyer.signer.address, 100_000_000_000n); // 100k ARIO
+
+      const buyerArio = buildArio(buyer.signer, RPC_URL!, WS_URL!);
+      const name = 'antstate' + Date.now().toString(36).slice(-6);
+      const target = 'b'.repeat(43); // valid 43-char Arweave-id shape, non-default
+
+      const result = await buyerArio.buyRecord({
+        name,
+        type: 'lease',
+        years: 1,
+        antState: {
+          transactionId: target,
+          ticker: 'E2E',
+          description: 'atomic buy metadata',
+          keywords: ['e2e', 'atomic'],
+        },
+      });
+      const spawnedProcessId = result.result?.processId as string | undefined;
+      assert.ok(spawnedProcessId, 'buyRecord must surface the spawned ANT');
+
+      const rpc = createSolanaRpc(RPC_URL!);
+      const antReader = await ANT.init({
+        rpc,
+        processId: spawnedProcessId!,
+        antProgramId: address(ANT_ID!),
+      });
+      const state = await antReader.getState();
+
+      // The @ record resolves to the supplied target — the headline win.
+      assert.equal(
+        state.Records['@']?.transactionId,
+        target,
+        '@ record must point at the supplied antState.transactionId',
+      );
+      assert.equal(state.Ticker, 'E2E', 'ticker must be set from antState');
+      assert.equal(
+        state.Description,
+        'atomic buy metadata',
+        'description must be set from antState',
+      );
+      assert.ok(
+        state.Keywords.includes('e2e') && state.Keywords.includes('atomic'),
+        'keywords must be set from antState',
+      );
+    });
+
     it('buyRecord({ fundFrom: "stakes", fundAsOperator: false }) deducts from delegation', async () => {
       // Fresh delegator signer
       const delegator = await freshSigner(scratch, 'delegator');

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -246,7 +246,10 @@ import {
   sendAndConfirm,
   sendWithEphemeralLookupTable,
 } from './send.js';
-import { buildSpawnAntInstructions } from './spawn-ant.js';
+import {
+  buildSpawnAntInstructions,
+  validateSpawnAntState,
+} from './spawn-ant.js';
 import type {
   SolanaRpcSubscriptions,
   SolanaSigner,
@@ -1509,15 +1512,25 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     let mintSigner: KeyPairSigner | undefined;
     let antPubkey: Address;
     if (params.processId === undefined) {
+      // Fold optional caller-supplied metadata + `@` target into the freshly
+      // minted ANT so a name can resolve to real content in the SAME buy tx.
+      // Validated up front for a clean error instead of an on-chain revert.
+      validateSpawnAntState(params.antState);
       const spawn = await buildSpawnAntInstructions({
         signer: this.signer,
-        state: { name: params.name },
+        state: { name: params.name, ...params.antState },
         antProgramId: this.antProgram,
       });
       spawnIxs = spawn.instructions;
       mintSigner = spawn.mintSigner;
       antPubkey = spawn.mint;
     } else {
+      if (params.antState !== undefined) {
+        this.logger.warn(
+          '[buyRecord] antState is ignored when buying to an existing ANT ' +
+            '(processId set); set metadata via the ANT writeable instead.',
+        );
+      }
       antPubkey = address(params.processId);
     }
 

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -1518,7 +1518,18 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       validateSpawnAntState(params.antState);
       const spawn = await buildSpawnAntInstructions({
         signer: this.signer,
-        state: { name: params.name, ...params.antState },
+        // Whitelist only the supported metadata fields — never spread
+        // `antState` wholesale, so a stray `name`/`uri` can't override the
+        // purchased name or bypass URI derivation at runtime.
+        state: {
+          name: params.name,
+          ticker: params.antState?.ticker,
+          description: params.antState?.description,
+          keywords: params.antState?.keywords,
+          logo: params.antState?.logo,
+          transactionId: params.antState?.transactionId,
+          targetProtocol: params.antState?.targetProtocol,
+        },
         antProgramId: this.antProgram,
       });
       spawnIxs = spawn.instructions;

--- a/src/solana/spawn-ant-state.test.ts
+++ b/src/solana/spawn-ant-state.test.ts
@@ -82,6 +82,19 @@ describe('validateSpawnAntState', () => {
     // Empty target is treated as unset.
     assert.doesNotThrow(() => validateSpawnAntState({ transactionId: '' }));
   });
+
+  it('rejects a targetProtocol other than 0 or 1', () => {
+    // The runtime guard must reject out-of-range values arriving from untyped
+    // callers (CLI / JSON), even though the public `ArNSBuyAntState` is 0 | 1.
+    for (const bad of [2, -1, Number.NaN]) {
+      assert.throws(
+        () => validateSpawnAntState({ targetProtocol: bad }),
+        /targetProtocol must be 0 \(Arweave\) or 1 \(IPFS\)/,
+      );
+    }
+    assert.doesNotThrow(() => validateSpawnAntState({ targetProtocol: 0 }));
+    assert.doesNotThrow(() => validateSpawnAntState({ targetProtocol: 1 }));
+  });
 });
 
 /**

--- a/src/solana/spawn-ant-state.test.ts
+++ b/src/solana/spawn-ant-state.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for `validateSpawnAntState` — the fast-fail guard for optional
+ * ANT metadata + `@` target supplied to an atomic `buyRecord` (or a spawn).
+ * Mirrors the on-chain `ario_ant::initialize` limits.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { validateSpawnAntState } from './spawn-ant.js';
+
+const TX = 'a'.repeat(43); // valid 43-char Arweave id shape
+
+describe('validateSpawnAntState', () => {
+  it('accepts undefined / empty state', () => {
+    assert.doesNotThrow(() => validateSpawnAntState(undefined));
+    assert.doesNotThrow(() => validateSpawnAntState({}));
+  });
+
+  it('accepts a fully-populated valid state', () => {
+    assert.doesNotThrow(() =>
+      validateSpawnAntState({
+        ticker: 'BLOG',
+        description: 'x'.repeat(512),
+        keywords: Array.from({ length: 16 }, (_, i) => `k${i}`),
+        logo: TX,
+        transactionId: TX,
+        targetProtocol: 0,
+      }),
+    );
+  });
+
+  it('rejects a description over 512 chars', () => {
+    assert.throws(
+      () => validateSpawnAntState({ description: 'x'.repeat(513) }),
+      /512 characters/,
+    );
+  });
+
+  it('rejects more than 16 keywords', () => {
+    assert.throws(
+      () =>
+        validateSpawnAntState({
+          keywords: Array.from({ length: 17 }, (_, i) => `k${i}`),
+        }),
+      /16 entries/,
+    );
+  });
+
+  it('rejects a malformed logo but allows an empty one', () => {
+    assert.throws(() => validateSpawnAntState({ logo: 'too-short' }), /logo/);
+    assert.doesNotThrow(() => validateSpawnAntState({ logo: '' }));
+    assert.doesNotThrow(() => validateSpawnAntState({ logo: TX }));
+  });
+
+  it('shape-checks the @ target only for an Arweave targetProtocol', () => {
+    // Arweave (0 / undefined) → must match the 43-char id shape.
+    assert.throws(
+      () => validateSpawnAntState({ transactionId: 'nope', targetProtocol: 0 }),
+      /@ target/,
+    );
+    assert.throws(
+      () => validateSpawnAntState({ transactionId: 'nope' }),
+      /@ target/,
+    );
+    // IPFS (1) → the target is a CID, so the Arweave shape check is skipped.
+    assert.doesNotThrow(() =>
+      validateSpawnAntState({
+        transactionId: 'QmSomeCidValue',
+        targetProtocol: 1,
+      }),
+    );
+    // Empty target is treated as unset.
+    assert.doesNotThrow(() => validateSpawnAntState({ transactionId: '' }));
+  });
+});

--- a/src/solana/spawn-ant-state.test.ts
+++ b/src/solana/spawn-ant-state.test.ts
@@ -6,9 +6,19 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { validateSpawnAntState } from './spawn-ant.js';
+import { generateKeyPairSigner } from '@solana/kit';
+
+import {
+  buildSpawnAntInstructions,
+  DEFAULT_ANT_TRANSACTION_ID,
+  validateSpawnAntState,
+} from './spawn-ant.js';
 
 const TX = 'a'.repeat(43); // valid 43-char Arweave id shape
+
+const utf8Hex = (s: string) => Buffer.from(s, 'utf8').toString('hex');
+const ixHex = (data: unknown) =>
+  Buffer.from(data as Uint8Array).toString('hex');
 
 describe('validateSpawnAntState', () => {
   it('accepts undefined / empty state', () => {
@@ -71,5 +81,69 @@ describe('validateSpawnAntState', () => {
     );
     // Empty target is treated as unset.
     assert.doesNotThrow(() => validateSpawnAntState({ transactionId: '' }));
+  });
+});
+
+/**
+ * Proves that metadata supplied at buy/spawn time is actually forwarded into
+ * the on-chain `ario_ant::initialize` instruction (the second instruction the
+ * spawn builder emits). `buyRecord` passes `{ name, ...antState }` straight into
+ * `buildSpawnAntInstructions`, so this covers the end-to-end threading: if the
+ * spawn stopped forwarding a field, or `buyRecord` stopped spreading `antState`,
+ * the encoded bytes would no longer contain these values.
+ */
+describe('buildSpawnAntInstructions threads metadata into initialize', () => {
+  const MARKER_TARGET = 'b'.repeat(43);
+  const MARKER_DESC = 'ZZUNIQUEDESCRIPTIONMARKER';
+  const MARKER_KEYWORD = 'ZZUNIQUEKEYWORD';
+  const MARKER_TICKER = 'ZZTICK';
+
+  it('encodes the supplied @ target, ticker, description, and keywords', async () => {
+    const signer = await generateKeyPairSigner();
+    const { instructions } = await buildSpawnAntInstructions({
+      signer,
+      state: {
+        name: 'threading-test',
+        ticker: MARKER_TICKER,
+        description: MARKER_DESC,
+        keywords: [MARKER_KEYWORD],
+        transactionId: MARKER_TARGET,
+      },
+    });
+    // [0] = CreateV1 (MPL Core), [1] = ario_ant::initialize.
+    const initData = ixHex(instructions[1]!.data);
+    assert.ok(
+      initData.includes(utf8Hex(MARKER_TARGET)),
+      'target not forwarded',
+    );
+    assert.ok(
+      initData.includes(utf8Hex(MARKER_TICKER)),
+      'ticker not forwarded',
+    );
+    assert.ok(
+      initData.includes(utf8Hex(MARKER_DESC)),
+      'description not forwarded',
+    );
+    assert.ok(
+      initData.includes(utf8Hex(MARKER_KEYWORD)),
+      'keyword not forwarded',
+    );
+  });
+
+  it('falls back to the default target when none is supplied', async () => {
+    const signer = await generateKeyPairSigner();
+    const { instructions } = await buildSpawnAntInstructions({
+      signer,
+      state: { name: 'threading-test' },
+    });
+    const initData = ixHex(instructions[1]!.data);
+    assert.ok(
+      initData.includes(utf8Hex(DEFAULT_ANT_TRANSACTION_ID)),
+      'default target not used',
+    );
+    assert.ok(
+      !initData.includes(utf8Hex(MARKER_DESC)),
+      'unexpected description bytes',
+    );
   });
 });

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -60,6 +60,7 @@ import {
   getSetComputeUnitLimitInstruction,
   getSetComputeUnitPriceInstruction,
 } from '@solana-program/compute-budget';
+import { ARWEAVE_TX_REGEX } from '../constants.js';
 import { SolanaANTRegistryWriteable } from './ant-registry-writeable.js';
 import { ARIO_ANT_PROGRAM_ID } from './constants.js';
 import { getAntRecordPDA } from './pda.js';
@@ -113,6 +114,56 @@ export type SpawnSolanaANTState = {
    */
   uri?: string;
 };
+
+/** The optional metadata subset of {@link SpawnSolanaANTState} to validate. */
+type ValidatableAntState = Partial<
+  Pick<
+    SpawnSolanaANTState,
+    | 'ticker'
+    | 'description'
+    | 'keywords'
+    | 'logo'
+    | 'transactionId'
+    | 'targetProtocol'
+  >
+>;
+
+/**
+ * Fast-fail validation of optional ANT initial state before an atomic buy /
+ * spawn. Mirrors the on-chain `ario_ant::initialize` limits so callers get a
+ * clear, actionable error instead of an opaque program revert. Only provided
+ * fields are checked; empty strings are treated as "unset". The `@` target is
+ * only shape-checked as an Arweave TX ID when `targetProtocol` is Arweave (0 /
+ * undefined) — for IPFS (1) the target is a CID, not an Arweave id.
+ */
+export function validateSpawnAntState(state?: ValidatableAntState): void {
+  if (!state) return;
+  if (state.description !== undefined && state.description.length > 512) {
+    throw new Error('ANT description must be 512 characters or fewer');
+  }
+  if (state.keywords !== undefined && state.keywords.length > 16) {
+    throw new Error('ANT keywords must be 16 entries or fewer');
+  }
+  if (
+    state.logo !== undefined &&
+    state.logo.length > 0 &&
+    !ARWEAVE_TX_REGEX.test(state.logo)
+  ) {
+    throw new Error('ANT logo must be a 43-character Arweave transaction ID');
+  }
+  const targetIsArweave =
+    state.targetProtocol === undefined || state.targetProtocol === 0;
+  if (
+    state.transactionId !== undefined &&
+    state.transactionId.length > 0 &&
+    targetIsArweave &&
+    !ARWEAVE_TX_REGEX.test(state.transactionId)
+  ) {
+    throw new Error(
+      'ANT base @ target must be a 43-character Arweave transaction ID',
+    );
+  }
+}
 
 export type SpawnSolanaANTParams = {
   /** RPC client used to fetch a recent blockhash + send the spawn transaction. */

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -151,6 +151,13 @@ export function validateSpawnAntState(state?: ValidatableAntState): void {
   ) {
     throw new Error('ANT logo must be a 43-character Arweave transaction ID');
   }
+  if (
+    state.targetProtocol !== undefined &&
+    state.targetProtocol !== 0 &&
+    state.targetProtocol !== 1
+  ) {
+    throw new Error('ANT targetProtocol must be 0 (Arweave) or 1 (IPFS)');
+  }
   const targetIsArweave =
     state.targetProtocol === undefined || state.targetProtocol === 0;
   if (

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -672,7 +672,7 @@ export type ArNSBuyAntState = {
   /** Base `@` record target — Arweave TX id (or IPFS CID when targetProtocol=1). */
   transactionId?: string;
   /** Storage protocol for the `@` target: 0 = Arweave (default), 1 = IPFS. */
-  targetProtocol?: number;
+  targetProtocol?: 0 | 1;
 };
 
 export type BuyRecordParams = ArNSPurchaseParams & {

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -649,10 +649,38 @@ export type ArNSPurchaseParams = ArNSNameParams & {
   referrer?: string;
 };
 
+/**
+ * Optional ANT metadata + base `@` target baked into an ATOMIC name buy — i.e.
+ * when `processId` is omitted and the SDK mints a fresh user-owned ANT in the
+ * same transaction. Ignored (with a warning) when buying to an existing ANT via
+ * `processId`; set metadata on that ANT via the ANT writeable instead.
+ *
+ * A backend-neutral subset of the Solana spawn state. `name` is omitted (it is
+ * always the bought name) and `uri` is derived. Note the base `@` target sets at
+ * mint, but its TTL cannot — `initialize` has no TTL field, so a non-default TTL
+ * still needs a post-buy `setBaseNameRecord`. Solana backend only today.
+ */
+export type ArNSBuyAntState = {
+  /** ANT ticker (defaults to "ANT" on chain). */
+  ticker?: string;
+  /** Description (≤ 512 chars). */
+  description?: string;
+  /** Keywords (≤ 16 entries). */
+  keywords?: string[];
+  /** Logo Arweave TX id (43 chars). */
+  logo?: string;
+  /** Base `@` record target — Arweave TX id (or IPFS CID when targetProtocol=1). */
+  transactionId?: string;
+  /** Storage protocol for the `@` target: 0 = Arweave (default), 1 = IPFS. */
+  targetProtocol?: number;
+};
+
 export type BuyRecordParams = ArNSPurchaseParams & {
   years?: number;
   type: 'lease' | 'permabuy';
   processId?: string;
+  /** Initial ANT metadata + `@` target for an atomic buy (no `processId`). */
+  antState?: ArNSBuyAntState;
 };
 
 export type ExtendLeaseParams = ArNSPurchaseParams & {


### PR DESCRIPTION
## Motivation

When `buyRecord` mints a fresh ANT (no `processId` — the atomic Solana path), it hardcodes the ANT's initial state to **name-only**. So a newly bought name always resolves to the default AR.IO logo until the buyer sends a *separate* `setBaseNameRecord` (and separate metadata writes), each an extra transaction/signature.

The spawn machinery already forwards `ticker` / `target` / `targetProtocol` / `logo` / `description` / `keywords` into the single `initialize` instruction (`buildSpawnAntInstructions` → `buildInitializeAntIx`) — it just wasn't exposed through `buyRecord`. This lets a consumer register a name **and point it at real content + set metadata in one signature**.

## Changes

- Add optional `antState?: ArNSBuyAntState` to `BuyRecordParams` — a backend-neutral subset of `SpawnSolanaANTState` (`name` omitted since it's always the bought name; `uri` derived).
- Thread it into the atomic mint: `state: { name, ...params.antState }`. When `processId` **is** set (buying to an existing ANT), `antState` is ignored with a `logger.warn`.
- Add `validateSpawnAntState` (exported, pure) mirroring the on-chain `ario_ant::initialize` limits — description ≤ 512, keywords ≤ 16, 43-char Arweave-id shape for `logo` and for the `@` target when `targetProtocol` is Arweave (skipped for IPFS CIDs). Called before the spawn so callers get a clear error instead of an opaque revert.

## Caveats (documented in the type)

- **TTL can't be set at mint** — `initialize` has no TTL field, so the `@` target sets atomically but a *non-default* TTL still needs a post-buy `setBaseNameRecord`.
- **Large `description` + many `keywords` can exceed the 1232-byte tx limit.** The ALT fallback compresses *accounts*, not *instruction data*, so consumers should keep long text on the post-buy path; the resolution-critical small fields (`transactionId`, `ticker`, `logo`) fit comfortably.

## Tests

- New `src/solana/spawn-ant-state.test.ts` covers `validateSpawnAntState` (limits, empty-as-unset, Arweave-vs-IPFS target).
- Existing spawn `CreateV1` byte-pin fixtures unchanged.
- `yarn test:unit`: 418 pass / 0 fail locally.

## Consumer

ar.io Console will pass `antState` from `buyRecord` to collapse today's N-signature post-buy metadata sequence into the single buy signature (base `@` target being the highest-value field).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for including optional ANT metadata and base target configuration when purchasing an atomic name.
  * Added validation for metadata limits, logo formats, and protocol-specific transaction IDs.
  * Supports different transaction ID validation rules for Arweave and IPFS targets.

* **Bug Fixes**
  * Prevented invalid ANT metadata from being used during purchases.
  * Clarified behavior when metadata is supplied while purchasing to an existing ANT.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->