### PR TITLE
release: promote alpha to main (4.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.1.2-alpha.2](https://github.com/ar-io/ar-io-sdk/compare/v4.1.2-alpha.1...v4.1.2-alpha.2) (2026-08-11)
+
+
+### Bug Fixes
+
+* convert timestamps to milliseconds in getArNSRecord ([1af52db](https://github.com/ar-io/ar-io-sdk/commit/1af52dbabe367adfd13c9931ac9ad28f8428976c))
+
 ## [4.1.2-alpha.1](https://github.com/ar-io/ar-io-sdk/compare/v4.1.1...v4.1.2-alpha.1) (2026-08-11)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.1.2-alpha.1](https://github.com/ar-io/ar-io-sdk/compare/v4.1.1...v4.1.2-alpha.1) (2026-08-11)
+
+
+### Bug Fixes
+
+* **crank:** drain several prune_name_to_returned txs per scan ([198d0e6](https://github.com/ar-io/ar-io-sdk/commit/198d0e69c72fc208a135b28337cd923f7c71079d))
+
 ## [4.1.1](https://github.com/ar-io/ar-io-sdk/compare/v4.1.0...v4.1.1) (2026-08-10)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.1.1",
+  "version": "4.1.2-alpha.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.1.2-alpha.1",
+  "version": "4.1.2-alpha.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/src/solana/crank-epoch-step.test.ts
+++ b/src/solana/crank-epoch-step.test.ts
@@ -206,9 +206,14 @@ class TestCranker extends SolanaARIOWriteable {
     this.calls.push('getPruneableToReturned');
     return this.pruneableToReturned;
   }
+  /** Name whose `pruneNameToReturned` should throw, for partial-drain tests. */
+  pruneToReturnedFailOn?: string;
   // biome-ignore lint/suspicious/noExplicitAny: test stubs
   async pruneNameToReturned(p: any): Promise<any> {
     this.calls.push(`pruneToReturned:${p.name}`);
+    if (this.pruneToReturnedFailOn === p.name) {
+      throw new Error(`boom:${p.name}`);
+    }
     return { id: 'tx-prune-to-returned' };
   }
 
@@ -929,16 +934,95 @@ describe('crankEpochStep — ArNS lease lifecycle (prune_name_to_returned / prun
     c.dfPeriod = { currentPeriod: 2, periodZeroStartTimestamp: 0 };
   };
 
-  it('converts a past-grace lease into a returned-name auction', async () => {
+  it('converts past-grace leases into returned-name auctions', async () => {
     const c = new TestCranker();
     liveWaiting(c);
     c.pruneableToReturned = leases(3);
     const r = await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
     assert.equal(r.action, 'prune_name_to_returned');
     assert.equal(r.txId, 'tx-prune-to-returned');
-    // one name per tx — the instruction takes a single record
-    assert.deepEqual(r.progress, { index: 1, total: 3 });
+    // one name per tx, but the whole backlog drains within the default budget
+    assert.deepEqual(r.progress, { index: 3, total: 3 });
     assert.ok(c.calls.includes('pruneToReturned:lease0'));
+    assert.ok(c.calls.includes('pruneToReturned:lease2'));
+  });
+
+  it('drains up to pruneToReturnedTxsPerCycle names per scan', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(25);
+    const r = await c.crankEpochStep({
+      now: 5000,
+      pruneScanIntervalMs: 0,
+      pruneToReturnedTxsPerCycle: 4,
+    });
+    assert.deepEqual(r.progress, { index: 4, total: 25 });
+    assert.equal(
+      c.calls.filter((x) => x.startsWith('pruneToReturned:')).length,
+      4,
+    );
+  });
+
+  it('defaults to 10 txs per scan', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(25);
+    const r = await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
+    assert.deepEqual(r.progress, { index: 10, total: 25 });
+    // a clean budget-bounded drain must NOT look like a failure
+    assert.equal(r.partialFailureReason, undefined);
+  });
+
+  it('scans getPruneableToReturnedRecords once per drain, not once per name', async () => {
+    // The scan is a getProgramAccounts over every ArnsRecord; re-running it per
+    // name would make draining a backlog quadratic in RPC cost.
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(10);
+    await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
+    assert.equal(
+      c.calls.filter((x) => x === 'getPruneableToReturned').length,
+      1,
+    );
+  });
+
+  it('reports partial progress when a later name fails mid-drain', async () => {
+    // The deadline is per-name, so one unconvertible record must not forfeit
+    // the whole cycle — the names already converted still count.
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(5);
+    c.pruneToReturnedFailOn = 'lease2';
+    const r = await c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 });
+    assert.equal(r.action, 'prune_name_to_returned');
+    assert.deepEqual(r.progress, { index: 2, total: 5 });
+    // the caller must be able to tell a bounded drain from a broken one
+    assert.match(String(r.partialFailureReason), /boom:lease2/);
+    // stopped at the failure rather than ploughing on
+    assert.ok(!c.calls.includes('pruneToReturned:lease3'));
+  });
+
+  it('rethrows when the very first name fails, so the step still surfaces errors', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(5);
+    c.pruneToReturnedFailOn = 'lease0';
+    await assert.rejects(
+      () => c.crankEpochStep({ now: 5000, pruneScanIntervalMs: 0 }),
+      /boom:lease0/,
+    );
+  });
+
+  it('never submits fewer than one tx even with a zero/negative budget', async () => {
+    const c = new TestCranker();
+    liveWaiting(c);
+    c.pruneableToReturned = leases(5);
+    const r = await c.crankEpochStep({
+      now: 5000,
+      pruneScanIntervalMs: 0,
+      pruneToReturnedTxsPerCycle: 0,
+    });
+    assert.deepEqual(r.progress, { index: 1, total: 5 });
   });
 
   it('prioritises prune_name_to_returned over both cleanup steps', async () => {

--- a/src/solana/io-readable.test.ts
+++ b/src/solana/io-readable.test.ts
@@ -1,11 +1,11 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { type Address } from '@solana/kit';
 import {
   PurchaseType,
   getArnsRecordEncoder,
 } from '@ar.io/solana-contracts/arns';
+import { type Address } from '@solana/kit';
 import bs58 from 'bs58';
 
 import { Logger } from '../common/logger.js';

--- a/src/solana/io-readable.test.ts
+++ b/src/solana/io-readable.test.ts
@@ -1,6 +1,11 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
+import { type Address } from '@solana/kit';
+import {
+  PurchaseType,
+  getArnsRecordEncoder,
+} from '@ar.io/solana-contracts/arns';
 import bs58 from 'bs58';
 
 import { Logger } from '../common/logger.js';
@@ -49,5 +54,98 @@ describe('SolanaARIOReadable accumulator batching', () => {
     assert.equal(counts.gma, 3, '250 gateways should be split into 3 calls');
     assert.equal(counts.gmaAccts, 250, 'all 250 accounts should be requested');
     assert.deepEqual(accumulators, new Map());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getArNSRecord — timestamp conversion (seconds → milliseconds)
+// ---------------------------------------------------------------------------
+
+const OWNER_ADDR = '11111111111111111111111111111111' as Address;
+const VERSION = { major: 1, minor: 0, patch: 0 };
+
+function arnsRecordBytes(
+  name: string,
+  startSec: number,
+  endSec: number | null,
+): Uint8Array {
+  return getArnsRecordEncoder().encode({
+    nameHash: new Uint8Array(32),
+    owner: OWNER_ADDR,
+    ant: OWNER_ADDR,
+    purchaseType: endSec === null ? PurchaseType.Permabuy : PurchaseType.Lease,
+    startTimestamp: startSec,
+    endTimestamp: endSec,
+    undernameLimit: 10,
+    purchasePrice: 0,
+    bump: 255,
+    name,
+    version: VERSION,
+  }) as Uint8Array;
+}
+
+/** Stub rpc that returns `bytes` for any getAccountInfo call. */
+function singleAccountRpc(bytes: Uint8Array): unknown {
+  const b64 = Buffer.from(bytes).toString('base64');
+  return {
+    getAccountInfo: () => ({
+      send: async () => ({
+        value: {
+          data: [b64, 'base64'] as readonly [string, string],
+          executable: false,
+          lamports: 1_000_000n,
+          owner: OWNER_ADDR,
+          rentEpoch: 0n,
+          space: BigInt(bytes.length),
+        },
+      }),
+    }),
+  };
+}
+
+describe('getArNSRecord — timestamp conversion', () => {
+  it('converts lease startTimestamp and endTimestamp from seconds to milliseconds', async () => {
+    const startSec = 1_720_000_000; // ~2024-07-03
+    const endSec = 1_756_000_000; // ~2025-08-23
+    const bytes = arnsRecordBytes('testname', startSec, endSec);
+    const readable = new SolanaARIOReadable({
+      rpc: singleAccountRpc(bytes) as never,
+    });
+
+    const record = await readable.getArNSRecord({ name: 'testname' });
+
+    assert.equal(record.type, 'lease');
+    assert.equal(
+      record.startTimestamp,
+      startSec * 1000,
+      'startTimestamp should be in milliseconds',
+    );
+    assert.equal(
+      'endTimestamp' in record ? record.endTimestamp : undefined,
+      endSec * 1000,
+      'endTimestamp should be in milliseconds',
+    );
+  });
+
+  it('converts permabuy startTimestamp and omits endTimestamp', async () => {
+    const startSec = 1_720_000_000;
+    const bytes = arnsRecordBytes('permatest', startSec, null);
+    const readable = new SolanaARIOReadable({
+      rpc: singleAccountRpc(bytes) as never,
+    });
+
+    const record = await readable.getArNSRecord({ name: 'permatest' });
+
+    assert.equal(record.type, 'permabuy');
+    assert.equal(
+      record.startTimestamp,
+      startSec * 1000,
+      'startTimestamp should be in milliseconds',
+    );
+    assert.equal(
+      'endTimestamp' in record,
+      false,
+      'permabuy should not have endTimestamp',
+    );
   });
 });

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -1240,7 +1240,7 @@ export class SolanaARIOReadable {
     }
     const record = deserializeArnsRecord(Buffer.from(account.data));
     const { name: _, owner: __, ...nameData } = record;
-    return nameData;
+    return toMsTimestamps(nameData);
   }
 
   async getArNSRecords(

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -566,7 +566,9 @@ export interface CrankEpochStepOptions {
    * (`WORKFLOWS.md`: "Cranker — drive epoch pipeline, update demand factor,
    * prune state | ario-gar, ario-arns").
    *
-   * One name per tx — the instruction takes a single record, not a batch.
+   * One name per tx — the instruction takes a single record, not a batch —
+   * but several txs may be submitted per scan; see
+   * {@link CrankEpochStepOptions.pruneToReturnedTxsPerCycle}.
    */
   enablePruneToReturned?: boolean;
   /**
@@ -582,6 +584,24 @@ export interface CrankEpochStepOptions {
    * 28 → over). Capped at 26 internally.
    */
   pruneExpiredBatchSize?: number;
+  /**
+   * Maximum `prune_name_to_returned` transactions to submit per scan.
+   * Default 10.
+   *
+   * The instruction takes a single record, so unlike the two cleanup steps this
+   * step cannot batch into one tx — its throughput is (txs per scan) × (scan
+   * rate). At one per scan a backlog can never drain faster than it accrues:
+   * the AR.IO cranker derives its scan interval from the epoch duration and
+   * clamps it to 30 min, so on a daily epoch throughput caps at ~48 names/day —
+   * the same order as the rate at which leases fall past their grace period.
+   * Any backlog then persists indefinitely, and every name that ages out of its
+   * auction window costs the protocol that Dutch auction permanently.
+   *
+   * Draining several per scan makes throughput proportional to the backlog
+   * rather than to the scan rate. Keep it under the caller's per-cycle tx
+   * budget (the AR.IO cranker allows 50 across all six phases).
+   */
+  pruneToReturnedTxsPerCycle?: number;
   /** Unix seconds; defaults to the wall clock. Injectable for testing. */
   now?: number;
 }
@@ -596,6 +616,14 @@ export interface CrankEpochStepResult {
   txId?: string;
   /** Batch progress for `'tally'` / `'distribute'`. */
   progress?: { index: number; total: number };
+  /**
+   * Set when a batched step stopped early because a submission failed. The
+   * step still reports the work it completed in `progress`; the failed item
+   * stays due and is retried on the next scan. Without this a partial drain is
+   * indistinguishable from a full one — the caller just sees a smaller
+   * `progress.index` and cannot tell whether the budget or an error bounded it.
+   */
+  partialFailureReason?: string;
   /** For `action: 'idle'`, why nothing was done. */
   reason?:
     | 'epochs_disabled'
@@ -4736,15 +4764,19 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
   }
 
   /**
-   * Convert ONE lease that is past its grace period — but still inside its
-   * return-auction window — into a `ReturnedName` Dutch auction, or `null`
-   * when none are due / the scan is throttled.
+   * Convert leases that are past their grace period — but still inside their
+   * return-auction window — into `ReturnedName` Dutch auctions, or `null` when
+   * none are due / the scan is throttled.
    *
    * This is the step whose absence stalled the whole ArNS lifecycle: without
    * it no ReturnedName PDA is ever created, so `prune_returned_names` drains a
    * queue that is never filled and expired names keep resolving forever.
    *
-   * One name per tx (the instruction takes a single record). Records past
+   * One name per tx (the instruction takes a single record), but up to
+   * {@link CrankEpochStepOptions.pruneToReturnedTxsPerCycle} txs per scan, off
+   * a single `getProgramAccounts`. Draining only one per scan caps throughput
+   * at the scan rate instead of the backlog size, which lets names age out of
+   * their auction window faster than they can be converted. Records past
    * `grace + auction` are intentionally NOT handled here — see
    * {@link maybePruneExpiredNamesStep}. The contract re-checks the grace
    * window itself, so a skewed client clock is safe.
@@ -4761,12 +4793,35 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     const due = await this.getPruneableToReturnedRecords(now);
     if (due.length === 0) return null;
 
-    const target = due[0];
-    const { id } = await this.pruneNameToReturned({ name: target.name });
+    const budget = Math.max(1, opts.pruneToReturnedTxsPerCycle ?? 10);
+    let lastTxId: string | undefined;
+    let partialFailureReason: string | undefined;
+    let pruned = 0;
+
+    for (const target of due.slice(0, budget)) {
+      try {
+        const { id } = await this.pruneNameToReturned({ name: target.name });
+        lastTxId = id;
+        pruned++;
+      } catch (error) {
+        // One unconvertible record must not strand the rest of the backlog —
+        // the deadline is per-name, so forfeiting the cycle to a single
+        // failure can cost auctions. Rethrow only when nothing succeeded, so a
+        // genuinely broken step still reaches the caller's error classifier;
+        // otherwise stop early and report real progress. The failed record
+        // stays due and is retried on the next scan.
+        if (pruned === 0) throw error;
+        partialFailureReason =
+          error instanceof Error ? error.message : String(error);
+        break;
+      }
+    }
+
     return {
       action: 'prune_name_to_returned',
-      txId: id,
-      progress: { index: 1, total: due.length },
+      txId: lastTxId,
+      progress: { index: pruned, total: due.length },
+      ...(partialFailureReason !== undefined ? { partialFailureReason } : {}),
     };
   }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.1.1';
+export const version = '4.1.2-alpha.1';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.1.2-alpha.1';
+export const version = '4.1.2-alpha.2';


### PR DESCRIPTION
Promotes `alpha` (validated as `4.1.2-alpha.2`) to `main` for a stable **4.1.2**.

Clean fast-forward: `alpha` is 9 ahead of `main`, `main` is 0 ahead of `alpha`, 0 conflicts.

## Contents

**`fix(crank): drain several prune_name_to_returned txs per scan`** (#703)
`maybePruneToReturnedStep` converted exactly one lease per scan, so throughput was `1 × scan rate` rather than a function of the backlog. That matters because it is the only deadline-bound step — a lease not converted inside its auction window is closed directly and the Dutch auction is lost permanently. With the AR.IO cranker's 30 min scan ceiling on a daily epoch, this capped at ~48 names/day against a measured expiry rate of ~48/day, so a 121-name mainnet backlog could never drain (it was growing, 155 → 174). Adds `pruneToReturnedTxsPerCycle` (default 10) draining off a single `getProgramAccounts`, plus `partialFailureReason` so a partial drain is distinguishable from a budget-bounded one.

**`fix: convert timestamps to milliseconds in getArNSRecord`** (#704)
`getArNSRecord` returned raw on-chain seconds while the rest of the projection layer (`toMsTimestamps` on gateways and returned names) returns milliseconds. Brings it in line, with regression tests covering both lease and permabuy records.

Plus a supporting import-sort fix.

## Validation

- 456 unit tests, 0 failures across both changes.
- Full CI matrix green on both PRs (node 18.x/20.x × lint/format/build, unit tests, CodeQL, CodeRabbit).
- `4.1.2-alpha.2` published and exercised end-to-end on AR.IO Staging V2 (devnet): drained **141 → 83 pruneable ArNS records in ~15 min**, with `progress.index` tracking the configured budget exactly. On-chain `PruneNameToReturned` confirmed, +0.000357 SOL rent reclaimed per prune. A live RPC 429 during the run exercised the partial-failure path and surfaced `partialFailureReason` as designed.

Both changes are additive — new optional option, new optional result field, and a projection-layer unit correction that aligns `getArNSRecord` with its siblings.