### PR TITLE
fix(solana): take the lifetime blockhash after CU simulation

### DIFF
--- a/src/solana/send.test.ts
+++ b/src/solana/send.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { address, generateKeyPairSigner } from '@solana/kit';
+import { sendAndConfirm } from './send.js';
+
+/**
+ * A blockhash is only valid for ~150 blocks (~60s) from ISSUE, not from send.
+ * `sendAndConfirm` right-sizes the compute-unit limit with a full
+ * `simulateTransaction` round trip, so taking the lifetime blockhash before
+ * that simulation hands the signed transaction a window already partly spent.
+ * On mainnet this expired an observer's `save_observations` by exactly one
+ * block, losing that epoch's observation and reward.
+ *
+ * These tests pin the ordering: the blockhash that ends up on the signed
+ * message must be fetched AFTER the simulation.
+ */
+
+const MEMO = address('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr');
+
+// Two distinct, valid-looking blockhashes so we can tell which one was used.
+const BLOCKHASH_BEFORE_SIM = '11111111111111111111111111111111';
+const BLOCKHASH_AFTER_SIM = '22222222222222222222222222222222';
+
+function makeRpc() {
+  const calls: string[] = [];
+  let blockhashCalls = 0;
+  return {
+    calls,
+    rpc: {
+      getLatestBlockhash: () => ({
+        send: async () => {
+          calls.push('getLatestBlockhash');
+          blockhashCalls++;
+          return {
+            value: {
+              blockhash:
+                blockhashCalls === 1
+                  ? BLOCKHASH_BEFORE_SIM
+                  : BLOCKHASH_AFTER_SIM,
+              lastValidBlockHeight: 100n,
+            },
+          };
+        },
+      }),
+      simulateTransaction: () => ({
+        send: async () => {
+          calls.push('simulateTransaction');
+          return { value: { err: null, unitsConsumed: 5000n, logs: [] } };
+        },
+      }),
+      getRecentPrioritizationFees: () => ({
+        send: async () => {
+          calls.push('getRecentPrioritizationFees');
+          return [];
+        },
+      }),
+    } as never,
+  };
+}
+
+async function runSend(rpc: never) {
+  const signer = await generateKeyPairSigner();
+  // No real network: the confirmation factory needs subscriptions, so it throws
+  // and we assert on what happened up to that point.
+  await assert.rejects(
+    sendAndConfirm({
+      rpc,
+      rpcSubscriptions: undefined as never,
+      signer,
+      instructions: [
+        { programAddress: MEMO, accounts: [], data: new Uint8Array([1]) },
+      ],
+    }),
+  );
+}
+
+describe('sendAndConfirm blockhash lifetime', () => {
+  it('fetches the signing blockhash AFTER the compute-unit simulation', async () => {
+    const { rpc, calls } = makeRpc();
+    await runSend(rpc);
+
+    const firstSim = calls.indexOf('simulateTransaction');
+    assert.ok(firstSim >= 0, 'expected a simulateTransaction call');
+
+    const blockhashAfterSim = calls
+      .slice(firstSim)
+      .indexOf('getLatestBlockhash');
+    assert.ok(
+      blockhashAfterSim >= 0,
+      `expected a getLatestBlockhash after simulateTransaction, got order: ${calls.join(' -> ')}`,
+    );
+  });
+
+  it('still fetches a blockhash before simulating (the message must compile)', async () => {
+    const { rpc, calls } = makeRpc();
+    await runSend(rpc);
+
+    const firstBlockhash = calls.indexOf('getLatestBlockhash');
+    const firstSim = calls.indexOf('simulateTransaction');
+    assert.ok(
+      firstBlockhash >= 0 && firstBlockhash < firstSim,
+      `expected a getLatestBlockhash before simulateTransaction, got order: ${calls.join(' -> ')}`,
+    );
+  });
+
+  it('does not re-fetch when no simulation runs (autoComputeUnitLimit off)', async () => {
+    const { rpc, calls } = makeRpc();
+    const signer = await generateKeyPairSigner();
+    await assert.rejects(
+      sendAndConfirm({
+        rpc,
+        rpcSubscriptions: undefined as never,
+        signer,
+        instructions: [
+          { programAddress: MEMO, accounts: [], data: new Uint8Array([1]) },
+        ],
+        autoComputeUnitLimit: false,
+      }),
+    );
+
+    // NB: a `simulateTransaction` still shows up here — `logSimulationDiagnostics`
+    // re-simulates in the catch block once the send fails. What matters is that
+    // no SECOND blockhash was fetched: with sizing off, nothing consumed the
+    // validity window before signing, so the extra round trip is pure cost.
+    assert.equal(
+      calls.filter((c) => c === 'getLatestBlockhash').length,
+      1,
+      `expected exactly one blockhash fetch, got order: ${calls.join(' -> ')}`,
+    );
+  });
+});

--- a/src/solana/send.ts
+++ b/src/solana/send.ts
@@ -413,16 +413,21 @@ export async function sendAndConfirm({
         ? 0n
         : BigInt(priorityFeeMicroLamports);
 
-  const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+  // A blockhash is needed to compile the SIMULATION message, but its value is
+  // irrelevant there: `estimateComputeUnitLimit` simulates with
+  // `replaceRecentBlockhash: true`, so the validator substitutes its own. The
+  // blockhash that matters is the one on the message we sign — see the re-fetch
+  // below.
+  let latestBlockhash = (await rpc.getLatestBlockhash().send()).value;
 
   // Build the (optionally ALT-compressed) message for a given CU limit. We may
   // build it twice: once with the ceiling limit to simulate, once with the
   // tight limit we actually sign.
-  const buildMessage = (units: number) => {
+  const buildMessage = (units: number, blockhash: typeof latestBlockhash) => {
     const baseMessage = pipe(
       createTransactionMessage({ version: 0 }),
       (tx) => setTransactionMessageFeePayerSigner(signer, tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+      (tx) => setTransactionMessageLifetimeUsingBlockhash(blockhash, tx),
       (tx) =>
         appendTransactionMessageInstructions(
           [
@@ -468,12 +473,35 @@ export async function sendAndConfirm({
   const units = shouldAutoSize
     ? await estimateComputeUnitLimit(
         rpc,
-        buildMessage(computeUnitLimit),
+        buildMessage(computeUnitLimit, latestBlockhash),
         computeUnitLimit,
       )
     : computeUnitLimit;
 
-  const message = buildMessage(units);
+  // Re-fetch the blockhash AFTER simulation. A blockhash is only valid for
+  // ~150 blocks (~60s), and that clock starts when it is issued — not when we
+  // send. `estimateComputeUnitLimit` is a full `simulateTransaction` round trip
+  // against a possibly-large message, so on a slow or rate-limited RPC it can
+  // burn a large slice of the window before the tx is even signed. Observed on
+  // mainnet: an observer's `save_observations` expired by exactly one block
+  // (`lastValidBlockHeight` 417090556 vs `currentBlockHeight` 417090557),
+  // losing that epoch's observation and reward. Taking the lifetime blockhash
+  // here gives the signed transaction the full window.
+  //
+  // Only re-fetched when we actually simulated — otherwise nothing consumed the
+  // window and the extra round trip would be pure cost.
+  // Best-effort: if the re-fetch fails we keep the pre-simulation blockhash and
+  // proceed exactly as before this optimization existed. A transient RPC hiccup
+  // here must never turn a send that used to work into a hard failure.
+  if (shouldAutoSize) {
+    try {
+      latestBlockhash = (await rpc.getLatestBlockhash().send()).value;
+    } catch {
+      // keep `latestBlockhash` as fetched before the simulation
+    }
+  }
+
+  const message = buildMessage(units, latestBlockhash);
 
   // Attach any extra keypair signers (e.g. a freshly generated ANT mint) so kit
   // can satisfy their SIGNER roles. `addSignersToTransactionMessage` walks the

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -492,18 +492,22 @@ export async function spawnSolanaANT(
   // the mint signer on the message alongside the fee payer signer.
   // Signer-aware fee (see sendAndConfirm): wallet signers get the market
   // rate their own estimator would pick; keypairs keep the cheap base rate.
-  const [{ value: latestBlockhash }, microLamports] = await Promise.all([
+  // The blockhash here only has to make the SIMULATION message compile —
+  // `estimateComputeUnitLimit` simulates with `replaceRecentBlockhash: true`.
+  // The one that matters is re-fetched after simulation (see below).
+  const [{ value: initialBlockhash }, microLamports] = await Promise.all([
     rpc.getLatestBlockhash().send(),
     isTransactionModifyingSigner(signer)
       ? estimateQuotePriorityFeeMicroLamports(rpc)
       : estimatePriorityFeeMicroLamports(rpc),
   ]);
+  let latestBlockhash = initialBlockhash;
 
-  const buildMessage = (units: number) =>
+  const buildMessage = (units: number, blockhash: typeof latestBlockhash) =>
     pipe(
       createTransactionMessage({ version: 0 }),
       (tx) => setTransactionMessageFeePayerSigner(signer, tx),
-      (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+      (tx) => setTransactionMessageLifetimeUsingBlockhash(blockhash, tx),
       (tx) =>
         appendTransactionMessageInstructions(
           [
@@ -528,14 +532,29 @@ export async function spawnSolanaANT(
   // interferes with that and trips the guard. The wallet rewrite is captured by
   // the modifying-signer flow below, so `computeUnitLimit` (the ceiling) is left
   // generous for them.
-  const units = isTransactionModifyingSigner(signer)
-    ? computeUnitLimit
-    : await estimateComputeUnitLimit(
+  const shouldAutoSize = !isTransactionModifyingSigner(signer);
+  const units = shouldAutoSize
+    ? await estimateComputeUnitLimit(
         rpc,
-        buildMessage(computeUnitLimit),
+        buildMessage(computeUnitLimit, latestBlockhash),
         computeUnitLimit,
-      );
-  const message = buildMessage(units);
+      )
+    : computeUnitLimit;
+
+  // Re-fetch after simulation so the SIGNED message gets the full ~150-block
+  // (~60s) validity window rather than whatever is left of it once the
+  // `simulateTransaction` round trip returns. Mirrors `sendAndConfirm`; see the
+  // longer note there for the mainnet expiry this fixes.
+  // Best-effort, as in `sendAndConfirm`: on failure keep the pre-simulation
+  // blockhash so this can only ever match the old behaviour, never worsen it.
+  if (shouldAutoSize) {
+    try {
+      latestBlockhash = (await rpc.getLatestBlockhash().send()).value;
+    } catch {
+      // keep `latestBlockhash` as fetched before the simulation
+    }
+  }
+  const message = buildMessage(units, latestBlockhash);
 
   // Attach the mint signer so kit can satisfy the WRITABLE_SIGNER role on the
   // mint account. `addSignersToTransactionMessage` walks the message's account


### PR DESCRIPTION
## What

`sendAndConfirm` (and `spawnSolanaANT`) fetched the lifetime blockhash *before* right-sizing the compute-unit limit, and that sizing is a full `simulateTransaction` round trip. A blockhash is valid ~150 blocks (~60s) **from issue**, so the signed transaction started with a window already partly spent.

Now the blockhash is taken after the simulation. Safe because `estimateComputeUnitLimit` simulates with `replaceRecentBlockhash: true` — the simulation's blockhash is substituted server-side and never mattered.

## Motivation, and what was ruled out

A mainnet observer lost an epoch to a one-block expiry (`lastValidBlockHeight` 417090556 vs `currentBlockHeight` 417090557) on a transaction that had uploaded its report and was well inside the observation window.

Two hypotheses were tested against on-chain data:

- **Priority-fee underpricing — ruled out.** `save_observations` pays a floor-rate priority fee (~290–375 lamports; measured across every landed epoch-512 submission, back-solving to `MIN_PRIORITY_FEE_MICRO_LAMPORTS = 10_000`). But two other observers landed epoch-512 submissions 17 and 60 minutes either side of the failure paying that same floor rate, and all 16 of the epoch's submissions landed at floor rates across the day. The fee was buying inclusion fine.
- **Blockhash window exhaustion — consistent with the evidence.** The transaction expired one block after the *full* window elapsed. Every RPC call made between issuing the blockhash and sending eats directly into that budget, and the exposure is worst when the RPC is lagging or slow.

This change removes the simulation round trip from that budget. On a healthy RPC that's a second or two of a sixty-second window; on a struggling one it is proportionally much more — which is exactly when it matters.

## Safety

- Re-fetch is **skipped** when no simulation ran (message-modifying wallet signers, `autoComputeUnitLimit: false`) — nothing consumed the window, so the extra round trip would be pure cost.
- Re-fetch is wrapped in try/catch falling back to the pre-simulation blockhash. This adds a network dependency, and the fallback guarantees the worst case is exactly the old behaviour rather than a new hard failure.

## Tests

New `src/solana/send.test.ts` pins the ordering. **Verified it fails against the old ordering and passes against the new** — the fix was reverted to confirm the assertion breaks, so it is a real regression test rather than a tautology.

Full suite: 458 pass / 0 fail (1 pre-existing skip). `tsc` clean, `biome` clean, `yarn build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKeNoHyV6m1Z3sh81Jykkf
