### PR TITLE
fix(solana): finalize ephemeral ALT before the consuming tx (mainnet atomic buy)

### DIFF
--- a/src/solana/send.ts
+++ b/src/solana/send.ts
@@ -763,39 +763,45 @@ export async function sendWithEphemeralLookupTable({
 
 /**
  * Poll until an Address Lookup Table holds at least `expectedCount` addresses
- * AND at least one slot has elapsed since they all landed. Lookup-table entries
- * are only usable the slot AFTER they are appended, and the leader processing
- * the consuming tx must already see them — otherwise the runtime rejects the tx
- * with "address table lookup uses an invalid index". ALT account layout is a
- * 56-byte metadata header followed by 32-byte addresses.
+ * AT 'finalized' COMMITMENT. Lookup-table entries are only usable once the
+ * leader that processes the consuming tx can resolve them; a table that is only
+ * 'confirmed' lives on our RPC's fork and, on mainnet, is often not yet visible
+ * to the (different) leader building the big ALT-referencing tx — which then
+ * silently drops it (simulates fine on our RPC but never lands). Waiting for
+ * finalization guarantees network-wide visibility. Without this, mainnet atomic
+ * spawn-and-buy (and prescribe) txs intermittently fail to confirm. ALT account
+ * layout is a 56-byte metadata header followed by 32-byte addresses.
  */
 async function waitForLookupTableActive(
   rpc: SolanaRpc,
   table: Address,
   expectedCount: number,
-  maxWaitMs = 30_000,
+  maxWaitMs = 45_000,
 ): Promise<void> {
   const META = 56;
   const start = Date.now();
-  let slotAllPresent: bigint | null = null;
   while (Date.now() - start < maxWaitMs) {
-    const acc = await rpc.getAccountInfo(table, { encoding: 'base64' }).send();
-    const slot = acc.context.slot;
+    // Poll at 'finalized' so the table (with all its addresses) is visible to
+    // (nearly) every validator before the consuming tx is sent. A table that is
+    // only 'confirmed' lives on our RPC's fork; on mainnet the leader that
+    // processes the big ALT-referencing tx may not have it yet and silently
+    // drops the tx (it simulates fine on our RPC but never lands). Finalization
+    // guarantees network-wide visibility, so the tx resolves the table wherever
+    // it's processed.
+    const acc = await rpc
+      .getAccountInfo(table, { encoding: 'base64', commitment: 'finalized' })
+      .send();
     if (acc.value) {
       const len = Buffer.from(acc.value.data[0], 'base64').length;
       const count = len >= META ? Math.floor((len - META) / 32) : 0;
       if (count >= expectedCount) {
-        if (slotAllPresent === null) {
-          slotAllPresent = slot;
-        } else if (slot > slotAllPresent) {
-          return; // all addresses present + a slot has elapsed → warm
-        }
+        return; // finalized with every address → resolvable by any leader
       }
     }
     await new Promise((r) => setTimeout(r, 800));
   }
   throw new Error(
-    `lookup table ${table} not active (≥${expectedCount} addresses + 1 slot) within ${maxWaitMs}ms`,
+    `lookup table ${table} not finalized with >=${expectedCount} addresses within ${maxWaitMs}ms`,
   );
 }
 

--- a/src/solana/send.ts
+++ b/src/solana/send.ts
@@ -781,6 +781,7 @@ async function waitForLookupTableActive(
   const META = 56;
   const start = Date.now();
   while (Date.now() - start < maxWaitMs) {
+    const remaining = maxWaitMs - (Date.now() - start);
     // Poll at 'finalized' so the table (with all its addresses) is visible to
     // (nearly) every validator before the consuming tx is sent. A table that is
     // only 'confirmed' lives on our RPC's fork; on mainnet the leader that
@@ -788,17 +789,29 @@ async function waitForLookupTableActive(
     // drops the tx (it simulates fine on our RPC but never lands). Finalization
     // guarantees network-wide visibility, so the tx resolves the table wherever
     // it's processed.
+    //
+    // Bound the RPC call by the remaining deadline so a hung request can't run
+    // past maxWaitMs (AbortSignal.timeout is Node 18+, which the SDK targets);
+    // a timed-out or transient failure yields null and re-polls until the loop
+    // deadline. The final `throw` still reports the bounded wait.
     const acc = await rpc
       .getAccountInfo(table, { encoding: 'base64', commitment: 'finalized' })
-      .send();
-    if (acc.value) {
+      .send({ abortSignal: AbortSignal.timeout(remaining) })
+      .catch(() => null);
+    if (acc?.value) {
       const len = Buffer.from(acc.value.data[0], 'base64').length;
       const count = len >= META ? Math.floor((len - META) / 32) : 0;
       if (count >= expectedCount) {
         return; // finalized with every address → resolvable by any leader
       }
     }
-    await new Promise((r) => setTimeout(r, 800));
+    // Cap the poll delay to the time left so it never overshoots the deadline.
+    await new Promise((r) =>
+      setTimeout(
+        r,
+        Math.min(800, Math.max(0, maxWaitMs - (Date.now() - start))),
+      ),
+    );
   }
   throw new Error(
     `lookup table ${table} not finalized with >=${expectedCount} addresses within ${maxWaitMs}ms`,


### PR DESCRIPTION
## Problem
The atomic spawn-and-buy (new ArNS name that auto-spawns its ANT) routes an oversized tx through a freshly-created **ephemeral Address Lookup Table**. `waitForLookupTableActive` only waited for the addresses to be present + 1 slot at **'confirmed'** commitment. On **mainnet**, that table is on our RPC's fork and often isn't yet visible to the *different* leader that builds the big ALT-referencing tx → the tx is **silently dropped** (simulates fine on our RPC, but never lands: `network progressed past the last block`, and no tx ever appears on-chain).

This breaks the **console + arns-react brand-new-name purchase** path on mainnet. Non-atomic buys (existing ANT) and standalone spawns are unaffected (small txs, no ALT).

## Fix
Poll the table at **'finalized'** commitment (network-wide visibility) before sending the consuming tx; bump the wait budget to 45s (finalization ~13s+).

## Verification (mainnet)
Before: atomic buy failed to confirm 3/3. After: confirms **2/2** — name resolves to the auto-spawned ANT, ADR-028 UpdateAuthority = ant_authority PDA, traits synced. tsc + format clean.

Publishes as a `4.1.x` patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lookup table readiness checks by waiting for finalized network state.
  * Increased the readiness timeout to reduce failures during network propagation.
  * Updated status and error messages to better reflect finalization and availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->