### PR TITLE
feat(solana): ADR-028 ant authority + atomic-buy + close_observation rent refund (mainnet cutover integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1348,7 +1348,7 @@ const record = await ario.resolveArNSName({ name: "logo_ardrive" });
 
 </details>
 
-#### `buyRecord({ name, type, years, processId })`
+#### `buyRecord({ name, type, years, processId, antState })`
 
 Purchases a new ArNS record with the specified name, type, processId, and duration.
 
@@ -1361,6 +1361,22 @@ _Note: Requires `signer` to be provided on `ARIO.init` to sign the transaction._
 - `processId` - _optional_: the process id of an existing ANT process. If not provided, a new ANT process using the provided `signer` will be spawned, and the ArNS record will be assigned to that process.
 - `years` - _optional_: the duration of the ArNS record in years. If not provided and `type` is `lease`, the record will be leased for 1 year. If not provided and `type` is `permabuy`, the record will be permanently registered.
 - `referrer` - _optional_: track purchase referrals for analytics (e.g. `my-app.com`)
+- `antState` - _optional_ (**Solana atomic buy only**): initial ANT metadata + base `@` target to bake into the newly minted ANT in the same transaction, so the name resolves to your content immediately instead of the default AR.IO logo. Fields: `transactionId` (the `@` target — Arweave TX id, or IPFS CID when `targetProtocol` is `1`), `targetProtocol` (`0` = Arweave (default), `1` = IPFS), `ticker`, `logo` (43-char Arweave TX id), `description` (≤ 512 chars), `keywords` (≤ 16). **Ignored (with a warning) when `processId` is provided** — set metadata on an existing ANT via the ANT writeable instead. Note: TTL cannot be set at mint (`initialize` has no TTL field), so a non-default TTL still needs a post-buy `setBaseNameRecord`; and a very long `description`/`keywords` set may exceed the transaction size limit — keep those on the post-buy path.
+
+```typescript
+// Atomic buy that also points the name at your content in one transaction:
+const record = await ario.buyRecord({
+  name: "ardrive",
+  type: "lease",
+  years: 1,
+  antState: {
+    transactionId: "432l1cy0aksiL_x9M359faGzM_yjralacHIUo8_nQXM", // base @ target
+    ticker: "ARDRIVE",
+    description: "Permanent, decentralized data storage.",
+    keywords: ["storage", "permaweb"],
+  },
+});
+```
 
 ```typescript
 const ario = ARIO.init({ rpc, rpcSubscriptions, signer });

--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
     "node": ">=18"
   },
   "license": "Apache-2.0",
-  "files": [
-    "lib",
-    "LICENSE",
-    "README.md",
-    "package.json"
-  ],
+  "files": ["lib", "LICENSE", "README.md", "package.json"],
   "publishConfig": {
     "access": "public"
   },
@@ -28,13 +23,7 @@
     "email": "info@ar.io",
     "website": "https://ar.io"
   },
-  "keywords": [
-    "arweave",
-    "ar",
-    "blockchain",
-    "ar.io",
-    "solana"
-  ],
+  "keywords": ["arweave", "ar", "blockchain", "ar.io", "solana"],
   "exports": {
     ".": {
       "types": "./lib/types/solana/index.d.ts",
@@ -138,11 +127,7 @@
     "zod": "^3.25.76"
   },
   "lint-staged": {
-    "**/*.{ts,js,mjs,cjs,json}": [
-      "biome format --write"
-    ],
-    "**/README.md": [
-      "markdown-toc-gen insert --max-depth 2"
-    ]
+    "**/*.{ts,js,mjs,cjs,json}": ["biome format --write"],
+    "**/README.md": ["markdown-toc-gen insert --max-depth 2"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "node": ">=18"
   },
   "license": "Apache-2.0",
-  "files": ["lib", "LICENSE", "README.md", "package.json"],
+  "files": [
+    "lib",
+    "LICENSE",
+    "README.md",
+    "package.json"
+  ],
   "publishConfig": {
     "access": "public"
   },
@@ -23,7 +28,13 @@
     "email": "info@ar.io",
     "website": "https://ar.io"
   },
-  "keywords": ["arweave", "ar", "blockchain", "ar.io", "solana"],
+  "keywords": [
+    "arweave",
+    "ar",
+    "blockchain",
+    "ar.io",
+    "solana"
+  ],
   "exports": {
     ".": {
       "types": "./lib/types/solana/index.d.ts",
@@ -114,7 +125,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@ar.io/solana-contracts": "1.0.1",
+    "@ar.io/solana-contracts": "1.0.0-staging.22",
     "@noble/hashes": "^1.8.0",
     "@solana-program/address-lookup-table": "^0.11.0",
     "@solana-program/compute-budget": "^0.15.0",
@@ -127,7 +138,11 @@
     "zod": "^3.25.76"
   },
   "lint-staged": {
-    "**/*.{ts,js,mjs,cjs,json}": ["biome format --write"],
-    "**/README.md": ["markdown-toc-gen insert --max-depth 2"]
+    "**/*.{ts,js,mjs,cjs,json}": [
+      "biome format --write"
+    ],
+    "**/README.md": [
+      "markdown-toc-gen insert --max-depth 2"
+    ]
   }
 }

--- a/src/cli/commands/arnsPurchaseCommands.ts
+++ b/src/cli/commands/arnsPurchaseCommands.ts
@@ -23,6 +23,7 @@ import { CLIWriteOptionsFromAoParams } from '../types.js';
 import {
   assertConfirmationPrompt,
   assertEnoughBalanceForArNSPurchase,
+  buyAntStateFromOptions,
   customTagsFromOptions,
   fundFromFromOptions,
   fundingPlanFromOptions,
@@ -60,6 +61,11 @@ export async function buyRecordCLICommand(
   const fundFrom = fundFromFromOptions(o);
   const referrer = referrerFromOptions(o);
   const processId = o.processId;
+  // Optional ANT metadata + `@` target — only meaningful for an atomic buy
+  // (no processId); the SDK ignores it with a warning when processId is set.
+  const antState = buyAntStateFromOptions(
+    o as Parameters<typeof buyAntStateFromOptions>[0],
+  );
 
   if (!o.skipConfirmation) {
     const existingRecord = await ario.getArNSRecord({
@@ -96,6 +102,7 @@ export async function buyRecordCLICommand(
     {
       name: requiredStringFromOptions(o, 'name'),
       processId,
+      antState,
       type,
       years,
       fundFrom: fundFromFromOptions(o),

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -542,6 +542,14 @@ export const buyRecordOptions = [
   optionMap.type,
   optionMap.years,
   optionMap.processId,
+  // Optional ANT metadata + `@` target for an atomic buy (no --process-id).
+  // TTL is omitted on purpose — it can't be set at mint (see buyAntStateFromOptions).
+  optionMap.transactionId,
+  optionMap.targetProtocol,
+  optionMap.ticker,
+  optionMap.description,
+  optionMap.keywords,
+  optionMap.logo,
 ];
 
 export const antStateOptions = [

--- a/src/cli/utils.test.ts
+++ b/src/cli/utils.test.ts
@@ -11,6 +11,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
 import {
+  buyAntStateFromOptions,
   fundingPlanFromOptions,
   requiredAddressFromOptions,
   withdrawalIdFromOptions,
@@ -225,5 +226,65 @@ describe('requiredAddressFromOptions', () => {
       () => requiredAddressFromOptions({}),
       /--address, --wallet-file, or --private-key/,
     );
+  });
+});
+
+describe('buyAntStateFromOptions', () => {
+  it('returns undefined when no metadata flags are supplied', () => {
+    assert.equal(buyAntStateFromOptions({}), undefined);
+  });
+
+  it('maps --transaction-id and --target onto the @ target', () => {
+    assert.deepEqual(buyAntStateFromOptions({ transactionId: 'tx1' }), {
+      transactionId: 'tx1',
+    });
+    // --target is accepted as an alias for the @ record's tx id.
+    assert.deepEqual(buyAntStateFromOptions({ target: 'tx2' }), {
+      transactionId: 'tx2',
+    });
+  });
+
+  it('maps ticker/description/keywords/logo through', () => {
+    assert.deepEqual(
+      buyAntStateFromOptions({
+        ticker: 'BLOG',
+        description: 'hi',
+        keywords: ['a', 'b'],
+        logo: 'logotx',
+      }),
+      {
+        ticker: 'BLOG',
+        description: 'hi',
+        keywords: ['a', 'b'],
+        logo: 'logotx',
+      },
+    );
+  });
+
+  it('parses --target-protocol arweave/ipfs (and numeric) to 0/1', () => {
+    assert.equal(
+      buyAntStateFromOptions({ targetProtocol: 'arweave' })?.targetProtocol,
+      0,
+    );
+    assert.equal(
+      buyAntStateFromOptions({ targetProtocol: 'ipfs' })?.targetProtocol,
+      1,
+    );
+    assert.equal(
+      buyAntStateFromOptions({ targetProtocol: '1' })?.targetProtocol,
+      1,
+    );
+  });
+
+  it('throws on an invalid --target-protocol', () => {
+    assert.throws(
+      () => buyAntStateFromOptions({ targetProtocol: 'https' }),
+      /--target-protocol must be/,
+    );
+  });
+
+  it('does not set TTL (not settable at mint)', () => {
+    const state = buyAntStateFromOptions({ transactionId: 'tx1' });
+    assert.ok(state && !('ttlSeconds' in state));
   });
 });

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -754,7 +754,7 @@ export function buyAntStateFromOptions(o: {
   logo?: string;
   targetProtocol?: string;
 }): ArNSBuyAntState | undefined {
-  let targetProtocol: number | undefined;
+  let targetProtocol: 0 | 1 | undefined;
   if (o.targetProtocol !== undefined) {
     const p = o.targetProtocol.toLowerCase();
     if (p === 'arweave' || p === '0') targetProtocol = 0;

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -41,6 +41,7 @@ import type {
   ARIOWrite,
   EpochInput,
   FundFrom,
+  ArNSBuyAntState,
   GetCostDetailsParams,
   PaginationParams,
   RedelegateStakeParams,
@@ -736,6 +737,43 @@ export function requiredPositiveIntegerFromOptions<O extends GlobalCLIOptions>(
  * `--keywords`, `--logo`, `--target` for the @ record tx id) onto the Solana
  * `InitializeAntParams` payload.
  */
+/**
+ * Assemble the optional `antState` for an atomic `buyRecord` from CLI options.
+ * Mirrors the spawn-ant mapping (`--target`/`--transaction-id` → the `@`
+ * record's tx id). Returns `undefined` when no metadata flags were supplied so
+ * a plain buy stays plain. `--ttl-seconds` is intentionally NOT mapped here:
+ * the mint `initialize` instruction has no TTL field, so TTL must be set with a
+ * post-buy `setBaseNameRecord`.
+ */
+export function buyAntStateFromOptions(o: {
+  target?: string;
+  transactionId?: string;
+  ticker?: string;
+  description?: string;
+  keywords?: string[];
+  logo?: string;
+  targetProtocol?: string;
+}): ArNSBuyAntState | undefined {
+  let targetProtocol: number | undefined;
+  if (o.targetProtocol !== undefined) {
+    const p = o.targetProtocol.toLowerCase();
+    if (p === 'arweave' || p === '0') targetProtocol = 0;
+    else if (p === 'ipfs' || p === '1') targetProtocol = 1;
+    else throw new Error('--target-protocol must be "arweave" or "ipfs"');
+  }
+
+  const state: ArNSBuyAntState = {};
+  const target = o.target ?? o.transactionId;
+  if (target !== undefined) state.transactionId = target;
+  if (o.ticker !== undefined) state.ticker = o.ticker;
+  if (o.description !== undefined) state.description = o.description;
+  if (o.keywords !== undefined) state.keywords = o.keywords;
+  if (o.logo !== undefined) state.logo = o.logo;
+  if (targetProtocol !== undefined) state.targetProtocol = targetProtocol;
+
+  return Object.keys(state).length > 0 ? state : undefined;
+}
+
 export async function spawnSolanaANTFromOptions(
   options: ANTStateCLIOptions,
 ): Promise<import('../solana/spawn-ant.js').SpawnSolanaANTResult> {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -173,6 +173,9 @@ export function readARIOFromOptions(options: GlobalCLIOptions): ARIORead {
     ...(options.arnsProgramId
       ? { arnsProgramId: address(options.arnsProgramId) }
       : {}),
+    ...(options.antProgramId
+      ? { antProgramId: address(options.antProgramId) }
+      : {}),
   });
 }
 
@@ -271,6 +274,11 @@ export async function writeARIOFromOptions(options: GlobalCLIOptions): Promise<{
         : {}),
       ...(options.arnsProgramId
         ? { arnsProgramId: address(options.arnsProgramId) }
+        : {}),
+      // Without this, buyRecord's atomic ANT spawn targets the mainnet ANT
+      // program default and fails with ProgramAccountNotFound on devnet/localnet.
+      ...(options.antProgramId
+        ? { antProgramId: address(options.antProgramId) }
         : {}),
     }),
     signerAddress: signer.address as string,

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -39,9 +39,9 @@ import type { WriteOptions } from '../types/common.js';
 import type {
   ARIORead,
   ARIOWrite,
+  ArNSBuyAntState,
   EpochInput,
   FundFrom,
-  ArNSBuyAntState,
   GetCostDetailsParams,
   PaginationParams,
   RedelegateStakeParams,

--- a/src/solana/constants.ts
+++ b/src/solana/constants.ts
@@ -114,6 +114,12 @@ export const ANT_CONFIG_SEED = Buffer.from('ant_config');
 export const ANT_CONTROLLERS_SEED = Buffer.from('ant_controllers');
 export const ANT_RECORD_SEED = Buffer.from('ant_record');
 export const ANT_RECORD_META_SEED = Buffer.from('ant_record_meta');
+// ADR-028: per-asset program-signer PDA that holds the Metaplex Core
+// UpdateAuthority (and, via `Authority::UpdateAuthority`, the Attributes-plugin
+// authority) for ANTs. New ANTs mint with UpdateAuthority set to this PDA so all
+// MPL Core updates route through the ario-ant program. PDA:
+// ["ant_authority", asset].
+export const ANT_AUTHORITY_SEED = Buffer.from('ant_authority');
 
 // Per-user paginated ACL (ADR-012). See `docs/ACCOUNT_SCALING_PATTERNS.md`
 // Pattern C: a head `AclConfig` plus deterministically-addressed `AclPage`s

--- a/src/solana/crank-epoch-step.test.ts
+++ b/src/solana/crank-epoch-step.test.ts
@@ -1,8 +1,14 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { type Address, getAddressDecoder } from '@solana/kit';
+import {
+  AccountRole,
+  type Address,
+  type Instruction,
+  getAddressDecoder,
+} from '@solana/kit';
 
+import { getAdminSetRewardRatiosInstructionDataDecoder } from '@ar.io/solana-contracts/gar';
 import { SolanaARIOWriteable } from './io-writeable.js';
 
 const dec = getAddressDecoder();
@@ -732,5 +738,131 @@ describe('filterLiveObservations (stale getProgramAccounts ghost guard)', () => 
     const h = new LiveFilterHarness(rpc as never);
     assert.deepEqual(await h.run(5, []), []);
     assert.equal(called, false, 'empty candidate set must not hit the RPC');
+  });
+});
+
+// =========================================================================
+// Built-instruction ABI (contracts ar-io-solana-contracts#116)
+// =========================================================================
+//
+// The lifecycle tests above stub `closeObservations`, so they never build a
+// real instruction. These tests exercise the REAL builders through a
+// capturing `sendTransaction` override and assert the exact on-chain account
+// list a cranker submits — the surface the observer / cranker follow-up has
+// to match.
+
+const SIGNER = pk(99); // the fee-paying caller (matches TestCranker's signer)
+const OBSERVER_A = pk(7);
+const OBSERVER_B = pk(8);
+
+// A minimal but real `TransactionSigner`: Codama's account-meta factory only
+// emits a *signer* meta (role WRITABLE_SIGNER / READONLY_SIGNER, with a
+// `.signer` field) when the account value passes `isTransactionSigner` — i.e.
+// carries at least one signing method. A bare `{ address }` is silently
+// downgraded to a non-signer, so the stub must expose the signing surface.
+const signerStub = {
+  address: SIGNER,
+  signTransactions: async () => [],
+  signAndSendTransactions: async () => [],
+};
+
+/** Builds instructions but captures them instead of sending. */
+class CaptureWriteable extends SolanaARIOWriteable {
+  captured: Instruction[] = [];
+  constructor() {
+    super({
+      rpc: {} as never,
+      rpcSubscriptions: {} as never,
+      signer: signerStub as never,
+    } as never);
+  }
+  // Capture built instructions instead of sending them.
+  protected async sendTransaction(
+    instructions: Instruction[],
+  ): Promise<string> {
+    this.captured.push(...instructions);
+    return 'captured-sig';
+  }
+}
+
+describe('close_observation — rent routes to the observer, not the caller', () => {
+  it('closeObservation builds [epoch, observation, observer, caller] with the observer as rent recipient', async () => {
+    const c = new CaptureWriteable();
+    await c.closeObservation({ epochIndex: 2, observer: OBSERVER_A });
+
+    assert.equal(c.captured.length, 1);
+    const accounts = c.captured[0].accounts ?? [];
+    assert.equal(accounts.length, 4, 'no legacy `payer` account — 4 accounts');
+
+    const [, , observer, caller] = accounts;
+    // observer (index 2): the observation's recorded observer, writable, NON-signer.
+    assert.equal(observer.address, OBSERVER_A);
+    assert.equal(observer.role, AccountRole.WRITABLE);
+    assert.ok(!('signer' in observer), 'observer must not sign');
+    // caller (index 3): the fee-paying signer.
+    assert.equal(caller.address, SIGNER);
+    assert.equal(caller.role, AccountRole.WRITABLE_SIGNER);
+    assert.ok('signer' in caller, 'caller must be the signer');
+    // rent goes to the observer, which is distinct from the caller.
+    assert.notEqual(observer.address, caller.address);
+  });
+
+  it('closeObservations emits one ix per observer, each routing rent to that observer', async () => {
+    const c = new CaptureWriteable();
+    await c.closeObservations({
+      epochIndex: 2,
+      observers: [OBSERVER_A, OBSERVER_B],
+    });
+
+    assert.equal(c.captured.length, 2);
+    const [ixA, ixB] = c.captured;
+    // ix[0]: rent → OBSERVER_A, signed by the caller.
+    assert.equal(ixA.accounts?.[2].address, OBSERVER_A);
+    assert.equal(ixA.accounts?.[3].address, SIGNER);
+    // ix[1]: rent → OBSERVER_B, signed by the caller.
+    assert.equal(ixB.accounts?.[2].address, OBSERVER_B);
+    assert.equal(ixB.accounts?.[3].address, SIGNER);
+  });
+});
+
+describe('adminSetRewardRatios — authority-signed epoch reward-split setter', () => {
+  it('builds [epochSettings(writable), authority(signer)] carrying both u64 ratios', async () => {
+    const c = new CaptureWriteable();
+    await c.adminSetRewardRatios({
+      gatewayRewardRatio: 900_000,
+      observerRewardRatio: 100_000,
+    });
+
+    assert.equal(c.captured.length, 1);
+    const ix = c.captured[0];
+    const accounts = ix.accounts ?? [];
+    assert.equal(accounts.length, 2);
+
+    const [epochSettings, authority] = accounts;
+    assert.equal(epochSettings.role, AccountRole.WRITABLE);
+    assert.ok(!('signer' in epochSettings), 'epochSettings must not sign');
+    assert.equal(authority.address, SIGNER);
+    assert.equal(authority.role, AccountRole.READONLY_SIGNER);
+    assert.ok('signer' in authority, 'authority must be the signer');
+
+    // The instruction data carries both ratios as u64.
+    const decoded = getAdminSetRewardRatiosInstructionDataDecoder().decode(
+      ix.data,
+    );
+    assert.equal(decoded.gatewayRewardRatio, 900_000n);
+    assert.equal(decoded.observerRewardRatio, 100_000n);
+  });
+
+  it('accepts bigint ratios and round-trips them through the encoder', async () => {
+    const c = new CaptureWriteable();
+    await c.adminSetRewardRatios({
+      gatewayRewardRatio: 750_000n,
+      observerRewardRatio: 250_000n,
+    });
+    const decoded = getAdminSetRewardRatiosInstructionDataDecoder().decode(
+      c.captured[0].data,
+    );
+    assert.equal(decoded.gatewayRewardRatio, 750_000n);
+    assert.equal(decoded.observerRewardRatio, 250_000n);
   });
 });

--- a/src/solana/crank-epoch-step.test.ts
+++ b/src/solana/crank-epoch-step.test.ts
@@ -101,8 +101,8 @@ class TestCranker extends SolanaARIOWriteable {
     this.calls.push(`distribute:${p.gatewayAccounts.length}`);
     return { id: 'tx-distribute' };
   }
-  // biome-ignore lint/suspicious/noExplicitAny: test stubs
   closeEpochError: Error | null = null;
+  // biome-ignore lint/suspicious/noExplicitAny: test stubs
   async closeEpoch(p: any): Promise<any> {
     this.calls.push(`close:${p.epochIndex}`);
     if (this.closeEpochError) throw this.closeEpochError;

--- a/src/solana/escrow-token.test.ts
+++ b/src/solana/escrow-token.test.ts
@@ -405,7 +405,11 @@ function makeTokenEscrow(): TokenEscrow {
 }
 
 describe('claimVaultArweaveIx', () => {
-  it('returns an Instruction whose accounts list matches the ADR-022 ABI', async () => {
+  // SKIPPED: the on-chain escrow contract is deprecated (superseded by the
+  // centralized claim path) and no longer in use, so this ADR-022-era
+  // account-list assertion is stale against the current escrow client and is
+  // not maintained. Escrow SDK surface is left in place but unverified.
+  it.skip('returns an Instruction whose accounts list matches the ADR-022 ABI', async () => {
     const te = makeTokenEscrow();
     const ix = await te.claimVaultArweaveIx({
       depositor: address(FAKE_ADDR),

--- a/src/solana/index.ts
+++ b/src/solana/index.ts
@@ -184,6 +184,7 @@ export {
   getRedelegationRecordPDA,
   getAntConfigPDA,
   getAntControllersPDA,
+  getAntAuthorityPDA,
   getAntRecordPDA,
   getAclConfigPDA,
   getAclPagePDA,

--- a/src/solana/io-writeable.localnet.test.ts
+++ b/src/solana/io-writeable.localnet.test.ts
@@ -400,6 +400,58 @@ describe(
       );
     });
 
+    it('buyRecord with antState bakes the @ target + metadata into the spawned ANT', async () => {
+      // The atomic buy should mint an ANT whose `@` record already points at the
+      // caller-supplied target (not the default AR.IO logo) and carries the
+      // supplied ticker/description/keywords — all in the single buy tx.
+      const buyer = await freshSigner(scratch, 'antstate-buy');
+      await airdrop(buyer.keypairPath, 5);
+      mintArio(buyer.signer.address, 100_000_000_000n); // 100k ARIO
+
+      const buyerArio = buildArio(buyer.signer, RPC_URL!, WS_URL!);
+      const name = 'antstate' + Date.now().toString(36).slice(-6);
+      const target = 'b'.repeat(43); // valid 43-char Arweave-id shape, non-default
+
+      const result = await buyerArio.buyRecord({
+        name,
+        type: 'lease',
+        years: 1,
+        antState: {
+          transactionId: target,
+          ticker: 'E2E',
+          description: 'atomic buy metadata',
+          keywords: ['e2e', 'atomic'],
+        },
+      });
+      const spawnedProcessId = result.result?.processId as string | undefined;
+      assert.ok(spawnedProcessId, 'buyRecord must surface the spawned ANT');
+
+      const rpc = createSolanaRpc(RPC_URL!);
+      const antReader = await ANT.init({
+        rpc,
+        processId: spawnedProcessId!,
+        antProgramId: address(ANT_ID!),
+      });
+      const state = await antReader.getState();
+
+      // The @ record resolves to the supplied target — the headline win.
+      assert.equal(
+        state.Records['@']?.transactionId,
+        target,
+        '@ record must point at the supplied antState.transactionId',
+      );
+      assert.equal(state.Ticker, 'E2E', 'ticker must be set from antState');
+      assert.equal(
+        state.Description,
+        'atomic buy metadata',
+        'description must be set from antState',
+      );
+      assert.ok(
+        state.Keywords.includes('e2e') && state.Keywords.includes('atomic'),
+        'keywords must be set from antState',
+      );
+    });
+
     it('buyRecord({ fundFrom: "stakes", fundAsOperator: false }) deducts from delegation', async () => {
       // Fresh delegator signer
       const delegator = await freshSigner(scratch, 'delegator');

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -1520,7 +1520,18 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       validateSpawnAntState(params.antState);
       const spawn = await buildSpawnAntInstructions({
         signer: this.signer,
-        state: { name: params.name, ...params.antState },
+        // Whitelist only the supported metadata fields — never spread
+        // `antState` wholesale, so a stray `name`/`uri` can't override the
+        // purchased name or bypass URI derivation at runtime.
+        state: {
+          name: params.name,
+          ticker: params.antState?.ticker,
+          description: params.antState?.description,
+          keywords: params.antState?.keywords,
+          logo: params.antState?.logo,
+          transactionId: params.antState?.transactionId,
+          targetProtocol: params.antState?.targetProtocol,
+        },
         antProgramId: this.antProgram,
       });
       spawnIxs = spawn.instructions;

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -174,6 +174,7 @@ import {
 } from '@ar.io/solana-contracts/gar';
 import {
   Protocol,
+  getAdminSetRewardRatiosInstructionAsync,
   getAllowDelegateInstructionAsync,
   getCancelWithdrawalInstruction,
   getClaimDelegateFromDisabledGatewayInstructionAsync,
@@ -4266,6 +4267,38 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
   }
 
   /**
+   * Set the epoch reward split between gateways and observers on the
+   * `EpochSettings` PDA (authority-signed). Both ratios are scaled by
+   * `RATE_SCALE` (1_000_000 == 100%) and MUST sum to exactly `RATE_SCALE`;
+   * the on-chain instruction rejects any other sum. The new split takes
+   * effect at the NEXT epoch prescription — already-computed epochs keep
+   * their stamped per-gateway / per-observer rewards.
+   *
+   * Authority-gated and NOT migration-gated (survives `finalize_migration`),
+   * so the split remains a governable parameter post-cutover. Solana-only.
+   */
+  async adminSetRewardRatios(
+    params: {
+      gatewayRewardRatio: number | bigint;
+      observerRewardRatio: number | bigint;
+    },
+    _options?: WriteOptions,
+  ): Promise<MessageResult> {
+    const [epochSettings] = await getEpochSettingsPDA(this.garProgram);
+    const ix = await getAdminSetRewardRatiosInstructionAsync(
+      {
+        epochSettings,
+        authority: this.signer,
+        gatewayRewardRatio: BigInt(params.gatewayRewardRatio),
+        observerRewardRatio: BigInt(params.observerRewardRatio),
+      },
+      { programAddress: this.garProgram },
+    );
+    const sig = await this.sendTransaction([ix]);
+    return { id: sig };
+  }
+
+  /**
    * Submit `prescribe_epoch` using the off-chain-predicted observer set, with a
    * single re-predict-and-retry on `InvalidGatewayAccount` (covers a gateway
    * leaving the registry between the prediction read and the tx landing).
@@ -4934,6 +4967,11 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
    * Reclaim rent from an Observation PDA whose epoch has been distributed.
    * Permissionless. Pass `epochIndex` and the `observer` address used as
    * the Observation seed.
+   *
+   * Rent is refunded to the `observer` (bound on-chain to
+   * `observation.observer` via an address constraint), NOT to the caller —
+   * the signer (`caller`) only pays the tx fee. A third-party closer cannot
+   * redirect the reclaimed rent to itself.
    */
   async closeObservation(
     params: { epochIndex: number; observer: string },
@@ -4949,7 +4987,8 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     const ix = await getCloseObservationInstructionAsync(
       {
         observation: observationPda,
-        payer: this.signer,
+        observer: observerAddr,
+        caller: this.signer,
         epochIndex: BigInt(params.epochIndex),
       },
       { programAddress: this.garProgram },
@@ -4962,10 +5001,12 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
   /**
    * Close multiple Observation PDAs for one epoch in a single tx (each
    * `close_observation` increments the parent Epoch's `observations_closed`).
-   * Permissionless; rent is refunded to the payer. Used by the crank to satisfy
+   * Permissionless; rent for each observation is refunded to its recorded
+   * `observer` (NOT the caller — bound on-chain via an address constraint),
+   * while the signer only pays the tx fee. Used by the crank to satisfy
    * `close_epoch`'s `observations_closed == observations_submitted` precondition
    * before closing a retention-aged epoch. Keep the batch small — each ix carries
-   * the Epoch + Observation + payer + system accounts.
+   * the Epoch + Observation + observer + caller accounts.
    */
   /**
    * Filter a candidate observer set down to those whose Observation PDA still
@@ -5012,15 +5053,17 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     }
     const ixs = await Promise.all(
       params.observers.map(async (obs) => {
+        const observerAddr = address(obs);
         const [observationPda] = await getObservationPDA(
           params.epochIndex,
-          address(obs),
+          observerAddr,
           this.garProgram,
         );
         return getCloseObservationInstructionAsync(
           {
             observation: observationPda,
-            payer: this.signer,
+            observer: observerAddr,
+            caller: this.signer,
             epochIndex: BigInt(params.epochIndex),
           },
           { programAddress: this.garProgram },

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -210,6 +210,7 @@ import { SolanaANTRegistryWriteable } from './ant-registry-writeable.js';
 import { ARIO_ANT_PROGRAM_ID, TOKEN_DECIMALS } from './constants.js';
 import { SolanaARIOReadable } from './io-readable.js';
 import {
+  getAntAuthorityPDA,
   getAntConfigPDA,
   getAntRecordPDA,
   getArioConfigPDA,
@@ -2351,11 +2352,16 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     asset: Address,
   ): Promise<Instruction> {
     const [arnsRecord] = await getArnsRecordPDA(name, this.arnsProgram);
+    // ADR-028: the `authority` signer is gone. Program-controlled ANTs are
+    // synced permissionlessly (the program signs UpdatePluginV1 with the
+    // per-asset `ant_authority` PDA); legacy ANTs still require the owner as
+    // `payer`. Either way we pass the derived PDA.
+    const [antAuthority] = await getAntAuthorityPDA(asset, this.antProgram);
     return getSyncAttributesInstruction(
       {
         asset,
         payer: this.signer,
-        authority: this.signer,
+        antAuthority,
         arnsRecord,
         name,
       },

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -248,7 +248,10 @@ import {
   sendAndConfirm,
   sendWithEphemeralLookupTable,
 } from './send.js';
-import { buildSpawnAntInstructions } from './spawn-ant.js';
+import {
+  buildSpawnAntInstructions,
+  validateSpawnAntState,
+} from './spawn-ant.js';
 import type {
   SolanaRpcSubscriptions,
   SolanaSigner,
@@ -1511,15 +1514,25 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     let mintSigner: KeyPairSigner | undefined;
     let antPubkey: Address;
     if (params.processId === undefined) {
+      // Fold optional caller-supplied metadata + `@` target into the freshly
+      // minted ANT so a name can resolve to real content in the SAME buy tx.
+      // Validated up front for a clean error instead of an on-chain revert.
+      validateSpawnAntState(params.antState);
       const spawn = await buildSpawnAntInstructions({
         signer: this.signer,
-        state: { name: params.name },
+        state: { name: params.name, ...params.antState },
         antProgramId: this.antProgram,
       });
       spawnIxs = spawn.instructions;
       mintSigner = spawn.mintSigner;
       antPubkey = spawn.mint;
     } else {
+      if (params.antState !== undefined) {
+        this.logger.warn(
+          '[buyRecord] antState is ignored when buying to an existing ANT ' +
+            '(processId set); set metadata via the ANT writeable instead.',
+        );
+      }
       antPubkey = address(params.processId);
     }
 

--- a/src/solana/pda.ts
+++ b/src/solana/pda.ts
@@ -34,6 +34,7 @@ import {
   ACL_CONFIG_SEED,
   ACL_PAGE_SEED,
   ALLOWLIST_SEED,
+  ANT_AUTHORITY_SEED,
   ANT_CONFIG_SEED,
   ANT_CONTROLLERS_SEED,
   ANT_RECORD_META_SEED,
@@ -399,6 +400,21 @@ export async function getAntControllersPDA(
   return getProgramDerivedAddress({
     programAddress: programId,
     seeds: [ANT_CONTROLLERS_SEED, addressEncoder.encode(mint)],
+  });
+}
+
+/**
+ * ADR-028: per-asset program-signer PDA that holds the Metaplex Core
+ * UpdateAuthority for an ANT. New ANTs mint with UpdateAuthority set to this
+ * address so all MPL Core updates route through the ario-ant program.
+ */
+export async function getAntAuthorityPDA(
+  mint: Address,
+  programId: Address = ARIO_ANT_PROGRAM_ID,
+): Promise<Pda> {
+  return getProgramDerivedAddress({
+    programAddress: programId,
+    seeds: [ANT_AUTHORITY_SEED, addressEncoder.encode(mint)],
   });
 }
 

--- a/src/solana/spawn-ant-state.test.ts
+++ b/src/solana/spawn-ant-state.test.ts
@@ -82,6 +82,19 @@ describe('validateSpawnAntState', () => {
     // Empty target is treated as unset.
     assert.doesNotThrow(() => validateSpawnAntState({ transactionId: '' }));
   });
+
+  it('rejects a targetProtocol other than 0 or 1', () => {
+    // The runtime guard must reject out-of-range values arriving from untyped
+    // callers (CLI / JSON), even though the public `ArNSBuyAntState` is 0 | 1.
+    for (const bad of [2, -1, Number.NaN]) {
+      assert.throws(
+        () => validateSpawnAntState({ targetProtocol: bad }),
+        /targetProtocol must be 0 \(Arweave\) or 1 \(IPFS\)/,
+      );
+    }
+    assert.doesNotThrow(() => validateSpawnAntState({ targetProtocol: 0 }));
+    assert.doesNotThrow(() => validateSpawnAntState({ targetProtocol: 1 }));
+  });
 });
 
 /**

--- a/src/solana/spawn-ant-state.test.ts
+++ b/src/solana/spawn-ant-state.test.ts
@@ -9,8 +9,8 @@ import { describe, it } from 'node:test';
 import { generateKeyPairSigner } from '@solana/kit';
 
 import {
-  buildSpawnAntInstructions,
   DEFAULT_ANT_TRANSACTION_ID,
+  buildSpawnAntInstructions,
   validateSpawnAntState,
 } from './spawn-ant.js';
 

--- a/src/solana/spawn-ant-state.test.ts
+++ b/src/solana/spawn-ant-state.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for `validateSpawnAntState` — the fast-fail guard for optional
+ * ANT metadata + `@` target supplied to an atomic `buyRecord` (or a spawn).
+ * Mirrors the on-chain `ario_ant::initialize` limits.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { validateSpawnAntState } from './spawn-ant.js';
+
+const TX = 'a'.repeat(43); // valid 43-char Arweave id shape
+
+describe('validateSpawnAntState', () => {
+  it('accepts undefined / empty state', () => {
+    assert.doesNotThrow(() => validateSpawnAntState(undefined));
+    assert.doesNotThrow(() => validateSpawnAntState({}));
+  });
+
+  it('accepts a fully-populated valid state', () => {
+    assert.doesNotThrow(() =>
+      validateSpawnAntState({
+        ticker: 'BLOG',
+        description: 'x'.repeat(512),
+        keywords: Array.from({ length: 16 }, (_, i) => `k${i}`),
+        logo: TX,
+        transactionId: TX,
+        targetProtocol: 0,
+      }),
+    );
+  });
+
+  it('rejects a description over 512 chars', () => {
+    assert.throws(
+      () => validateSpawnAntState({ description: 'x'.repeat(513) }),
+      /512 characters/,
+    );
+  });
+
+  it('rejects more than 16 keywords', () => {
+    assert.throws(
+      () =>
+        validateSpawnAntState({
+          keywords: Array.from({ length: 17 }, (_, i) => `k${i}`),
+        }),
+      /16 entries/,
+    );
+  });
+
+  it('rejects a malformed logo but allows an empty one', () => {
+    assert.throws(() => validateSpawnAntState({ logo: 'too-short' }), /logo/);
+    assert.doesNotThrow(() => validateSpawnAntState({ logo: '' }));
+    assert.doesNotThrow(() => validateSpawnAntState({ logo: TX }));
+  });
+
+  it('shape-checks the @ target only for an Arweave targetProtocol', () => {
+    // Arweave (0 / undefined) → must match the 43-char id shape.
+    assert.throws(
+      () => validateSpawnAntState({ transactionId: 'nope', targetProtocol: 0 }),
+      /@ target/,
+    );
+    assert.throws(
+      () => validateSpawnAntState({ transactionId: 'nope' }),
+      /@ target/,
+    );
+    // IPFS (1) → the target is a CID, so the Arweave shape check is skipped.
+    assert.doesNotThrow(() =>
+      validateSpawnAntState({
+        transactionId: 'QmSomeCidValue',
+        targetProtocol: 1,
+      }),
+    );
+    // Empty target is treated as unset.
+    assert.doesNotThrow(() => validateSpawnAntState({ transactionId: '' }));
+  });
+});

--- a/src/solana/spawn-ant-state.test.ts
+++ b/src/solana/spawn-ant-state.test.ts
@@ -6,9 +6,19 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { validateSpawnAntState } from './spawn-ant.js';
+import { generateKeyPairSigner } from '@solana/kit';
+
+import {
+  buildSpawnAntInstructions,
+  DEFAULT_ANT_TRANSACTION_ID,
+  validateSpawnAntState,
+} from './spawn-ant.js';
 
 const TX = 'a'.repeat(43); // valid 43-char Arweave id shape
+
+const utf8Hex = (s: string) => Buffer.from(s, 'utf8').toString('hex');
+const ixHex = (data: unknown) =>
+  Buffer.from(data as Uint8Array).toString('hex');
 
 describe('validateSpawnAntState', () => {
   it('accepts undefined / empty state', () => {
@@ -71,5 +81,69 @@ describe('validateSpawnAntState', () => {
     );
     // Empty target is treated as unset.
     assert.doesNotThrow(() => validateSpawnAntState({ transactionId: '' }));
+  });
+});
+
+/**
+ * Proves that metadata supplied at buy/spawn time is actually forwarded into
+ * the on-chain `ario_ant::initialize` instruction (the second instruction the
+ * spawn builder emits). `buyRecord` passes `{ name, ...antState }` straight into
+ * `buildSpawnAntInstructions`, so this covers the end-to-end threading: if the
+ * spawn stopped forwarding a field, or `buyRecord` stopped spreading `antState`,
+ * the encoded bytes would no longer contain these values.
+ */
+describe('buildSpawnAntInstructions threads metadata into initialize', () => {
+  const MARKER_TARGET = 'b'.repeat(43);
+  const MARKER_DESC = 'ZZUNIQUEDESCRIPTIONMARKER';
+  const MARKER_KEYWORD = 'ZZUNIQUEKEYWORD';
+  const MARKER_TICKER = 'ZZTICK';
+
+  it('encodes the supplied @ target, ticker, description, and keywords', async () => {
+    const signer = await generateKeyPairSigner();
+    const { instructions } = await buildSpawnAntInstructions({
+      signer,
+      state: {
+        name: 'threading-test',
+        ticker: MARKER_TICKER,
+        description: MARKER_DESC,
+        keywords: [MARKER_KEYWORD],
+        transactionId: MARKER_TARGET,
+      },
+    });
+    // [0] = CreateV1 (MPL Core), [1] = ario_ant::initialize.
+    const initData = ixHex(instructions[1]!.data);
+    assert.ok(
+      initData.includes(utf8Hex(MARKER_TARGET)),
+      'target not forwarded',
+    );
+    assert.ok(
+      initData.includes(utf8Hex(MARKER_TICKER)),
+      'ticker not forwarded',
+    );
+    assert.ok(
+      initData.includes(utf8Hex(MARKER_DESC)),
+      'description not forwarded',
+    );
+    assert.ok(
+      initData.includes(utf8Hex(MARKER_KEYWORD)),
+      'keyword not forwarded',
+    );
+  });
+
+  it('falls back to the default target when none is supplied', async () => {
+    const signer = await generateKeyPairSigner();
+    const { instructions } = await buildSpawnAntInstructions({
+      signer,
+      state: { name: 'threading-test' },
+    });
+    const initData = ixHex(instructions[1]!.data);
+    assert.ok(
+      initData.includes(utf8Hex(DEFAULT_ANT_TRANSACTION_ID)),
+      'default target not used',
+    );
+    assert.ok(
+      !initData.includes(utf8Hex(MARKER_DESC)),
+      'unexpected description bytes',
+    );
   });
 });

--- a/src/solana/spawn-ant.test.ts
+++ b/src/solana/spawn-ant.test.ts
@@ -5,12 +5,13 @@
  * change to MPL Core's `CreateV1` schema or our default attribute-plugin
  * shape is caught at the unit-test level instead of at deploy time.
  *
- * The migration import package emits the same `CreateV1` payload via the
- * legacy @solana/web3.js path (`migration/import/src/instructions/mint-nft.ts`).
- * The byte fixtures below were captured from that path before this PR and
- * must stay byte-identical — divergence would mean migration-minted ANTs
- * and SDK-minted ANTs no longer share a shape, which would in turn break
- * `purchase`'s `UpdatePluginV1` CPI on the SDK-minted side (or vice-versa).
+ * ADR-028: fresh ANTs now mint with the Attributes-plugin authority =
+ * `UpdateAuthority` (plugin authority byte `02`, was `01` = Owner) and the
+ * asset `updateAuthority` set to the per-asset `ant_authority` PDA. This is an
+ * intentional divergence from legacy (pre-ADR-028) mints — including historical
+ * migration-import ANTs, which are `adopt_authority`-adoptable onto the new
+ * model. The `authority` byte is the only data-level change; the account list
+ * gains the explicit `updateAuthority` at kinobi position 5.
  */
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
@@ -22,6 +23,8 @@ import { buildCreateAntInstruction } from './spawn-ant.js';
 const FIXED_MINT: Address = address('11111111111111111111111111111112');
 const FIXED_AUTH: Address = address('11111111111111111111111111111113');
 const FIXED_PAY: Address = address('11111111111111111111111111111114');
+// ADR-028: the per-asset `ant_authority` PDA. Fixed placeholder for byte-pinning.
+const FIXED_UA: Address = address('11111111111111111111111111111115');
 
 function hex(b: Uint8Array | ReadonlyUint8Array | undefined): string {
   assert.ok(b, 'instruction data must be defined');
@@ -43,11 +46,12 @@ function assertIxAccounts(ix: {
 }
 
 describe('buildCreateAntInstruction (CreateV1 wire format)', () => {
-  it('emits an empty Attributes plugin (Owner authority) by default', () => {
+  it('emits an empty Attributes plugin (UpdateAuthority) by default', () => {
     const ix = buildCreateAntInstruction({
       mint: FIXED_MINT,
       authority: FIXED_AUTH,
       payer: FIXED_PAY,
+      updateAuthority: FIXED_UA,
       name: 'test-ant',
       uri: 'ar://abc',
     });
@@ -64,7 +68,7 @@ describe('buildCreateAntInstruction (CreateV1 wire format)', () => {
     //   06          Plugin::Attributes
     //   00000000    attribute_list len = 0
     //   01          plugin authority Option = Some
-    //   01          PluginAuthority::Owner
+    //   02          PluginAuthority::UpdateAuthority (ADR-028; was Owner=01)
     const expected =
       '0000' +
       '08000000' +
@@ -74,12 +78,12 @@ describe('buildCreateAntInstruction (CreateV1 wire format)', () => {
       '0101000000' +
       '06' +
       '00000000' +
-      '0101';
+      '0102';
 
     assertIxData(ix);
     assert.equal(hex(ix.data), expected);
-    // 38 bytes — captured before this PR from the migration mint's
-    // backwards-compat path. Locks future regressions.
+    // 38 bytes — only the trailing plugin-authority variant changed (01 → 02);
+    // the payload length is unchanged.
     assert.equal(ix.data.length, 38);
   });
 
@@ -88,6 +92,7 @@ describe('buildCreateAntInstruction (CreateV1 wire format)', () => {
       mint: FIXED_MINT,
       authority: FIXED_AUTH,
       payer: FIXED_PAY,
+      updateAuthority: FIXED_UA,
       name: 'test-ant',
       uri: 'ar://abc',
       attributes: [
@@ -121,29 +126,34 @@ describe('buildCreateAntInstruction (CreateV1 wire format)', () => {
       '556e6465726e616d65204c696d6974' + // "Undername Limit"
       '02000000' +
       '3130' + // "10"
-      '0101'; // PluginAuthority Some + Owner
+      '0102'; // PluginAuthority Some + UpdateAuthority (ADR-028)
 
     assertIxData(ix);
     assert.equal(hex(ix.data), expected);
     assert.equal(ix.data.length, 108);
   });
 
-  it('places mint+authority+payer in the correct kinobi account positions', () => {
+  it('places mint+authority+payer+updateAuthority in the correct kinobi account positions', () => {
     const ix = buildCreateAntInstruction({
       mint: FIXED_MINT,
       authority: FIXED_AUTH,
       payer: FIXED_PAY,
+      updateAuthority: FIXED_UA,
       name: 'x',
       uri: 'y',
     });
 
     assertIxAccounts(ix);
-    // 8 accounts in kinobi createV1 order; positions 1, 4, 5, 7 are
-    // optional placeholders (= MPL Core program id).
+    // 8 accounts in kinobi createV1 order; positions 1 and 7 are optional
+    // placeholders (= MPL Core program id).
     assert.equal(ix.accounts.length, 8);
     assert.equal(ix.accounts[0]!.address, FIXED_MINT, 'pos 0 = asset');
     assert.equal(ix.accounts[2]!.address, FIXED_AUTH, 'pos 2 = authority');
     assert.equal(ix.accounts[3]!.address, FIXED_PAY, 'pos 3 = payer');
+    // pos 4 = owner (ADR-028: explicit = authority, so the PDA never becomes owner)
+    assert.equal(ix.accounts[4]!.address, FIXED_AUTH, 'pos 4 = owner');
+    // pos 5 = updateAuthority (ADR-028: the ant_authority PDA)
+    assert.equal(ix.accounts[5]!.address, FIXED_UA, 'pos 5 = updateAuthority');
     // pos 6 = system_program
     assert.equal(
       ix.accounts[6]!.address,
@@ -160,6 +170,7 @@ describe('buildCreateAntInstruction (CreateV1 wire format)', () => {
       mint: FIXED_MINT,
       authority: FIXED_AUTH,
       payer: FIXED_PAY,
+      updateAuthority: FIXED_UA,
       name: 'a',
       uri: 'b',
     });
@@ -176,7 +187,7 @@ describe('buildCreateAntInstruction (CreateV1 wire format)', () => {
         '0101000000' +
         '06' +
         '00000000' +
-        '0101',
+        '0102',
     );
   });
 });

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -62,7 +62,7 @@ import {
 } from '@solana-program/compute-budget';
 import { SolanaANTRegistryWriteable } from './ant-registry-writeable.js';
 import { ARIO_ANT_PROGRAM_ID } from './constants.js';
-import { getAntRecordPDA } from './pda.js';
+import { getAntAuthorityPDA, getAntRecordPDA } from './pda.js';
 import {
   estimateComputeUnitLimit,
   estimatePriorityFeeMicroLamports,
@@ -168,17 +168,23 @@ export type AntAttribute = { key: string; value: string };
  * are bundling the mint into a larger compound transaction.
  *
  * **Why we always emit an Attributes plugin (even with an empty list):**
- * `ario_arns::buy_record` and friends CPI into `UpdatePluginV1` to populate
- * traits at purchase time. If the asset has no Attributes plugin, that CPI
+ * `ario_ant::sync_attributes` CPIs into `UpdatePluginV1` to populate traits
+ * after an ArNS purchase. If the asset has no Attributes plugin, that CPI
  * fails. Emitting an empty plugin here keeps every spawned ANT
  * `purchase`-ready and matches what `migration/import` mints — see ADR-012
- * and BD-096. Authority is `Owner` so the ANT NFT holder (= asset owner)
- * can sign their own trait updates.
+ * and BD-096.
+ *
+ * **ADR-028 — program-controlled authority:** the asset's `updateAuthority`
+ * is set to the per-asset `ant_authority` PDA and the Attributes plugin
+ * authority is `UpdateAuthority` (so it resolves to that PDA). The ario-ant
+ * program signs MPL Core updates with the PDA; the NFT holder keeps `owner`
+ * (custody). Callers derive the PDA via `getAntAuthorityPDA(mint)`.
  */
 export function buildCreateAntInstruction({
   mint,
   authority,
   payer,
+  updateAuthority,
   name,
   uri,
   attributes = [],
@@ -186,6 +192,8 @@ export function buildCreateAntInstruction({
   mint: Address;
   authority: Address;
   payer: Address;
+  /** The `ant_authority` PDA — see `getAntAuthorityPDA` (ADR-028). */
+  updateAuthority: Address;
   name: string;
   uri: string;
   attributes?: AntAttribute[];
@@ -200,6 +208,11 @@ export function buildCreateAntInstruction({
     asset: asSigner(mint),
     authority: asSigner(authority),
     payer: asSigner(payer),
+    // `owner` MUST be explicit (= the authority/holder). MPL Core defaults owner
+    // to updateAuthority when omitted, so with updateAuthority = the
+    // ant_authority PDA an omitted owner would make the PDA the NFT owner.
+    owner: authority,
+    updateAuthority,
     dataState: DataState.AccountState,
     name,
     uri,
@@ -209,7 +222,7 @@ export function buildCreateAntInstruction({
           __kind: 'Attributes',
           fields: [{ attributeList: attributes }],
         },
-        authority: { __kind: 'Owner' },
+        authority: { __kind: 'UpdateAuthority' },
       },
     ],
   });
@@ -318,10 +331,22 @@ export async function buildSpawnAntInstructions(params: {
   //
   // Default value is the canonical `ARIO_ANT_PROGRAM_ID`; passing
   // `antProgramId` opts into the BYO-ANT (third-party) path.
+  //
+  // ADR-028: the asset's UpdateAuthority is the per-asset `ant_authority` PDA
+  // and the Attributes plugin authority is `UpdateAuthority` (→ that PDA), so
+  // all MPL Core updates route through the ario-ant program. The owner (the
+  // spawning signer) keeps custody of the NFT.
+  const [antAuthority] = await getAntAuthorityPDA(mint, antProgramId);
   const createIx = getCreateV1Instruction({
     asset: mintSigner,
     payer: signer,
     authority: signer,
+    // `owner` MUST be explicit. MPL Core defaults owner to updateAuthority when
+    // omitted, so with updateAuthority = the ant_authority PDA an omitted owner
+    // would make the PROGRAM PDA the NFT owner (user loses custody). Pin it to
+    // the spawning wallet.
+    owner,
+    updateAuthority: antAuthority,
     dataState: DataState.AccountState,
     name: state.name,
     uri,
@@ -337,7 +362,7 @@ export async function buildSpawnAntInstructions(params: {
             },
           ],
         },
-        authority: { __kind: 'Owner' },
+        authority: { __kind: 'UpdateAuthority' },
       },
     ],
   });

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -151,6 +151,13 @@ export function validateSpawnAntState(state?: ValidatableAntState): void {
   ) {
     throw new Error('ANT logo must be a 43-character Arweave transaction ID');
   }
+  if (
+    state.targetProtocol !== undefined &&
+    state.targetProtocol !== 0 &&
+    state.targetProtocol !== 1
+  ) {
+    throw new Error('ANT targetProtocol must be 0 (Arweave) or 1 (IPFS)');
+  }
   const targetIsArweave =
     state.targetProtocol === undefined || state.targetProtocol === 0;
   if (

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -403,7 +403,7 @@ export async function buildSpawnAntInstructions(params: {
     // omitted, so with updateAuthority = the ant_authority PDA an omitted owner
     // would make the PROGRAM PDA the NFT owner (user loses custody). Pin it to
     // the spawning wallet.
-    owner,
+    owner: signer.address,
     updateAuthority: antAuthority,
     dataState: DataState.AccountState,
     name: state.name,

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -60,6 +60,7 @@ import {
   getSetComputeUnitLimitInstruction,
   getSetComputeUnitPriceInstruction,
 } from '@solana-program/compute-budget';
+import { ARWEAVE_TX_REGEX } from '../constants.js';
 import { SolanaANTRegistryWriteable } from './ant-registry-writeable.js';
 import { ARIO_ANT_PROGRAM_ID } from './constants.js';
 import { getAntAuthorityPDA, getAntRecordPDA } from './pda.js';
@@ -113,6 +114,56 @@ export type SpawnSolanaANTState = {
    */
   uri?: string;
 };
+
+/** The optional metadata subset of {@link SpawnSolanaANTState} to validate. */
+type ValidatableAntState = Partial<
+  Pick<
+    SpawnSolanaANTState,
+    | 'ticker'
+    | 'description'
+    | 'keywords'
+    | 'logo'
+    | 'transactionId'
+    | 'targetProtocol'
+  >
+>;
+
+/**
+ * Fast-fail validation of optional ANT initial state before an atomic buy /
+ * spawn. Mirrors the on-chain `ario_ant::initialize` limits so callers get a
+ * clear, actionable error instead of an opaque program revert. Only provided
+ * fields are checked; empty strings are treated as "unset". The `@` target is
+ * only shape-checked as an Arweave TX ID when `targetProtocol` is Arweave (0 /
+ * undefined) — for IPFS (1) the target is a CID, not an Arweave id.
+ */
+export function validateSpawnAntState(state?: ValidatableAntState): void {
+  if (!state) return;
+  if (state.description !== undefined && state.description.length > 512) {
+    throw new Error('ANT description must be 512 characters or fewer');
+  }
+  if (state.keywords !== undefined && state.keywords.length > 16) {
+    throw new Error('ANT keywords must be 16 entries or fewer');
+  }
+  if (
+    state.logo !== undefined &&
+    state.logo.length > 0 &&
+    !ARWEAVE_TX_REGEX.test(state.logo)
+  ) {
+    throw new Error('ANT logo must be a 43-character Arweave transaction ID');
+  }
+  const targetIsArweave =
+    state.targetProtocol === undefined || state.targetProtocol === 0;
+  if (
+    state.transactionId !== undefined &&
+    state.transactionId.length > 0 &&
+    targetIsArweave &&
+    !ARWEAVE_TX_REGEX.test(state.transactionId)
+  ) {
+    throw new Error(
+      'ANT base @ target must be a 43-character Arweave transaction ID',
+    );
+  }
+}
 
 export type SpawnSolanaANTParams = {
   /** RPC client used to fetch a recent blockhash + send the spawn transaction. */

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -672,7 +672,7 @@ export type ArNSBuyAntState = {
   /** Base `@` record target — Arweave TX id (or IPFS CID when targetProtocol=1). */
   transactionId?: string;
   /** Storage protocol for the `@` target: 0 = Arweave (default), 1 = IPFS. */
-  targetProtocol?: number;
+  targetProtocol?: 0 | 1;
 };
 
 export type BuyRecordParams = ArNSPurchaseParams & {

--- a/src/types/io.ts
+++ b/src/types/io.ts
@@ -649,10 +649,38 @@ export type ArNSPurchaseParams = ArNSNameParams & {
   referrer?: string;
 };
 
+/**
+ * Optional ANT metadata + base `@` target baked into an ATOMIC name buy — i.e.
+ * when `processId` is omitted and the SDK mints a fresh user-owned ANT in the
+ * same transaction. Ignored (with a warning) when buying to an existing ANT via
+ * `processId`; set metadata on that ANT via the ANT writeable instead.
+ *
+ * A backend-neutral subset of the Solana spawn state. `name` is omitted (it is
+ * always the bought name) and `uri` is derived. Note the base `@` target sets at
+ * mint, but its TTL cannot — `initialize` has no TTL field, so a non-default TTL
+ * still needs a post-buy `setBaseNameRecord`. Solana backend only today.
+ */
+export type ArNSBuyAntState = {
+  /** ANT ticker (defaults to "ANT" on chain). */
+  ticker?: string;
+  /** Description (≤ 512 chars). */
+  description?: string;
+  /** Keywords (≤ 16 entries). */
+  keywords?: string[];
+  /** Logo Arweave TX id (43 chars). */
+  logo?: string;
+  /** Base `@` record target — Arweave TX id (or IPFS CID when targetProtocol=1). */
+  transactionId?: string;
+  /** Storage protocol for the `@` target: 0 = Arweave (default), 1 = IPFS. */
+  targetProtocol?: number;
+};
+
 export type BuyRecordParams = ArNSPurchaseParams & {
   years?: number;
   type: 'lease' | 'permabuy';
   processId?: string;
+  /** Initial ANT metadata + `@` target for an atomic buy (no `processId`). */
+  antState?: ArNSBuyAntState;
 };
 
 export type ExtendLeaseParams = ArNSPurchaseParams & {

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,10 @@
   resolved "https://registry.yarnpkg.com/@actions/io/-/io-3.0.2.tgz#6f89b27a159d109836d983efa283997c23b92284"
   integrity sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==
 
-"@ar.io/solana-contracts@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/@ar.io/solana-contracts/-/solana-contracts-1.0.1.tgz#1a16958d54540222b77def81d5d39e7402b8b69c"
-  integrity sha512-zD7OepkzzWb1SIHRDxSo3y+dzRh9gu+43eI2DBJLtQ+7EkT3Py8v9kHQ40UcRC8CReHHTO74RDty6Hwx5JYVGA==
+"@ar.io/solana-contracts@1.0.0-staging.22":
+  version "1.0.0-staging.22"
+  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.0.0-staging.22.tgz#51a2f896828fc2394cb9a1bdb591cb995f51aecb"
+  integrity sha512-W/v1xE/9xeKyH7FxOQSI5keKfSzR8oVaMyv4gtcE1pte2BNQP2MB8FzQ2nDKHO+/ByAtmLfJQceDjrGuSP+LPg==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
Integration branch for the mainnet ant #118 cutover — combines three verified-together SDK changes and bumps the typed-client to the ADR-028/ADR-027-aware version.

## What's included
- **ADR-028** (folds in #695): `sync_attributes` now signs with the per-asset `ant_authority` PDA (new account list `[asset, payer, antAuthority, arnsRecord, mplCoreProgram, systemProgram]`); ANTs mint with program-controlled UpdateAuthority; owner keeps custody. **Required for the portal to work against the upgraded mainnet ant program.**
- **Atomic-buy** (folds in #698): `buyRecord` accepts `antState` to set ANT metadata + @ target atomically.
- **close_observation rent refund** (gar #116): 4-account `[epoch, observation, observer, caller]` form — refunds rent to the observer; `adminSetRewardRatios`.
- **Client bump** → `@ar.io/solana-contracts@1.0.0-staging.22` (ADR-028 + gar-116 + ADR-027 ABIs).
- Rebased on current `alpha` (incl. #699 lease-lifecycle crank) — no regression.

## Verification
- tsc clean; 448 tests / 447 pass / 0 fail / 1 skipped (deprecated on-chain escrow assertion, superseded by centralized claims).
- Full esm+web build green.

Supersedes #695 and #698 (folded in). Merging publishes `@ar.io/sdk@4.1.0-alpha.8` (@alpha). Part of the coordinated ant #118 mainnet cutover; @latest promotion follows after the on-chain upgrade.