### PR TITLE
fix(solana): report the live SPL mint supply in getTokenSupply

### DIFF
--- a/src/solana/deserialize.ts
+++ b/src/solana/deserialize.ts
@@ -583,7 +583,17 @@ export function deserializeEpochSettings(data: Buffer): {
 // ArIO Config deserialization
 // =========================================
 
+/**
+ * Decode an `ArioConfig` account (ario-core singleton).
+ *
+ * @param data - Raw encoded `ArioConfig` account data.
+ * @returns The configured ARIO SPL mint plus the declared supply fields. Note
+ * that `totalSupply` is the **genesis declaration** written once by
+ * `finalize_supply` — it does not track holder burns, so callers reporting real
+ * supply should read the `mint`'s live `supply` instead.
+ */
 export function deserializeArioConfig(data: Buffer): {
+  mint: Address;
   totalSupply: number;
   protocolBalance: number;
   circulatingSupply: number;
@@ -592,6 +602,7 @@ export function deserializeArioConfig(data: Buffer): {
   const d = getArioConfigDecoder().decode(new Uint8Array(data));
 
   return {
+    mint: d.mint,
     totalSupply: Number(d.totalSupply),
     protocolBalance: Number(d.protocolBalance),
     circulatingSupply: Number(d.circulatingSupply),

--- a/src/solana/io-readable.test.ts
+++ b/src/solana/io-readable.test.ts
@@ -5,11 +5,15 @@ import {
   PurchaseType,
   getArnsRecordEncoder,
 } from '@ar.io/solana-contracts/arns';
+import { getArioConfigEncoder } from '@ar.io/solana-contracts/core';
+import { getGatewaySettingsEncoder } from '@ar.io/solana-contracts/gar';
 import { type Address } from '@solana/kit';
 import bs58 from 'bs58';
 
 import { Logger } from '../common/logger.js';
+import { ARIO_CORE_PROGRAM_ID, ARIO_GAR_PROGRAM_ID } from './constants.js';
 import { SolanaARIOReadable } from './io-readable.js';
+import { getArioConfigPDA, getGarSettingsPDA } from './pda.js';
 
 type Counts = { gma: number; gmaAccts: number };
 
@@ -146,6 +150,280 @@ describe('getArNSRecord — timestamp conversion', () => {
       'endTimestamp' in record,
       false,
       'permabuy should not have endTimestamp',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTokenSupply — live mint supply + derived circulating
+// ---------------------------------------------------------------------------
+
+// `mint(n)` above just builds a deterministic 32-byte address.
+const ARIO_MINT = mint(7) as Address;
+const PROTOCOL_TOKEN_ACCOUNT = mint(8) as Address;
+
+// mARIO (6 decimals). The live/declared pair mirrors mainnet after two holder
+// burns: ArioConfig still declares the 1B genesis mint, the SPL mint holds
+// 999,999,626.703 ARIO.
+const DECLARED_TOTAL = 1_000_000_000_000_000;
+const LIVE_SUPPLY = 999_999_626_703_000;
+const STORED_CIRCULATING = 567_000_000_000_000; // stale by construction
+const LOCKED = 350_823_675_500_000;
+const STAKED = 13_960_000_000_000;
+const DELEGATED = 14_500_000_000_000;
+const WITHDRAWN = 2_530_000_000;
+const RESERVE = 57_382_790_800_000;
+
+function arioConfigBytes(overrides: {
+  totalSupply?: number;
+  circulatingSupply?: number;
+  lockedSupply?: number;
+}): Uint8Array {
+  return getArioConfigEncoder().encode({
+    authority: OWNER_ADDR,
+    mint: ARIO_MINT,
+    arnsProgram: OWNER_ADDR,
+    treasury: OWNER_ADDR,
+    totalSupply: overrides.totalSupply ?? DECLARED_TOTAL,
+    // Folded accounting field — deliberately NOT the reward reserve.
+    protocolBalance: 87_280_000_000_000,
+    circulatingSupply: overrides.circulatingSupply ?? STORED_CIRCULATING,
+    lockedSupply: overrides.lockedSupply ?? LOCKED,
+    minVaultDuration: 0,
+    maxVaultDuration: 0,
+    primaryNameRequestExpiry: 0,
+    migrationActive: true,
+    migrationAuthority: OWNER_ADDR,
+    bump: 255,
+    garProgram: OWNER_ADDR,
+    version: VERSION,
+  }) as Uint8Array;
+}
+
+function garSettingsBytes(): Uint8Array {
+  return getGatewaySettingsEncoder().encode({
+    authority: OWNER_ADDR,
+    mint: ARIO_MINT,
+    minOperatorStake: 0,
+    minDelegateStake: 0,
+    withdrawalPeriod: 0,
+    maxExpeditedWithdrawalPenalty: 0,
+    minExpeditedWithdrawalPenalty: 0,
+    minExpeditedWithdrawalAmount: 0,
+    maxDelegatesPerGateway: 0,
+    migrationActive: true,
+    migrationAuthority: OWNER_ADDR,
+    stakeTokenAccount: OWNER_ADDR,
+    protocolTokenAccount: PROTOCOL_TOKEN_ACCOUNT,
+    arnsProgramId: OWNER_ADDR,
+    totalStaked: STAKED,
+    totalDelegated: DELEGATED,
+    totalWithdrawn: WITHDRAWN,
+    bump: 255,
+    version: VERSION,
+  }) as Uint8Array;
+}
+
+/** 82-byte SPL Mint account; `supply` is a u64 LE at [36, 44). */
+function splMintBytes(supply: number): Uint8Array {
+  const data = Buffer.alloc(82);
+  data.writeBigUInt64LE(BigInt(supply), 36);
+  return data;
+}
+
+/** 165-byte SPL Token account; `amount` is a u64 LE at [64, 72). */
+function splTokenAccountBytes(amount: number): Uint8Array {
+  const data = Buffer.alloc(165);
+  data.writeBigUInt64LE(BigInt(amount), 64);
+  return data;
+}
+
+/**
+ * Stub rpc that serves getAccountInfo from an address → bytes map, counting
+ * fetches per address so callers can assert caching.
+ */
+function mappedAccountRpc(
+  accounts: Map<string, Uint8Array>,
+  fetches: Map<string, number> = new Map(),
+): unknown {
+  return {
+    getAccountInfo: (addr: Address) => ({
+      send: async () => {
+        const key = String(addr);
+        fetches.set(key, (fetches.get(key) ?? 0) + 1);
+        const bytes = accounts.get(key);
+        if (!bytes) return { value: null };
+        return {
+          value: {
+            data: [
+              Buffer.from(bytes).toString('base64'),
+              'base64',
+            ] as readonly [string, string],
+            executable: false,
+            lamports: 1_000_000n,
+            owner: OWNER_ADDR,
+            rentEpoch: 0n,
+            space: BigInt(bytes.length),
+          },
+        };
+      },
+    }),
+  };
+}
+
+/** Exposes the protected mint resolver for assertions. */
+class MintReadable extends SolanaARIOReadable {
+  async readArioMint() {
+    return this.getArioMint();
+  }
+}
+
+async function supplyAccounts(
+  configBytes: Uint8Array,
+  { withMint = true }: { withMint?: boolean } = {},
+): Promise<Map<string, Uint8Array>> {
+  const [configPda] = await getArioConfigPDA(ARIO_CORE_PROGRAM_ID);
+  const [garSettingsPda] = await getGarSettingsPDA(ARIO_GAR_PROGRAM_ID);
+
+  const accounts = new Map<string, Uint8Array>([
+    [String(configPda), configBytes],
+    [String(garSettingsPda), garSettingsBytes()],
+    [String(PROTOCOL_TOKEN_ACCOUNT), splTokenAccountBytes(RESERVE)],
+  ]);
+  if (withMint) {
+    accounts.set(String(ARIO_MINT), splMintBytes(LIVE_SUPPLY));
+  }
+  return accounts;
+}
+
+async function supplyReadable(
+  configBytes: Uint8Array,
+  { withMint = true }: { withMint?: boolean } = {},
+): Promise<SolanaARIOReadable> {
+  const accounts = await supplyAccounts(configBytes, { withMint });
+
+  return new SolanaARIOReadable({
+    rpc: mappedAccountRpc(accounts) as never,
+    logger: new Logger({ level: 'none' }),
+  });
+}
+
+describe('getTokenSupply — live mint supply', () => {
+  it('reports the live SPL mint supply as total, not the frozen ArioConfig declaration', async () => {
+    const readable = await supplyReadable(arioConfigBytes({}));
+
+    const supply = await readable.getTokenSupply();
+
+    assert.equal(supply.total, LIVE_SUPPLY);
+    assert.notEqual(
+      supply.total,
+      DECLARED_TOTAL,
+      'total must track burns, not the genesis declaration',
+    );
+    assert.equal(supply.protocolBalance, RESERVE, 'reserve = token account');
+  });
+
+  it('derives circulating so the six buckets reconcile to the live total', async () => {
+    const readable = await supplyReadable(arioConfigBytes({}));
+
+    const supply = await readable.getTokenSupply();
+
+    const sum =
+      supply.circulating +
+      supply.locked +
+      supply.staked +
+      supply.delegated +
+      supply.withdrawn +
+      supply.protocolBalance;
+    assert.equal(sum, supply.total, 'six buckets must sum to total');
+    assert.equal(
+      supply.circulating,
+      LIVE_SUPPLY - LOCKED - STAKED - DELEGATED - WITHDRAWN - RESERVE,
+    );
+    assert.notEqual(
+      supply.circulating,
+      STORED_CIRCULATING,
+      'circulating must be derived, not the stale stored field',
+    );
+  });
+
+  it('falls back to ArioConfig.total_supply when the mint is unreadable', async () => {
+    const readable = await supplyReadable(arioConfigBytes({}), {
+      withMint: false,
+    });
+
+    const supply = await readable.getTokenSupply();
+
+    assert.equal(supply.total, DECLARED_TOTAL);
+    const sum =
+      supply.circulating +
+      supply.locked +
+      supply.staked +
+      supply.delegated +
+      supply.withdrawn +
+      supply.protocolBalance;
+    assert.equal(
+      sum,
+      DECLARED_TOTAL,
+      'buckets still reconcile to the fallback',
+    );
+  });
+
+  it('falls back to the stored circulating_supply when the buckets exceed the live total', async () => {
+    // locked alone swallows the whole live supply → derivation would go negative
+    const readable = await supplyReadable(
+      arioConfigBytes({ lockedSupply: LIVE_SUPPLY }),
+    );
+
+    const supply = await readable.getTokenSupply();
+
+    assert.equal(supply.total, LIVE_SUPPLY);
+    assert.equal(supply.circulating, STORED_CIRCULATING);
+  });
+
+  it('falls back to ArioConfig.total_supply when the mint account is truncated', async () => {
+    const accounts = await supplyAccounts(arioConfigBytes({}));
+    // Too short to hold the u64 `supply` field at [36, 44)
+    accounts.set(String(ARIO_MINT), Buffer.alloc(32));
+    const readable = new SolanaARIOReadable({
+      rpc: mappedAccountRpc(accounts) as never,
+      logger: new Logger({ level: 'none' }),
+    });
+
+    const supply = await readable.getTokenSupply();
+
+    assert.equal(supply.total, DECLARED_TOTAL);
+  });
+});
+
+describe('getArioMint', () => {
+  it('resolves the mint from ArioConfig and caches it', async () => {
+    const accounts = await supplyAccounts(arioConfigBytes({}));
+    const [configPda] = await getArioConfigPDA(ARIO_CORE_PROGRAM_ID);
+    const fetches = new Map<string, number>();
+    const readable = new MintReadable({
+      rpc: mappedAccountRpc(accounts, fetches) as never,
+      logger: new Logger({ level: 'none' }),
+    });
+
+    assert.equal(await readable.readArioMint(), ARIO_MINT);
+    assert.equal(await readable.readArioMint(), ARIO_MINT);
+    assert.equal(
+      fetches.get(String(configPda)),
+      1,
+      'ArioConfig should be fetched once and cached',
+    );
+  });
+
+  it('throws a helpful error when ArioConfig is missing', async () => {
+    const readable = new MintReadable({
+      rpc: mappedAccountRpc(new Map()) as never,
+      logger: new Logger({ level: 'none' }),
+    });
+
+    await assert.rejects(
+      () => readable.readArioMint(),
+      /ArioConfig not found at .* on coreProgram/,
     );
   });
 });

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -625,6 +625,8 @@ export class SolanaARIOReadable {
     if (!configAccount.exists) {
       throw new Error('ArioConfig account not found');
     }
+    // The mint comes off the config we already fetched, so reading its live
+    // supply below costs no extra config round-trip.
     const config = deserializeArioConfig(Buffer.from(configAccount.data));
 
     // Supply counters from GatewaySettings (staked/delegated/withdrawn).
@@ -675,9 +677,36 @@ export class SolanaARIOReadable {
       }
     }
 
+    // `total` is the LIVE SPL mint supply, not the frozen
+    // `ArioConfig.total_supply` genesis declaration. ARIO is a standard SPL
+    // token: any holder can burn their own tokens (e.g. via a wallet-cleanup
+    // incinerator), so real supply drifts below the 1B genesis mint over time.
+    // `config.total_supply` is written once at `finalize_supply` and never
+    // tracks those burns; the mint's `supply` field does. Fall back to the
+    // config value only if the mint can't be read (e.g. pre-init).
+    let total = config.totalSupply;
+    const liveSupply = await this.getMintSupply(config.mint);
+    if (liveSupply !== null) total = liveSupply;
+
+    // `circulating` is DERIVED so the six buckets always reconcile to `total`
+    //   circulating + locked + staked + delegated + withdrawn + protocolBalance == total
+    // and self-correct as `total` drifts down via burns. Falls back to the
+    // stored `circulating_supply` only if the derivation would go negative
+    // (buckets exceed the live total — a data anomaly, e.g. an over-funded
+    // reserve).
+    const derivedCirculating =
+      total -
+      config.lockedSupply -
+      staked -
+      delegated -
+      withdrawn -
+      protocolBalance;
+    const circulating =
+      derivedCirculating >= 0 ? derivedCirculating : config.circulatingSupply;
+
     return {
-      total: config.totalSupply,
-      circulating: config.circulatingSupply,
+      total,
+      circulating,
       locked: config.lockedSupply,
       staked,
       delegated,
@@ -709,16 +738,36 @@ export class SolanaARIOReadable {
     return Number(amount);
   }
 
+  /**
+   * Live total supply (in mARIO) of the ARIO SPL mint, read from the mint's
+   * `supply` field (bytes [36, 44) of the SPL Mint layout). This is the
+   * authoritative total — it tracks burns/mints in real time, unlike the frozen
+   * `ArioConfig.total_supply` genesis declaration. Returns `null` if the mint
+   * can't be read. Uses the same portable little-endian u64 decode as
+   * {@link getTokenAccountAmount} (some browser bundlers strip the BigInt
+   * readers from the `buffer` shim's prototype).
+   */
+  private async getMintSupply(mint: Address): Promise<number | null> {
+    const account = await this.getAccount(mint);
+    if (!account.exists) return null;
+    const data = account.data;
+    if (data.length < 44) return null;
+    let amount = 0n;
+    for (let i = 7; i >= 0; i--) {
+      amount = (amount << 8n) | BigInt(data[36 + i]);
+    }
+    // ARIO supply caps at 1B * 1e6 mARIO ≈ 2^50, well under MAX_SAFE_INTEGER.
+    return Number(amount);
+  }
+
   // =========================================
   // Balance read methods
   // =========================================
 
   /**
-   * Resolve the ARIO SPL mint address from the on-chain `ArioConfig`.
-   *
-   * `ArioConfig` layout: [8 disc][32 authority][32 mint][...]. We decode
-   * the mint at offset 40 and cache it for the lifetime of this instance —
-   * the mint never changes once the protocol is deployed.
+   * Resolve the ARIO SPL mint address from the on-chain `ArioConfig`, cached
+   * for the lifetime of this instance — the mint never changes once the
+   * protocol is deployed.
    */
   protected async getArioMint(): Promise<Address> {
     if (this._arioMint) return this._arioMint;
@@ -729,8 +778,7 @@ export class SolanaARIOReadable {
         `ArioConfig not found at ${configPda} on coreProgram ${this.coreProgram} — is the program deployed and initialized?`,
       );
     }
-    const data = Buffer.from(account.data);
-    const mint = addressDecoder.decode(data.subarray(40, 72));
+    const { mint } = deserializeArioConfig(Buffer.from(account.data));
     this._arioMint = mint;
     return mint;
   }


### PR DESCRIPTION
## Problem

`getTokenSupply().total` returns `ArioConfig.total_supply` — the **1B genesis declaration**, written once by `finalize_supply` and never updated again.

ARIO is a standard SPL token, so **any holder can burn their own tokens**; nothing in our programs gates it. Mainnet supply is already below 1B:

| | |
|---|---|
| `ArioConfig.total_supply` (declared) | 1,000,000,000 ARIO |
| ARIO mint `supply` (live) | **999,999,626.703 ARIO** |
| difference | 373.297318 ARIO |

That gap is fully accounted for: two holders ran their wallets through the Sol Incinerator (`BURNowgY7HVZsFrGo6u7ACfs3wxaThQQdCJhUY4eKtCW`) and torched ARIO alongside memecoin/NFT dust — 234.713097 ARIO on 2026-07-05 and 138.584221 ARIO on 2026-08-10, summing bit-exact to the difference. Genesis minted a perfect 1B; this is ordinary, permanent, user-initiated deflation, not a leak.

The consequence is that every consumer of `getTokenSupply` — portal, dashboards, integrators — reports a total the chain no longer holds, and the error only grows with each future burn.

## Change

- **`total` now comes from the mint's `supply` field**, which tracks burns and mints in real time.
- **`circulating` is derived** from that total so the six buckets always reconcile:
  ```
  circulating + locked + staked + delegated + withdrawn + protocolBalance == total
  ```
  and keep reconciling as supply drifts down, with no further intervention.
- **Fallbacks preserved:** if the mint can't be read (e.g. pre-init) `total` falls back to `ArioConfig.total_supply`; if the derivation would go negative (buckets exceed the live total — a data anomaly such as an over-funded reserve) `circulating` falls back to the stored `circulating_supply`.
- **Housekeeping:** `deserializeArioConfig` now surfaces `mint`, so the ArioConfig mint offset is decoded in exactly one place. `getTokenSupply` reads the mint off the config account it already fetched (no extra round-trip), and `getArioMint` drops its hand-rolled `subarray(40, 72)` decode.

Read-path only — no instruction, ABI, or on-chain change. `protocolBalance` semantics are untouched (still the live reward-reserve token account, not the folded `ArioConfig.protocol_balance`).

## Tests

Four new cases in `src/solana/io-readable.test.ts`, driven by a stubbed RPC that serves encoded `ArioConfig` / `GatewaySettings` / SPL mint / SPL token accounts (values mirror mainnet):

- live mint supply is reported as `total`, not the frozen declaration
- the six buckets sum exactly to the live total, and `circulating` is derived rather than the stale stored field
- mint unreadable → falls back to `ArioConfig.total_supply`, buckets still reconcile
- buckets exceed the live total → falls back to the stored `circulating_supply`

```
yarn test:unit   →  460 tests, 459 pass, 0 fail, 1 skipped (pre-existing)
tsc --noEmit     →  clean
biome check      →  no new findings
```

## Operator note (not part of this PR)

The migration-side rebase tool (`migration/import/src/rebase-supply.ts` in `solana-ar-io`) still targets a hard-coded 1B and would re-declare it on-chain via `finalize_supply`. That needs the same retargeting to live mint supply before the supply rebase runs; tracked separately. With this SDK change in place, `ArioConfig.total_supply` becomes a cosmetic declaration rather than the number consumers read.

## Checklist

- [x] My PR is against the correct branch (`alpha`, per CONTRIBUTING.md)
- [x] My commit messages follow conventional commits style
- [x] My commit messages clearly explain the reasons for the changes
- [x] I have followed the architecture guidelines
- [x] I have run lint and format checks
- [x] I have run all tests
- [x] I have checked for existing issues/PRs to avoid duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token supply information now reflects the current on-chain mint supply when available.
  * Circulating supply is calculated from reconciled token balances for more accurate reporting.
  * The ARIO mint address is now surfaced as part of decoded configuration data.

* **Bug Fixes**
  * Added fallback handling when mint data is unavailable or balance calculations produce invalid results, preserving reliable supply values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->