### PR TITLE
fix(crank): drain several prune_name_to_returned txs per scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## [4.0.3](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2...v4.0.3) (2026-06-20)
+
+
+### Bug Fixes
+
+* **arns:** floor returned-name premium at 1x to match on-chain pricing ([9ddfd9e](https://github.com/ar-io/ar-io-sdk/commit/9ddfd9eac36e3a2d14aa9152450dbfbfbf7dd955))
+* chunk delegates getMultipleAccounts call at 100 ([bfeaa60](https://github.com/ar-io/ar-io-sdk/commit/bfeaa6042507491dbd2b2714272d1bd25f1ce3fb))
+* **cli:** normalize argv[1] path separators for Windows compatibility ([c1d100b](https://github.com/ar-io/ar-io-sdk/commit/c1d100bad47537ceaa0a6c70a01e8fff52dbbe63))
+* **gas est:** add gas estimation utils ([12f2bcf](https://github.com/ar-io/ar-io-sdk/commit/12f2bcf8ba680757712d6f1c52cf6572d2e1b4ff))
+* **gas:** update gas estimate logic ([e667568](https://github.com/ar-io/ar-io-sdk/commit/e667568d712c9700e8f07356cdcb3c7aaf0ea21b))
+* **gas:** update gas utils comments ([af4889b](https://github.com/ar-io/ar-io-sdk/commit/af4889bd1d29fbfa6f462a349b10319a2f856edf))
+* **primary names:** fix primary names funding plan for permabought names ([0aac17c](https://github.com/ar-io/ar-io-sdk/commit/0aac17c7626f8487417e8bc4631c5954f89c558b))
+* **send tx:** update send tx ([693cb93](https://github.com/ar-io/ar-io-sdk/commit/693cb9391c9a87b3d6b4025e8a943b0d2659c226))
+* **solana:** filter finalize_gone candidates by leave-window eligibility ([900319c](https://github.com/ar-io/ar-io-sdk/commit/900319c43fb5a090e00d43a2f74309f3d18c047e))
+* **solana:** finalize_gone eligibility must use the full leave window ([49c70d2](https://github.com/ar-io/ar-io-sdk/commit/49c70d202f1bcdbe45448d26eb55028ba6471fdc)), closes [#685](https://github.com/ar-io/ar-io-sdk/issues/685)
+* **solana:** price returned-name premium against the cluster clock ([8ffec26](https://github.com/ar-io/ar-io-sdk/commit/8ffec264a77f0a54f0f83d484fe0431bb0094827))
+* **solana:** source demand-factor settings from program constants ([f5bccb1](https://github.com/ar-io/ar-io-sdk/commit/f5bccb123da246fa2aabccb5d632965ca5bb56f1)), closes [ar-io/ar-io-solana-contracts#export-arns-constants](https://github.com/ar-io/ar-io-solana-contracts/issues/export-arns-constants)
+* **solana:** use base64 encoding for memcmp filters in getProgramAccounts ([26de129](https://github.com/ar-io/ar-io-sdk/commit/26de12916ffaaa3ad4ee8917b9db568fe2b6b95e))
+* **solana:** use epoch duration in seconds for finalize_gone window ([de99061](https://github.com/ar-io/ar-io-sdk/commit/de990613af7806a1b7a0c96a0d0e453eeb09f1aa))
+* **undername increase:** fix undername increase action ([83aa1de](https://github.com/ar-io/ar-io-sdk/commit/83aa1deb7944fcf73a8253cd9f31c5c98cf63438))
+
 ## [4.0.3-alpha.1](https://github.com/ar-io/ar-io-sdk/compare/v4.0.2...v4.0.3-alpha.1) (2026-06-20)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.1.1](https://github.com/ar-io/ar-io-sdk/compare/v4.1.0...v4.1.1) (2026-08-10)
+
+
+### Bug Fixes
+
+* **solana:** wait for ephemeral ALT finalization before the consuming tx ([f255656](https://github.com/ar-io/ar-io-sdk/commit/f2556563939d97482762d2d7dfc83fa1ce58ba82))
+
 # [4.1.0](https://github.com/ar-io/ar-io-sdk/compare/v4.0.3...v4.1.0) (2026-08-10)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# [4.1.0](https://github.com/ar-io/ar-io-sdk/compare/v4.0.3...v4.1.0) (2026-08-10)
+
+
+### Bug Fixes
+
+* **arns:** resolve txId from ANT record in resolveArNSName ([ba061cf](https://github.com/ar-io/ar-io-sdk/commit/ba061cf51c74ddf827a678f447193316f76ffb03))
+* **cli:** forward --ant-program-id to ARIO read/write clients ([c1f9c0e](https://github.com/ar-io/ar-io-sdk/commit/c1f9c0e63f0fc41e7392a48b5dc6e41da9a31fda))
+* **solana:** don't let sync_attributes revert the spawned-ANT ACL records ([ba3cd1e](https://github.com/ar-io/ar-io-sdk/commit/ba3cd1e415d0ff712a569e52a9a36765349d21cf))
+* **solana:** drop stale getProgramAccounts ghosts before close_observations batch ([f95937c](https://github.com/ar-io/ar-io-sdk/commit/f95937c5f5e3012153b3c8f0b16adacb720fac9b))
+* **solana:** getVaults returns numeric vaultId so release/revoke work ([eae22cc](https://github.com/ar-io/ar-io-sdk/commit/eae22cc98297a65237068aec334af3bdfb402238))
+* **solana:** harden atomic-buy antState (CodeRabbit) ([6d1a3d8](https://github.com/ar-io/ar-io-sdk/commit/6d1a3d8de77606ab03e8adb6b7fdef117a49d340))
+* **solana:** pin spawn owner to signer + skip stale escrow ADR-022 test ([7a6bc2b](https://github.com/ar-io/ar-io-sdk/commit/7a6bc2bbeaf144eca32631a50719964234a766e9)), closes [post-#698](https://github.com/post-/issues/698)
+* **solana:** route oversized atomic spawn-and-buy through a lookup table ([a929556](https://github.com/ar-io/ar-io-sdk/commit/a92955603d9b34951b5073f25b35aaa3aaf47040))
+
+
+### Features
+
+* **acl:** add sync acl api ([892811b](https://github.com/ar-io/ar-io-sdk/commit/892811bab1f2f0659fb6b6bf9702bc1ef658d31e))
+* **cli:** expose atomic-buy ANT metadata (antState) in buy-record + docs ([73dcbf9](https://github.com/ar-io/ar-io-sdk/commit/73dcbf9ca230d699ad5c5584cb120a3a8ed99248))
+* **crank:** drive the full ArNS lease lifecycle from crankEpochStep ([0d8b7ea](https://github.com/ar-io/ar-io-sdk/commit/0d8b7ea00525edd9dcb0d7f0f3fb8153acf6da9f))
+* **solana:** allow setting ANT metadata + @ target atomically in buyRecord ([e7c4ef4](https://github.com/ar-io/ar-io-sdk/commit/e7c4ef404421c66efd79edacce2fae16862ce30c))
+* **solana:** atomically spawn an ANT during buyRecord when no processId ([35b3dea](https://github.com/ar-io/ar-io-sdk/commit/35b3dea306b6bc3461a25122581f4c13eca07ff0))
+* **solana:** close_observation refunds rent to observer + adminSetRewardRatios ([dd1c246](https://github.com/ar-io/ar-io-sdk/commit/dd1c2465a1ff8730b74118f1dc1efb52d90f0f27)), closes [ar-io-solana-contracts#116](https://github.com/ar-io-solana-contracts/issues/116)
+* **solana:** mint ANTs with program-controlled UpdateAuthority (ADR-028) ([fc67988](https://github.com/ar-io/ar-io-sdk/commit/fc67988844915e0a67d5bde22a8facd882bfe8b7))
+
 # [4.1.0-alpha.8](https://github.com/ar-io/ar-io-sdk/compare/v4.1.0-alpha.7...v4.1.0-alpha.8) (2026-08-10)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.0.3-alpha.1",
+  "version": "4.0.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.1.0-alpha.8",
+  "version": "4.1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@ar.io/solana-contracts": "1.0.0-staging.22",
+    "@ar.io/solana-contracts": "1.1.0",
     "@noble/hashes": "^1.8.0",
     "@solana-program/address-lookup-table": "^0.11.0",
     "@solana-program/compute-budget": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/src/solana/crank-epoch-step.test.ts
+++ b/src/solana/crank-epoch-step.test.ts
@@ -206,9 +206,14 @@ class TestCranker extends SolanaARIOWriteable {
     this.calls.push('getPruneableToReturned');
     return this.pruneableToReturned;
   }
+  /** Name whose `pruneNameToReturned` should throw, for partial-drain tests. */
+  pruneToReturnedFailOn?: string;
   // biome-ignore lint/suspicious/noExplicitAny: test stubs
   async pruneNameToReturned(p: any): Promise<any> {
     this.calls.push(`pruneToReturned:${p.name}`);
+    if (this.pruneToReturnedFailOn === p.name) {
+      throw new Error(`boom:${p.name}`);
+    }
     return { id: 'tx-prune-to-returned' };
   }
 
@@ -929,16 +934,95 @@ describe('crankEpochStep — ArNS lease lifecycle (prune_name_to_returned / prun
     c.dfPeriod = { currentPeriod: 2, periodZeroStartTimestamp: 0 };
   };
 
-  it('converts a past-grace lease into a returned-name auction', async () => {
+  it('converts past-grace leases into returned-name auctions', async () => {
     const c = new TestCranker();
     liveWaiting(c);
     c.pruneableToReturned = leases(3);
     const r = await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
     assert.equal(r.action, 'prune_name_to_returned');
     assert.equal(r.txId, 'tx-prune-to-returned');
-    // one name per tx — the instruction takes a single record
-    assert.deepEqual(r.progress, { index: 1, total: 3 });
+    // one name per tx, but the whole backlog drains within the default budget
+    assert.deepEqual(r.progress, { index: 3, total: 3 });
     assert.ok(c.calls.includes('pruneToReturned:lease0'));
+    assert.ok(c.calls.includes('pruneToReturned:lease2'));
+  });
+
+  it('drains up to pruneToReturnedTxsPerCycle names per scan', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(25);
+    const r = await c.crankEpochStep({
+      now: 5000,
+      pruneScanIntervalMs: 0,
+      pruneToReturnedTxsPerCycle: 4,
+    });
+    assert.deepEqual(r.progress, { index: 4, total: 25 });
+    assert.equal(
+      c.calls.filter((x) => x.startsWith('pruneToReturned:')).length,
+      4,
+    );
+  });
+
+  it('defaults to 10 txs per scan', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(25);
+    const r = await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
+    assert.deepEqual(r.progress, { index: 10, total: 25 });
+    // a clean budget-bounded drain must NOT look like a failure
+    assert.equal(r.partialFailureReason, undefined);
+  });
+
+  it('scans getPruneableToReturnedRecords once per drain, not once per name', async () => {
+    // The scan is a getProgramAccounts over every ArnsRecord; re-running it per
+    // name would make draining a backlog quadratic in RPC cost.
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(10);
+    await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
+    assert.equal(
+      c.calls.filter((x) => x === 'getPruneableToReturned').length,
+      1,
+    );
+  });
+
+  it('reports partial progress when a later name fails mid-drain', async () => {
+    // The deadline is per-name, so one unconvertible record must not forfeit
+    // the whole cycle — the names already converted still count.
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(5);
+    c.pruneToReturnedFailOn = 'lease2';
+    const r = await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
+    assert.equal(r.action, 'prune_name_to_returned');
+    assert.deepEqual(r.progress, { index: 2, total: 5 });
+    // the caller must be able to tell a bounded drain from a broken one
+    assert.match(String(r.partialFailureReason), /boom:lease2/);
+    // stopped at the failure rather than ploughing on
+    assert.ok(!c.calls.includes('pruneToReturned:lease3'));
+  });
+
+  it('rethrows when the very first name fails, so the step still surfaces errors', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(5);
+    c.pruneToReturnedFailOn = 'lease0';
+    await assert.rejects(
+      () => c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 }),
+      /boom:lease0/,
+    );
+  });
+
+  it('never submits fewer than one tx even with a zero/negative budget', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(5);
+    const r = await c.crankEpochStep({
+      now: 5000,
+      pruneScanIntervalMs: 0,
+      pruneToReturnedTxsPerCycle: 0,
+    });
+    assert.deepEqual(r.progress, { index: 1, total: 5 });
   });
 
   it('prioritises prune_name_to_returned over both cleanup steps', async () => {

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -566,7 +566,9 @@ export interface CrankEpochStepOptions {
    * (`WORKFLOWS.md`: "Cranker — drive epoch pipeline, update demand factor,
    * prune state | ario-gar, ario-arns").
    *
-   * One name per tx — the instruction takes a single record, not a batch.
+   * One name per tx — the instruction takes a single record, not a batch —
+   * but several txs may be submitted per scan; see
+   * {@link CrankEpochStepOptions.pruneToReturnedTxsPerCycle}.
    */
   enablePruneToReturned?: boolean;
   /**
@@ -582,6 +584,24 @@ export interface CrankEpochStepOptions {
    * 28 → over). Capped at 26 internally.
    */
   pruneExpiredBatchSize?: number;
+  /**
+   * Maximum `prune_name_to_returned` transactions to submit per scan.
+   * Default 10.
+   *
+   * The instruction takes a single record, so unlike the two cleanup steps this
+   * step cannot batch into one tx — its throughput is (txs per scan) × (scan
+   * rate). At one per scan a backlog can never drain faster than it accrues:
+   * the AR.IO cranker derives its scan interval from the epoch duration and
+   * clamps it to 30 min, so on a daily epoch throughput caps at ~48 names/day —
+   * the same order as the rate at which leases fall past their grace period.
+   * Any backlog then persists indefinitely, and every name that ages out of its
+   * auction window costs the protocol that Dutch auction permanently.
+   *
+   * Draining several per scan makes throughput proportional to the backlog
+   * rather than to the scan rate. Keep it under the caller's per-cycle tx
+   * budget (the AR.IO cranker allows 50 across all six phases).
+   */
+  pruneToReturnedTxsPerCycle?: number;
   /** Unix seconds; defaults to the wall clock. Injectable for testing. */
   now?: number;
 }
@@ -596,6 +616,14 @@ export interface CrankEpochStepResult {
   txId?: string;
   /** Batch progress for `'tally'` / `'distribute'`. */
   progress?: { index: number; total: number };
+  /**
+   * Set when a batched step stopped early because a submission failed. The
+   * step still reports the work it completed in `progress`; the failed item
+   * stays due and is retried on the next scan. Without this a partial drain is
+   * indistinguishable from a full one — the caller just sees a smaller
+   * `progress.index` and cannot tell whether the budget or an error bounded it.
+   */
+  partialFailureReason?: string;
   /** For `action: 'idle'`, why nothing was done. */
   reason?:
     | 'epochs_disabled'
@@ -4736,15 +4764,19 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
   }
 
   /**
-   * Convert ONE lease that is past its grace period — but still inside its
-   * return-auction window — into a `ReturnedName` Dutch auction, or `null`
-   * when none are due / the scan is throttled.
+   * Convert leases that are past their grace period — but still inside their
+   * return-auction window — into `ReturnedName` Dutch auctions, or `null` when
+   * none are due / the scan is throttled.
    *
    * This is the step whose absence stalled the whole ArNS lifecycle: without
    * it no ReturnedName PDA is ever created, so `prune_returned_names` drains a
    * queue that is never filled and expired names keep resolving forever.
    *
-   * One name per tx (the instruction takes a single record). Records past
+   * One name per tx (the instruction takes a single record), but up to
+   * {@link CrankEpochStepOptions.pruneToReturnedTxsPerCycle} txs per scan, off
+   * a single `getProgramAccounts`. Draining only one per scan caps throughput
+   * at the scan rate instead of the backlog size, which lets names age out of
+   * their auction window faster than they can be converted. Records past
    * `grace + auction` are intentionally NOT handled here — see
    * {@link maybePruneExpiredNamesStep}. The contract re-checks the grace
    * window itself, so a skewed client clock is safe.
@@ -4761,12 +4793,35 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     const due = await this.getPruneableToReturnedRecords(now);
     if (due.length === 0) return null;
 
-    const target = due[0];
-    const { id } = await this.pruneNameToReturned({ name: target.name });
+    const budget = Math.max(1, opts.pruneToReturnedTxsPerCycle ?? 10);
+    let lastTxId: string | undefined;
+    let partialFailureReason: string | undefined;
+    let pruned = 0;
+
+    for (const target of due.slice(0, budget)) {
+      try {
+        const { id } = await this.pruneNameToReturned({ name: target.name });
+        lastTxId = id;
+        pruned++;
+      } catch (error) {
+        // One unconvertible record must not strand the rest of the backlog —
+        // the deadline is per-name, so forfeiting the cycle to a single
+        // failure can cost auctions. Rethrow only when nothing succeeded, so a
+        // genuinely broken step still reaches the caller's error classifier;
+        // otherwise stop early and report real progress. The failed record
+        // stays due and is retried on the next scan.
+        if (pruned === 0) throw error;
+        partialFailureReason =
+          error instanceof Error ? error.message : String(error);
+        break;
+      }
+    }
+
     return {
       action: 'prune_name_to_returned',
-      txId: id,
-      progress: { index: 1, total: due.length },
+      txId: lastTxId,
+      progress: { index: pruned, total: due.length },
+      ...(partialFailureReason !== undefined ? { partialFailureReason } : {}),
     };
   }
 

--- a/src/solana/send.ts
+++ b/src/solana/send.ts
@@ -763,39 +763,45 @@ export async function sendWithEphemeralLookupTable({
 
 /**
  * Poll until an Address Lookup Table holds at least `expectedCount` addresses
- * AND at least one slot has elapsed since they all landed. Lookup-table entries
- * are only usable the slot AFTER they are appended, and the leader processing
- * the consuming tx must already see them — otherwise the runtime rejects the tx
- * with "address table lookup uses an invalid index". ALT account layout is a
- * 56-byte metadata header followed by 32-byte addresses.
+ * AT 'finalized' COMMITMENT. Lookup-table entries are only usable once the
+ * leader that processes the consuming tx can resolve them; a table that is only
+ * 'confirmed' lives on our RPC's fork and, on mainnet, is often not yet visible
+ * to the (different) leader building the big ALT-referencing tx — which then
+ * silently drops it (simulates fine on our RPC but never lands). Waiting for
+ * finalization guarantees network-wide visibility. Without this, mainnet atomic
+ * spawn-and-buy (and prescribe) txs intermittently fail to confirm. ALT account
+ * layout is a 56-byte metadata header followed by 32-byte addresses.
  */
 async function waitForLookupTableActive(
   rpc: SolanaRpc,
   table: Address,
   expectedCount: number,
-  maxWaitMs = 30_000,
+  maxWaitMs = 45_000,
 ): Promise<void> {
   const META = 56;
   const start = Date.now();
-  let slotAllPresent: bigint | null = null;
   while (Date.now() - start < maxWaitMs) {
-    const acc = await rpc.getAccountInfo(table, { encoding: 'base64' }).send();
-    const slot = acc.context.slot;
+    // Poll at 'finalized' so the table (with all its addresses) is visible to
+    // (nearly) every validator before the consuming tx is sent. A table that is
+    // only 'confirmed' lives on our RPC's fork; on mainnet the leader that
+    // processes the big ALT-referencing tx may not have it yet and silently
+    // drops the tx (it simulates fine on our RPC but never lands). Finalization
+    // guarantees network-wide visibility, so the tx resolves the table wherever
+    // it's processed.
+    const acc = await rpc
+      .getAccountInfo(table, { encoding: 'base64', commitment: 'finalized' })
+      .send();
     if (acc.value) {
       const len = Buffer.from(acc.value.data[0], 'base64').length;
       const count = len >= META ? Math.floor((len - META) / 32) : 0;
       if (count >= expectedCount) {
-        if (slotAllPresent === null) {
-          slotAllPresent = slot;
-        } else if (slot > slotAllPresent) {
-          return; // all addresses present + a slot has elapsed → warm
-        }
+        return; // finalized with every address → resolvable by any leader
       }
     }
     await new Promise((r) => setTimeout(r, 800));
   }
   throw new Error(
-    `lookup table ${table} not active (≥${expectedCount} addresses + 1 slot) within ${maxWaitMs}ms`,
+    `lookup table ${table} not finalized with >=${expectedCount} addresses within ${maxWaitMs}ms`,
   );
 }
 

--- a/src/solana/send.ts
+++ b/src/solana/send.ts
@@ -781,6 +781,7 @@ async function waitForLookupTableActive(
   const META = 56;
   const start = Date.now();
   while (Date.now() - start < maxWaitMs) {
+    const remaining = maxWaitMs - (Date.now() - start);
     // Poll at 'finalized' so the table (with all its addresses) is visible to
     // (nearly) every validator before the consuming tx is sent. A table that is
     // only 'confirmed' lives on our RPC's fork; on mainnet the leader that
@@ -788,17 +789,29 @@ async function waitForLookupTableActive(
     // drops the tx (it simulates fine on our RPC but never lands). Finalization
     // guarantees network-wide visibility, so the tx resolves the table wherever
     // it's processed.
+    //
+    // Bound the RPC call by the remaining deadline so a hung request can't run
+    // past maxWaitMs (AbortSignal.timeout is Node 18+, which the SDK targets);
+    // a timed-out or transient failure yields null and re-polls until the loop
+    // deadline. The final `throw` still reports the bounded wait.
     const acc = await rpc
       .getAccountInfo(table, { encoding: 'base64', commitment: 'finalized' })
-      .send();
-    if (acc.value) {
+      .send({ abortSignal: AbortSignal.timeout(remaining) })
+      .catch(() => null);
+    if (acc?.value) {
       const len = Buffer.from(acc.value.data[0], 'base64').length;
       const count = len >= META ? Math.floor((len - META) / 32) : 0;
       if (count >= expectedCount) {
         return; // finalized with every address → resolvable by any leader
       }
     }
-    await new Promise((r) => setTimeout(r, 800));
+    // Cap the poll delay to the time left so it never overshoots the deadline.
+    await new Promise((r) =>
+      setTimeout(
+        r,
+        Math.min(800, Math.max(0, maxWaitMs - (Date.now() - start))),
+      ),
+    );
   }
   throw new Error(
     `lookup table ${table} not finalized with >=${expectedCount} addresses within ${maxWaitMs}ms`,

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.0.3-alpha.1';
+export const version = '4.0.3';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.1.0-alpha.8';
+export const version = '4.1.0';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.1.0';
+export const version = '4.1.1';

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,10 @@
   resolved "https://registry.yarnpkg.com/@actions/io/-/io-3.0.2.tgz#6f89b27a159d109836d983efa283997c23b92284"
   integrity sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==
 
-"@ar.io/solana-contracts@1.0.0-staging.22":
-  version "1.0.0-staging.22"
-  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.0.0-staging.22.tgz#51a2f896828fc2394cb9a1bdb591cb995f51aecb"
-  integrity sha512-W/v1xE/9xeKyH7FxOQSI5keKfSzR8oVaMyv4gtcE1pte2BNQP2MB8FzQ2nDKHO+/ByAtmLfJQceDjrGuSP+LPg==
+"@ar.io/solana-contracts@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.1.0.tgz#900784dad9b0867ae76678dc177d346692f5e61f"
+  integrity sha512-qX8ttp5GoZYMMNNgVzGMdBmaym3g1XL3Y7GyApbbXo4e4SSgt3DXMKl6PCISij5snhkec21LAhHxzHuLyoOe8w==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
## Problem

`maybePruneToReturnedStep` converted exactly **one** lease per scan, so the step's throughput was `1 × scan rate` rather than a function of the backlog.

That cap is load-bearing, because this is the one time-sensitive step — as the dispatcher already documents: a lease must be converted while still inside its auction window, or it ages into the past-auction band and is closed directly, **losing the protocol that Dutch auction permanently**.

The AR.IO cranker derives its scan interval from the epoch duration and clamps it to a 30 min ceiling, so on a daily epoch throughput capped at **~48 names/day**.

Observed on mainnet: a **121-name backlog** with names ageing out of their auction window at **~48/day** — arrival and max service rate were the same number, so the queue could never drain and every aged-out name was a lost auction. The backlog had been *growing* (155 → 174) before intervention.

Note the asymmetry this creates: the revenue-*losing* path (`prune_expired_names`, direct close) batches 26 per tx, while the revenue-*earning* auction path did 1.

## Change

- `pruneToReturnedTxsPerCycle` (default **10**) — drain up to that many per scan. The instruction takes a single record so it genuinely cannot batch into one tx, but nothing stopped several txs off a **single** `getProgramAccounts`, so RPC cost stays linear rather than quadratic.
- The default sits well under the AR.IO cranker's 50-tx-per-cycle budget shared across its six phases.
- A failure part-way through reports the progress already made rather than forfeiting the cycle (the deadline is per-name), and still rethrows when the *first* name fails so a genuinely broken step reaches the caller's error classifier.
- `partialFailureReason` on the result — without it a partial drain is indistinguishable from a budget-bounded one; the caller just sees a smaller `progress.index`.

## Testing

- 454 unit tests, 0 failures (7 new covering budget, default, single-scan, zero-budget floor, partial failure, first-failure rethrow, and reason propagation).
- `lint:check` / `format:check` / `build` green on node 18.x and 20.x (the CI matrix).
- **Validated end-to-end on AR.IO Staging V2 (devnet)**: drained **141 → 83 pruneable records in ~15 min**. `progress.index` tracked the configured budget exactly (5, then 8). On-chain `PruneNameToReturned` confirmed, `err: None`, **+0.000357 SOL** rent reclaimed per prune.
- A real RPC 429 during that run tripped the partial path and surfaced `partialFailureReason: "HTTP error (429): Too Many Requests"` — which is precisely why that field was added.

## Compatibility

Purely additive: a new optional option and a new optional result field. Callers that pass neither keep working, though they stay capped at one per scan until they opt in.