### PR TITLE
fix: convert timestamps to milliseconds in getArNSRecord

### DIFF
--- a/src/solana/io-readable.test.ts
+++ b/src/solana/io-readable.test.ts
@@ -1,11 +1,11 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { type Address } from '@solana/kit';
 import {
   PurchaseType,
   getArnsRecordEncoder,
 } from '@ar.io/solana-contracts/arns';
+import { type Address } from '@solana/kit';
 import bs58 from 'bs58';
 
 import { Logger } from '../common/logger.js';

--- a/src/solana/io-readable.test.ts
+++ b/src/solana/io-readable.test.ts
@@ -1,6 +1,11 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
+import { type Address } from '@solana/kit';
+import {
+  PurchaseType,
+  getArnsRecordEncoder,
+} from '@ar.io/solana-contracts/arns';
 import bs58 from 'bs58';
 
 import { Logger } from '../common/logger.js';
@@ -49,5 +54,98 @@ describe('SolanaARIOReadable accumulator batching', () => {
     assert.equal(counts.gma, 3, '250 gateways should be split into 3 calls');
     assert.equal(counts.gmaAccts, 250, 'all 250 accounts should be requested');
     assert.deepEqual(accumulators, new Map());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getArNSRecord — timestamp conversion (seconds → milliseconds)
+// ---------------------------------------------------------------------------
+
+const OWNER_ADDR = '11111111111111111111111111111111' as Address;
+const VERSION = { major: 1, minor: 0, patch: 0 };
+
+function arnsRecordBytes(
+  name: string,
+  startSec: number,
+  endSec: number | null,
+): Uint8Array {
+  return getArnsRecordEncoder().encode({
+    nameHash: new Uint8Array(32),
+    owner: OWNER_ADDR,
+    ant: OWNER_ADDR,
+    purchaseType: endSec === null ? PurchaseType.Permabuy : PurchaseType.Lease,
+    startTimestamp: startSec,
+    endTimestamp: endSec,
+    undernameLimit: 10,
+    purchasePrice: 0,
+    bump: 255,
+    name,
+    version: VERSION,
+  }) as Uint8Array;
+}
+
+/** Stub rpc that returns `bytes` for any getAccountInfo call. */
+function singleAccountRpc(bytes: Uint8Array): unknown {
+  const b64 = Buffer.from(bytes).toString('base64');
+  return {
+    getAccountInfo: () => ({
+      send: async () => ({
+        value: {
+          data: [b64, 'base64'] as readonly [string, string],
+          executable: false,
+          lamports: 1_000_000n,
+          owner: OWNER_ADDR,
+          rentEpoch: 0n,
+          space: BigInt(bytes.length),
+        },
+      }),
+    }),
+  };
+}
+
+describe('getArNSRecord — timestamp conversion', () => {
+  it('converts lease startTimestamp and endTimestamp from seconds to milliseconds', async () => {
+    const startSec = 1_720_000_000; // ~2024-07-03
+    const endSec = 1_756_000_000; // ~2025-08-23
+    const bytes = arnsRecordBytes('testname', startSec, endSec);
+    const readable = new SolanaARIOReadable({
+      rpc: singleAccountRpc(bytes) as never,
+    });
+
+    const record = await readable.getArNSRecord({ name: 'testname' });
+
+    assert.equal(record.type, 'lease');
+    assert.equal(
+      record.startTimestamp,
+      startSec * 1000,
+      'startTimestamp should be in milliseconds',
+    );
+    assert.equal(
+      'endTimestamp' in record ? record.endTimestamp : undefined,
+      endSec * 1000,
+      'endTimestamp should be in milliseconds',
+    );
+  });
+
+  it('converts permabuy startTimestamp and omits endTimestamp', async () => {
+    const startSec = 1_720_000_000;
+    const bytes = arnsRecordBytes('permatest', startSec, null);
+    const readable = new SolanaARIOReadable({
+      rpc: singleAccountRpc(bytes) as never,
+    });
+
+    const record = await readable.getArNSRecord({ name: 'permatest' });
+
+    assert.equal(record.type, 'permabuy');
+    assert.equal(
+      record.startTimestamp,
+      startSec * 1000,
+      'startTimestamp should be in milliseconds',
+    );
+    assert.equal(
+      'endTimestamp' in record,
+      false,
+      'permabuy should not have endTimestamp',
+    );
   });
 });

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -1240,7 +1240,7 @@ export class SolanaARIOReadable {
     }
     const record = deserializeArnsRecord(Buffer.from(account.data));
     const { name: _, owner: __, ...nameData } = record;
-    return nameData;
+    return toMsTimestamps(nameData);
   }
 
   async getArNSRecords(


### PR DESCRIPTION
## Summary
- `getArNSRecord` (singular) returns raw `deserializeArnsRecord` timestamps in **seconds** (on-chain format)
- `getArNSRecords` (plural) converts them to **milliseconds** via `arnsRecordToWithName` → `secToMs`
- This inconsistency causes consumers expecting milliseconds to show lease expiry dates as 1970 and all leases as "Expired"
- Fix: apply `toMsTimestamps` to the return value, matching every other public method on `SolanaARIOReadable`

## One-line change
```diff
-    return nameData;
+    return toMsTimestamps(nameData);
```

## Impact
Any consumer calling `getArNSRecord` and comparing `startTimestamp`/`endTimestamp` against `Date.now()` or passing them to `new Date()` was affected. The `arns-react` app worked around this in v2.3.4 but the fix belongs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected timestamp values returned by ArNS records to use JavaScript-compatible milliseconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->