### PR TITLE
feat(crank): drive the full ArNS lease lifecycle from crankEpochStep

### DIFF
--- a/src/solana/crank-epoch-step.test.ts
+++ b/src/solana/crank-epoch-step.test.ts
@@ -186,6 +186,41 @@ class TestCranker extends SolanaARIOWriteable {
     this.calls.push(`pruneReturned:${p.returnedNames.length}`);
     return { id: 'tx-prune-returned' };
   }
+
+  // --- ArNS lifecycle steps: leases past grace (→ auction) and leases past
+  // grace+auction (→ closed directly). Both default empty so every pre-existing
+  // test keeps its old behaviour. ---
+  pruneableToReturned: Array<{
+    pubkey: Address;
+    name: string;
+    endTimestamp: bigint;
+  }> = [];
+  // biome-ignore lint/suspicious/noExplicitAny: test stubs
+  async getPruneableToReturnedRecords(): Promise<any> {
+    this.calls.push('getPruneableToReturned');
+    return this.pruneableToReturned;
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: test stubs
+  async pruneNameToReturned(p: any): Promise<any> {
+    this.calls.push(`pruneToReturned:${p.name}`);
+    return { id: 'tx-prune-to-returned' };
+  }
+
+  expiredArns: Array<{
+    pubkey: Address;
+    name: string;
+    endTimestamp: bigint;
+  }> = [];
+  // biome-ignore lint/suspicious/noExplicitAny: test stubs
+  async getExpiredArnsRecords(): Promise<any> {
+    this.calls.push('getExpiredArns');
+    return this.expiredArns;
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: test stubs
+  async pruneExpiredNames(p: any): Promise<any> {
+    this.calls.push(`pruneExpired:${p.arnsRecords.length}`);
+    return { id: 'tx-prune-expired' };
+  }
 }
 
 const baseSettings: Settings = {
@@ -732,5 +767,177 @@ describe('filterLiveObservations (stale getProgramAccounts ghost guard)', () => 
     const h = new LiveFilterHarness(rpc as never);
     assert.deepEqual(await h.run(5, []), []);
     assert.equal(called, false, 'empty candidate set must not hit the RPC');
+  });
+});
+
+describe('crankEpochStep — ArNS lease lifecycle (prune_name_to_returned / prune_expired_names)', () => {
+  const leases = (n: number, tag = 40) =>
+    Array.from({ length: n }, (_, i) => ({
+      pubkey: pk(tag + i),
+      name: `lease${i}`,
+      endTimestamp: 0n,
+    }));
+  const returned = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      pubkey: pk(20 + i),
+      name: `ret${i}`,
+      returnedAt: 0n,
+    }));
+
+  // Live epoch parked in the observation window — the dominant idle state.
+  const liveWaiting = (c: TestCranker) => {
+    c.settings = { ...baseSettings };
+    c.epochs[0] = { ...liveEpoch, rewardsDistributed: 0, endTimestamp: 9999 };
+  };
+  // Fully-distributed epoch, before the next one is due — the tail window.
+  const tail = (c: TestCranker) => {
+    c.settings = { ...baseSettings, currentEpochIndex: 3 };
+    c.epochs[2] = { ...liveEpoch, endTimestamp: 1000 };
+    c.compoundable = [];
+    c.dfPeriod = { currentPeriod: 2, periodZeroStartTimestamp: 0 };
+  };
+
+  it('converts a past-grace lease into a returned-name auction', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(3);
+    const r = await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
+    assert.equal(r.action, 'prune_name_to_returned');
+    assert.equal(r.txId, 'tx-prune-to-returned');
+    // one name per tx — the instruction takes a single record
+    assert.deepEqual(r.progress, { index: 1, total: 3 });
+    assert.ok(c.calls.includes('pruneToReturned:lease0'));
+  });
+
+  it('prioritises prune_name_to_returned over both cleanup steps', async () => {
+    // All three have work. The to-returned step is the only time-sensitive one:
+    // miss the auction window and the auction is lost permanently.
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(1);
+    c.expiredReturned = returned(5);
+    c.expiredArns = leases(5, 60);
+    const r = await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
+    assert.equal(r.action, 'prune_name_to_returned');
+    assert.ok(!c.calls.some((x) => x.startsWith('pruneReturned')));
+    assert.ok(!c.calls.some((x) => x.startsWith('pruneExpired')));
+  });
+
+  it('closes past-auction leases once the earlier steps have nothing to do', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = [];
+    c.expiredReturned = [];
+    c.expiredArns = leases(4, 60);
+    const r = await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
+    assert.equal(r.action, 'prune_expired_names');
+    assert.equal(r.txId, 'tx-prune-expired');
+    assert.deepEqual(r.progress, { index: 4, total: 4 });
+    assert.ok(c.calls.includes('pruneExpired:4'));
+  });
+
+  it('caps the expired-name batch at 26 (the 1232-byte tx ceiling)', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.expiredArns = leases(100, 60);
+    const r = await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
+    assert.equal(r.action, 'prune_expired_names');
+    assert.deepEqual(r.progress, { index: 26, total: 100 });
+    assert.ok(c.calls.includes('pruneExpired:26'));
+  });
+
+  it('honours a smaller pruneExpiredBatchSize but never exceeds 26', async () => {
+    const small = new TestCranker();
+    liveWaiting(small);
+    small.expiredArns = leases(100, 60);
+    const r1 = await small.crankEpochStep({
+      now: 5000,
+      pruneScanIntervalMs: 0,
+      pruneExpiredBatchSize: 5,
+    });
+    assert.deepEqual(r1.progress, { index: 5, total: 100 });
+
+    const big = new TestCranker();
+    liveWaiting(big);
+    big.expiredArns = leases(100, 60);
+    const r2 = await big.crankEpochStep({
+      now: 5000,
+      pruneScanIntervalMs: 0,
+      pruneExpiredBatchSize: 250, // oversized caller value must be clamped
+    });
+    assert.deepEqual(r2.progress, { index: 26, total: 100 });
+  });
+
+  it('enablePruneToReturned:false leaves past-grace leases alone', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(3);
+    const r = await c.crankEpochStep({
+      now: 5000,
+      pruneScanIntervalMs: 0,
+      enablePruneToReturned: false,
+    });
+    assert.equal(r.action, 'idle');
+    assert.ok(!c.calls.some((x) => x.startsWith('pruneToReturned')));
+  });
+
+  it('enablePruneExpired:false leaves past-auction leases alone', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.expiredArns = leases(3, 60);
+    const r = await c.crankEpochStep({
+      now: 5000,
+      pruneScanIntervalMs: 0,
+      enablePruneExpired: false,
+    });
+    assert.equal(r.action, 'idle');
+    assert.ok(!c.calls.some((x) => x.startsWith('pruneExpired')));
+  });
+
+  it('throttles each scan independently so neither starves the other', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(1);
+    c.expiredArns = leases(3, 60);
+    // default 60s throttle: first call scans + converts
+    const r1 = await c.crankEpochStep({ now: 5000 });
+    assert.equal(r1.action, 'prune_name_to_returned');
+    const toReturnedScans = c.calls.filter(
+      (x) => x === 'getPruneableToReturned',
+    ).length;
+    // immediate second call → to-returned scan throttled; must not re-scan
+    const r2 = await c.crankEpochStep({ now: 5000 });
+    assert.equal(
+      c.calls.filter((x) => x === 'getPruneableToReturned').length,
+      toReturnedScans,
+      'throttled step must not re-scan within its window',
+    );
+    // ...while the expired step, on its own independent clock, is still free to
+    // run this tick. That independence is the whole point: the to-returned
+    // step's throttle must not starve the cleanup steps behind it.
+    assert.equal(r2.action, 'prune_expired_names');
+    // Third call: every scan is now inside its own window → genuinely idle.
+    const r3 = await c.crankEpochStep({ now: 5000 });
+    assert.equal(r3.action, 'idle');
+  });
+
+  it('also runs the lifecycle in the post-distribution tail', async () => {
+    const c = new TestCranker();
+    tail(c);
+    c.pruneableToReturned = leases(2);
+    const r = await c.crankEpochStep({ now: 1200, pruneScanIntervalMs: 0 });
+    assert.equal(r.action, 'prune_name_to_returned');
+    assert.ok(c.calls.includes('pruneToReturned:lease0'));
+  });
+
+  it('idles when the whole ArNS lifecycle is clear', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = [];
+    c.expiredReturned = [];
+    c.expiredArns = [];
+    const r = await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
+    assert.equal(r.action, 'idle');
+    assert.equal(r.reason, 'waiting_for_observations');
   });
 });

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -2892,6 +2892,58 @@ export class SolanaARIOReadable {
   }
 
   /**
+   * Enumerate ArnsRecord PDAs whose lease is past its grace period but whose
+   * return-auction window has NOT yet elapsed
+   * (`end_timestamp + grace_period <= now < end_timestamp + grace_period +
+   * return_auction_duration`) — i.e. the records `prune_name_to_returned`
+   * should convert into a Dutch auction.
+   *
+   * Deliberately excludes records past `grace + auction`: those missed their
+   * auction window entirely and belong to {@link getExpiredArnsRecords} /
+   * `prune_expired_names`, which closes them directly. Sending them here
+   * instead would mint them a *fresh* 50x-premium auction they are not
+   * entitled to. Permabuys (no `end_timestamp`) are excluded.
+   */
+  async getPruneableToReturnedRecords(
+    now: number,
+  ): Promise<Array<{ pubkey: Address; name: string; endTimestamp: bigint }>> {
+    const [arnsConfigPda] = await getArnsSettingsPDA(this.arnsProgram);
+    const cfgAccount = await this.getCachedAccount(arnsConfigPda);
+    if (!cfgAccount.exists) return [];
+    const cfg = getArnsConfigDecoder().decode(cfgAccount.data);
+    const grace = Number(cfg.gracePeriodSeconds);
+    const auction = Number(cfg.returnAuctionDurationSeconds);
+
+    const accounts = await this.getAccountsByDiscriminator(
+      this.arnsProgram,
+      ARNS_RECORD_DISCRIMINATOR,
+    );
+    const decoder = getArnsRecordDecoder();
+    const out: Array<{
+      pubkey: Address;
+      name: string;
+      endTimestamp: bigint;
+    }> = [];
+    for (const { pubkey, data } of accounts) {
+      try {
+        const r = decoder.decode(data);
+        if (r.endTimestamp.__option !== 'Some') continue;
+        const end = Number(r.endTimestamp.value);
+        if (end + grace <= now && now < end + grace + auction) {
+          out.push({
+            pubkey,
+            name: r.name,
+            endTimestamp: r.endTimestamp.value,
+          });
+        }
+      } catch {
+        // skip malformed
+      }
+    }
+    return out;
+  }
+
+  /**
    * Enumerate ReturnedName PDAs whose Dutch auction window has fully
    * elapsed (`returned_at + return_auction_duration <= now`).
    */

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -489,7 +489,9 @@ export type CrankAction =
   | 'distribute'
   | 'compound'
   | 'update_demand_factor'
+  | 'prune_name_to_returned'
   | 'prune_returned_names'
+  | 'prune_expired_names'
   | 'close_observation'
   | 'close'
   | 'idle';
@@ -547,6 +549,34 @@ export interface CrankEpochStepOptions {
    * crank poll rate. Default 60_000 (1 min). Set 0 to scan every step (tests).
    */
   pruneScanIntervalMs?: number;
+  /**
+   * Convert leases past their grace period into ReturnedName Dutch auctions
+   * (`prune_name_to_returned`) as part of the crank. Default true.
+   *
+   * Without this the ArNS lifecycle never advances: `prune_returned_names`
+   * only cleans up ReturnedName PDAs, and none can ever exist unless something
+   * creates them. Nobody else has an incentive to — `prune_to_returned` always
+   * sets `initiator = config`, so `buy_returned_name` pays 100% to the protocol
+   * and 0% to the caller. The cranker is the designated actor
+   * (`WORKFLOWS.md`: "Cranker — drive epoch pipeline, update demand factor,
+   * prune state | ario-gar, ario-arns").
+   *
+   * One name per tx — the instruction takes a single record, not a batch.
+   */
+  enablePruneToReturned?: boolean;
+  /**
+   * Directly close lease records that are past `grace + auction` — they missed
+   * their auction window, so `prune_expired_names` closes them without minting
+   * a fresh (unearned) auction. Default true. Batched like the returned-name
+   * step; rent refunds to the cranker, so this is net-positive on SOL.
+   */
+  enablePruneExpired?: boolean;
+  /**
+   * ArnsRecord PDAs to close per `prune_expired_names` tx. Default 26 — the
+   * measured ceiling before the 1232-byte tx limit is exceeded (26 → 1178 B,
+   * 28 → over). Capped at 26 internally.
+   */
+  pruneExpiredBatchSize?: number;
   /** Unix seconds; defaults to the wall clock. Injectable for testing. */
   now?: number;
 }
@@ -4329,6 +4359,8 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     const compoundMinPending = opts.compoundMinPendingRewards ?? 0;
     const enableDemandFactorRoll = opts.enableDemandFactorRoll ?? true;
     const enablePrune = opts.enablePrune ?? true;
+    const enablePruneToReturned = opts.enablePruneToReturned ?? true;
+    const enablePruneExpired = opts.enablePruneExpired ?? true;
     const now = opts.now ?? Math.floor(Date.now() / 1000);
 
     const settings = await this.getEpochSettingsFull();
@@ -4401,10 +4433,12 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     // observe → distribution never advances → the post-distribution tail below
     // is never reached).
     if (now < epoch.endTimestamp) {
-      if (enablePrune) {
-        const pruned = await this.maybePruneReturnedNamesStep(opts, now);
-        if (pruned) return pruned;
-      }
+      const pruned = await this.maybeArnsLifecycleStep(opts, now, {
+        toReturned: enablePruneToReturned,
+        returned: enablePrune,
+        expired: enablePruneExpired,
+      });
+      if (pruned) return pruned;
       return { action: 'idle', reason: 'waiting_for_observations' };
     }
 
@@ -4504,8 +4538,12 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       const rolled = await this.maybeRollDemandFactorStep(now);
       if (rolled) return rolled;
     }
-    if (enablePrune) {
-      const pruned = await this.maybePruneReturnedNamesStep(opts, now);
+    {
+      const pruned = await this.maybeArnsLifecycleStep(opts, now, {
+        toReturned: enablePruneToReturned,
+        returned: enablePrune,
+        expired: enablePruneExpired,
+      });
       if (pruned) return pruned;
     }
 
@@ -4563,6 +4601,13 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
    *  getProgramAccounts scan below the crank poll rate. */
   private lastReturnedNamePruneScanMs = 0;
 
+  /** Wall-clock (ms) of the last prune-to-returned scan. Throttled separately
+   *  from the returned-name scan so one can't starve the other. */
+  private lastPruneToReturnedScanMs = 0;
+
+  /** Wall-clock (ms) of the last past-auction (direct close) prune scan. */
+  private lastPruneExpiredScanMs = 0;
+
   /**
    * One prune batch over ReturnedName PDAs whose 14-day auction window has
    * elapsed (≤ {@link CrankEpochStepOptions.pruneBatchSize} per tx), or `null`
@@ -4591,6 +4636,106 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     });
     return {
       action: 'prune_returned_names',
+      txId: id,
+      progress: { index: batch.length, total: expired.length },
+    };
+  }
+
+  /**
+   * The full ArNS lifecycle-maintenance sweep, run wherever the epoch pipeline
+   * is otherwise idle. Returns the first step that did work, or `null`.
+   *
+   * Order is load-bearing. `prune_name_to_returned` goes FIRST because it is
+   * the only time-sensitive step: a lease past its grace period must be
+   * converted while it is still inside its auction window, otherwise it ages
+   * into the past-auction band and gets closed directly — the protocol loses
+   * that Dutch auction (and its revenue) permanently. The two cleanup steps
+   * have no such deadline, so they yield to it.
+   */
+  private async maybeArnsLifecycleStep(
+    opts: CrankEpochStepOptions,
+    now: number,
+    flags: { toReturned: boolean; returned: boolean; expired: boolean },
+  ): Promise<CrankEpochStepResult | null> {
+    if (flags.toReturned) {
+      const r = await this.maybePruneToReturnedStep(opts, now);
+      if (r) return r;
+    }
+    if (flags.returned) {
+      const r = await this.maybePruneReturnedNamesStep(opts, now);
+      if (r) return r;
+    }
+    if (flags.expired) {
+      const r = await this.maybePruneExpiredNamesStep(opts, now);
+      if (r) return r;
+    }
+    return null;
+  }
+
+  /**
+   * Convert ONE lease that is past its grace period — but still inside its
+   * return-auction window — into a `ReturnedName` Dutch auction, or `null`
+   * when none are due / the scan is throttled.
+   *
+   * This is the step whose absence stalled the whole ArNS lifecycle: without
+   * it no ReturnedName PDA is ever created, so `prune_returned_names` drains a
+   * queue that is never filled and expired names keep resolving forever.
+   *
+   * One name per tx (the instruction takes a single record). Records past
+   * `grace + auction` are intentionally NOT handled here — see
+   * {@link maybePruneExpiredNamesStep}. The contract re-checks the grace
+   * window itself, so a skewed client clock is safe.
+   */
+  private async maybePruneToReturnedStep(
+    opts: CrankEpochStepOptions,
+    now: number,
+  ): Promise<CrankEpochStepResult | null> {
+    const scanInterval = opts.pruneScanIntervalMs ?? 60_000;
+    const wallNow = Date.now();
+    if (wallNow - this.lastPruneToReturnedScanMs < scanInterval) return null;
+    this.lastPruneToReturnedScanMs = wallNow;
+
+    const due = await this.getPruneableToReturnedRecords(now);
+    if (due.length === 0) return null;
+
+    const target = due[0];
+    const { id } = await this.pruneNameToReturned({ name: target.name });
+    return {
+      action: 'prune_name_to_returned',
+      txId: id,
+      progress: { index: 1, total: due.length },
+    };
+  }
+
+  /**
+   * One batch of `prune_expired_names` over lease records past
+   * `grace + auction`, or `null` when none are due / the scan is throttled.
+   *
+   * These missed their auction window entirely, so the contract closes them
+   * directly rather than minting a fresh 50x-premium auction. Closing returns
+   * the record's rent to the cranker, making this step net-positive on SOL.
+   */
+  private async maybePruneExpiredNamesStep(
+    opts: CrankEpochStepOptions,
+    now: number,
+  ): Promise<CrankEpochStepResult | null> {
+    const scanInterval = opts.pruneScanIntervalMs ?? 60_000;
+    const wallNow = Date.now();
+    if (wallNow - this.lastPruneExpiredScanMs < scanInterval) return null;
+    this.lastPruneExpiredScanMs = wallNow;
+
+    const expired = await this.getExpiredArnsRecords(now);
+    if (expired.length === 0) return null;
+
+    // 26 is the measured ceiling before the 1232-byte tx limit (26 -> 1178 B).
+    const batchSize = Math.min(opts.pruneExpiredBatchSize ?? 26, 26);
+    const batch = expired.slice(0, batchSize).map((r) => r.pubkey as string);
+    const { id } = await this.pruneExpiredNames({
+      maxNames: batch.length,
+      arnsRecords: batch,
+    });
+    return {
+      action: 'prune_expired_names',
       txId: id,
       progress: { index: batch.length, total: expired.length },
     };

--- a/src/solana/prune-to-returned-discovery.test.ts
+++ b/src/solana/prune-to-returned-discovery.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for `SolanaARIOReadable.getPruneableToReturnedRecords`.
+ *
+ * This helper selects a BAND, not a threshold: leases past their grace period
+ * but still inside their return-auction window. Both edges matter.
+ *
+ *   |<-- active -->|<-- grace 14d -->|<-- auction 14d -->|<-- past auction -->|
+ *                                    ^^^^^^^^^^^^^^^^^^^
+ *                                    only this band qualifies
+ *
+ * Getting the upper edge wrong is the expensive mistake: feeding a past-auction
+ * record to `prune_name_to_returned` mints it a *fresh* 50x-premium auction it
+ * is not entitled to, instead of closing it via `prune_expired_names`.
+ *
+ * Unlike the helpers in prune-discovery.test.ts, this one needs a two-step rpc
+ * dance (ArnsConfig fetch for grace/auction, then the record scan), so the stub
+ * below answers both getAccountInfo and getProgramAccounts.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { type Address } from '@solana/kit';
+
+import {
+  PurchaseType,
+  getArnsConfigEncoder,
+  getArnsRecordEncoder,
+} from '@ar.io/solana-contracts/arns';
+import { SolanaARIOReadable } from './io-readable.js';
+
+const PUBKEY_1 = 'GatewayAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as Address;
+const PUBKEY_2 = 'GatewayBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' as Address;
+const PUBKEY_3 = 'GatewayCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC' as Address;
+const OWNER = '11111111111111111111111111111111' as Address;
+
+const VERSION = { major: 1, minor: 0, patch: 0 };
+const DAY = 86_400;
+const GRACE = 14 * DAY;
+const AUCTION = 14 * DAY;
+
+function configBytes(): Uint8Array {
+  return getArnsConfigEncoder().encode({
+    authority: OWNER,
+    mint: OWNER,
+    treasury: OWNER,
+    gracePeriodSeconds: GRACE,
+    returnAuctionDurationSeconds: AUCTION,
+    maxLeaseLengthYears: 5,
+    totalNamesRegistered: 0,
+    nextRecordsPruneTimestamp: 0,
+    nextReturnedNamesPruneTimestamp: 0,
+    migrationActive: false,
+    migrationAuthority: OWNER,
+    bump: 255,
+    version: VERSION,
+  }) as Uint8Array;
+}
+
+/** A lease record ending at `end`, or a permabuy when `end` is null. */
+function recordBytes(name: string, end: number | null): Uint8Array {
+  return getArnsRecordEncoder().encode({
+    nameHash: new Uint8Array(32),
+    owner: OWNER,
+    ant: OWNER,
+    purchaseType: end === null ? PurchaseType.Permabuy : PurchaseType.Lease,
+    startTimestamp: 0,
+    endTimestamp: end === null ? null : end,
+    undernameLimit: 10,
+    purchasePrice: 0,
+    bump: 255,
+    name,
+    version: VERSION,
+  }) as Uint8Array;
+}
+
+/** Stub rpc answering the config fetch AND the record scan. */
+function stubRpc(rows: Array<{ pubkey: Address; bytes: Uint8Array }>): unknown {
+  const cfg = Buffer.from(configBytes()).toString('base64');
+  return {
+    getAccountInfo: () => ({
+      send: async () => ({
+        value: {
+          data: [cfg, 'base64'] as readonly [string, string],
+          executable: false,
+          lamports: 1_000_000n,
+          owner: OWNER,
+          rentEpoch: 0n,
+          space: BigInt(configBytes().length),
+        },
+      }),
+    }),
+    getProgramAccounts: () => ({
+      send: async () =>
+        rows.map(({ pubkey, bytes }) => ({
+          pubkey,
+          account: {
+            data: [
+              Buffer.from(bytes).toString('base64'),
+              'base64',
+            ] as readonly [string, string],
+          },
+        })),
+    }),
+  };
+}
+
+function reader(rows: Array<{ pubkey: Address; bytes: Uint8Array }>) {
+  return new SolanaARIOReadable({ rpc: stubRpc(rows) } as never);
+}
+
+describe('getPruneableToReturnedRecords — band selection', () => {
+  const NOW = 1_000_000_000;
+
+  it('includes a lease past grace but still inside the auction window', async () => {
+    // ended GRACE + 1 day ago → 13 days of auction window left
+    const end = NOW - GRACE - DAY;
+    const r = await reader([
+      { pubkey: PUBKEY_1, bytes: recordBytes('inband', end) },
+    ]).getPruneableToReturnedRecords(NOW);
+    assert.equal(r.length, 1);
+    assert.equal(r[0].name, 'inband');
+    assert.equal(r[0].pubkey, PUBKEY_1);
+  });
+
+  it('excludes a lease past grace+auction (belongs to prune_expired_names)', async () => {
+    // This is the expensive false positive: pruning it to returned would mint
+    // an unearned 50x auction instead of closing the record.
+    const end = NOW - GRACE - AUCTION - DAY;
+    const r = await reader([
+      { pubkey: PUBKEY_1, bytes: recordBytes('pastauction', end) },
+    ]).getPruneableToReturnedRecords(NOW);
+    assert.deepEqual(r, []);
+  });
+
+  it('excludes a lease still inside its grace period', async () => {
+    const end = NOW - DAY; // expired 1d ago, owner can still extend
+    const r = await reader([
+      { pubkey: PUBKEY_1, bytes: recordBytes('ingrace', end) },
+    ]).getPruneableToReturnedRecords(NOW);
+    assert.deepEqual(r, []);
+  });
+
+  it('excludes an active (unexpired) lease', async () => {
+    const r = await reader([
+      { pubkey: PUBKEY_1, bytes: recordBytes('active', NOW + 30 * DAY) },
+    ]).getPruneableToReturnedRecords(NOW);
+    assert.deepEqual(r, []);
+  });
+
+  it('excludes permabuy records, which never expire', async () => {
+    const r = await reader([
+      { pubkey: PUBKEY_1, bytes: recordBytes('permabuy', null) },
+    ]).getPruneableToReturnedRecords(NOW);
+    assert.deepEqual(r, []);
+  });
+
+  it('is inclusive at the grace edge and exclusive at the auction edge', async () => {
+    // exactly at end+grace  → eligible (end + grace <= now)
+    // exactly at end+grace+auction → NOT eligible (now < end + grace + auction)
+    const r = await reader([
+      { pubkey: PUBKEY_1, bytes: recordBytes('graceEdge', NOW - GRACE) },
+      {
+        pubkey: PUBKEY_2,
+        bytes: recordBytes('auctionEdge', NOW - GRACE - AUCTION),
+      },
+    ]).getPruneableToReturnedRecords(NOW);
+    assert.deepEqual(
+      r.map((x) => x.name),
+      ['graceEdge'],
+    );
+  });
+
+  it('returns every in-band record and skips undecodable rows', async () => {
+    const end = NOW - GRACE - DAY;
+    const r = await reader([
+      { pubkey: PUBKEY_1, bytes: recordBytes('a', end) },
+      { pubkey: PUBKEY_2, bytes: new Uint8Array([1, 2, 3]) }, // garbage
+      { pubkey: PUBKEY_3, bytes: recordBytes('b', end) },
+    ]).getPruneableToReturnedRecords(NOW);
+    assert.deepEqual(
+      r.map((x) => x.name),
+      ['a', 'b'],
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`crankEpochStep` only ever called `prune_returned_names`, which cleans up `ReturnedName` PDAs once their auction ends. Nothing ever *created* those PDAs — `prune_name_to_returned` is the instruction that converts an expired lease into a Dutch auction, and no actor calls it. The cranker was draining a queue that was never filled.

The consequence is that expired leases accumulate on-chain forever: still resolving through gateways, and impossible for anyone to re-buy.

Measured on mainnet ArNS (`2yCUx5edFvUrkibYaUa2ZXWyx9kuJkS8CwyzsgHPWdZZ`) before this change:

| | count |
|---|---|
| lease records | 2,469 |
| past `end_timestamp` | **601** |
| ├ within 14d grace (correct) | 210 |
| ├ past grace → should be in auction | **391** |
| └ past grace + auction | **343** |
| `ReturnedName` PDAs ever created | **0** |

Oldest was 78 days past expiry — 50 days past when its auction should have *ended*. An account-discriminator sweep confirms zero `ReturnedName` PDAs have ever existed, and decoding recent program transactions shows only `buy_name` / `update_demand_factor` / `extend_lease` / `upgrade_name` / `increase_undername_limit` — no prune instruction, ever.

## Why the cranker

No other actor has an incentive. `prune_to_returned` always sets `initiator = config`, so `buy_returned_name` routes **100% to the protocol and 0% to whoever triggered the auction**. `DECISIONS.md` justifies the permissionless/no-keeper-reward model with "gateway operators have self-interest in triggering reward distribution" — true for epochs, but nothing in ArNS pruning pays anyone. `WORKFLOWS.md` already assigns `prune state | ario-gar, ario-arns` to the Cranker; this implements it.

## Changes

- **`io-readable.ts`** — `getPruneableToReturnedRecords(now)` selects the band `end+grace <= now < end+grace+auction`. The upper edge is load-bearing: routing a past-auction record through `prune_name_to_returned` mints it an unearned 50x-premium auction instead of closing it.
- **`io-writeable.ts`** — adds `prune_name_to_returned` and `prune_expired_names` crank actions, and folds all three ArNS steps into one `maybeArnsLifecycleStep` helper called from **both** crank sites (observation window and post-distribution tail), replacing the duplicated single-step call.
- **Ordering** — `prune_name_to_returned` runs first. It is the only time-sensitive step: a lease that misses its auction window ages into the direct-close band and the protocol loses that auction permanently. We watched two names cross that line during this work.
- **Batching** — `prune_expired_names` batches at **26 records/tx**, the measured ceiling before the 1232-byte transaction limit (26 → 1178 B; 28 → over).
- Each step throttles its own scan independently so none can starve another. New opts `enablePruneToReturned` / `enablePruneExpired` / `pruneExpiredBatchSize` all default on, behind the existing enable flags.

## Testing

- **Full SDK unit suite: 429/429 pass** on this base, typecheck clean.
- 10 new tests in `crank-epoch-step.test.ts` — step ordering, priority over both cleanup steps, batch capping, per-step enable flags, independent throttling, post-distribution tail.
- New `prune-to-returned-discovery.test.ts` (7 tests) covering both band edges: inclusive at `end+grace`, exclusive at `end+grace+auction`, plus in-grace / active / permabuy exclusion and undecodable-row skipping.
- `ario-arns` Rust integration tests: **14/14 pass** (run in the `docker/Dockerfile` anchor-builder image).
- Lint: 43 problems before and after — zero introduced.

**Validated against mainnet.** `prune_expired_names` was simulated and then executed for real: 343 past-auction records closed across 14 transactions, 0 failures, verified independently by a `getProgramAccounts` sweep (3,547 → 3,204 records; past-grace+auction band 343 → 0; permabuy count unchanged at 1,078, confirming nothing was over-pruned). A pruned name's `buy_name` then simulates clean — the names became purchasable again, which is the user-visible point.

Not yet exercised against mainnet: the patched cranker driving `prune_name_to_returned` itself. That path is unit-tested and its instruction simulates clean (`err: null`, 50,144 CU, `Program log: Expired name 'opepins' pruned to returned name auction`), but has not been run through a live crank loop.

## Companion change

`ar-io-observer`'s `epoch-cranker.ts` needs to pass the three new opts (gated on the same `enableCleanup` config as the existing prune step) — 8 lines. Happy to open that PR alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjByJECE5DcTSjNLAUMcBc