### PR TITLE
fix(solana): route retry/circuit-breaker logs through the shared Logger

### DIFF
--- a/src/solana/retry.test.ts
+++ b/src/solana/retry.test.ts
@@ -233,6 +233,8 @@ describe('withRetry logging', () => {
     // The actual regression: a private error-level logger made this impossible.
     const seen: string[] = [];
     const original = Logger.default.debug.bind(Logger.default);
+    // Logger has no level getter, so restore the documented constructor
+    // default ('info') rather than leaking 'debug' into later tests.
     Logger.default.setLogLevel('debug');
     (Logger.default as unknown as { debug: (m: string) => void }).debug = (
       m: string,
@@ -251,9 +253,72 @@ describe('withRetry logging', () => {
       );
     } finally {
       (Logger.default as unknown as { debug: unknown }).debug = original;
+      Logger.default.setLogLevel('info');
     }
 
     assert.equal(seen.length, 1);
     assert.match(seen[0], /\[retry\] attempt 1\/3 failed/);
+  });
+
+  /**
+   * The exhaustion warn must not re-evaluate the retry predicate.
+   *
+   * `if (isLast || !retryable(error))` short-circuits, so on the final
+   * attempt `retryable()` is never called. Testing it again inside the
+   * branch would let a throwing user-supplied predicate replace the
+   * operation's own error -- the caller would see "predicate blew up"
+   * instead of the real failure.
+   */
+  it('does not consult the retry predicate on the final attempt', async () => {
+    const { lines, logger } = collect();
+    let predicateCalls = 0;
+    const opError = new TypeError('fetch failed');
+
+    await assert.rejects(
+      () =>
+        withRetry(
+          async () => {
+            throw opError;
+          },
+          {
+            maxAttempts: 2,
+            baseDelayMs: 1,
+            maxDelayMs: 5,
+            logger,
+            isRetryable: () => {
+              predicateCalls++;
+              return true;
+            },
+          },
+        ),
+      (err: unknown) => err === opError,
+    );
+
+    // attempt 0 consults it; the final attempt short-circuits via isLast
+    assert.equal(predicateCalls, 1);
+    assert.equal(lines.filter((l) => l.level === 'warn').length, 1);
+  });
+
+  it('surfaces the operation error even if the predicate throws', async () => {
+    const { logger } = collect();
+    const opError = new TypeError('fetch failed');
+
+    await assert.rejects(
+      () =>
+        withRetry(
+          async () => {
+            throw opError;
+          },
+          {
+            maxAttempts: 1,
+            baseDelayMs: 1,
+            logger,
+            isRetryable: () => {
+              throw new Error('predicate blew up');
+            },
+          },
+        ),
+      (err: unknown) => err === opError,
+    );
   });
 });

--- a/src/solana/retry.test.ts
+++ b/src/solana/retry.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
+import { Logger } from '../common/logger.js';
 import { isRetryableError, withRetry } from './retry.js';
 
 describe('isRetryableError', () => {
@@ -150,5 +151,109 @@ describe('withRetry', () => {
       ),
     );
     assert.equal(calls, 3);
+  });
+});
+
+/**
+ * Regression guard for the silenced-logger bug.
+ *
+ * `retry.ts` and `rpc-circuit-breaker.ts` each built a private
+ * `new Logger({ level: 'error' })`. Because the Logger suppresses any level
+ * numerically below its own, every `logger.debug`/`info`/`warn` in those
+ * modules was dead code — and, critically, `Logger.default.setLogLevel()`
+ * (which ar-io-node drives from AR_IO_SDK_LOG_LEVEL) had no effect on them.
+ * Operators had no way to observe retries or circuit transitions at all.
+ */
+describe('withRetry logging', () => {
+  const collect = () => {
+    const lines: { level: string; message: string }[] = [];
+    return {
+      lines,
+      logger: {
+        setLogLevel: () => undefined,
+        debug: (message: string) => lines.push({ level: 'debug', message }),
+        info: (message: string) => lines.push({ level: 'info', message }),
+        warn: (message: string) => lines.push({ level: 'warn', message }),
+        error: (message: string) => lines.push({ level: 'error', message }),
+      },
+    };
+  };
+
+  it('logs a debug line for each retried attempt', async () => {
+    const { lines, logger } = collect();
+    let calls = 0;
+    const result = await withRetry(
+      async () => {
+        calls++;
+        if (calls < 3) throw new TypeError('fetch failed');
+        return 'ok';
+      },
+      { baseDelayMs: 1, maxDelayMs: 5, logger },
+    );
+
+    assert.equal(result, 'ok');
+    const debugs = lines.filter((l) => l.level === 'debug');
+    // two failures -> two retry logs
+    assert.equal(debugs.length, 2);
+    assert.match(debugs[0].message, /\[retry\] attempt 1\/3 failed/);
+    assert.match(debugs[1].message, /\[retry\] attempt 2\/3 failed/);
+  });
+
+  it('warns once when every attempt is exhausted', async () => {
+    const { lines, logger } = collect();
+    await assert.rejects(() =>
+      withRetry(
+        async () => {
+          throw new TypeError('fetch failed');
+        },
+        { maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 5, logger },
+      ),
+    );
+
+    const warns = lines.filter((l) => l.level === 'warn');
+    assert.equal(warns.length, 1);
+    assert.match(warns[0].message, /exhausted 3 attempt\(s\)/);
+  });
+
+  it('does not warn when the error was never retryable', async () => {
+    const { lines, logger } = collect();
+    await assert.rejects(() =>
+      withRetry(
+        async () => {
+          throw new Error('account not found');
+        },
+        { baseDelayMs: 1, logger },
+      ),
+    );
+    assert.equal(lines.filter((l) => l.level === 'warn').length, 0);
+    assert.equal(lines.filter((l) => l.level === 'debug').length, 0);
+  });
+
+  it('defaults to the shared Logger so setLogLevel() reaches it', async () => {
+    // The actual regression: a private error-level logger made this impossible.
+    const seen: string[] = [];
+    const original = Logger.default.debug.bind(Logger.default);
+    Logger.default.setLogLevel('debug');
+    (Logger.default as unknown as { debug: (m: string) => void }).debug = (
+      m: string,
+    ) => seen.push(m);
+
+    try {
+      let calls = 0;
+      await withRetry(
+        async () => {
+          calls++;
+          if (calls < 2) throw new TypeError('fetch failed');
+          return 'ok';
+        },
+        // no logger injected -> must fall back to Logger.default
+        { baseDelayMs: 1, maxDelayMs: 5 },
+      );
+    } finally {
+      (Logger.default as unknown as { debug: unknown }).debug = original;
+    }
+
+    assert.equal(seen.length, 1);
+    assert.match(seen[0], /\[retry\] attempt 1\/3 failed/);
   });
 });

--- a/src/solana/retry.ts
+++ b/src/solana/retry.ts
@@ -27,9 +27,7 @@
  * ```
  */
 
-import { Logger } from '../common/logger.js';
-
-const logger = new Logger({ level: 'error' });
+import { ILogger, Logger } from '../common/logger.js';
 
 export interface RetryOptions {
   /** Maximum number of attempts (first call + retries). @default 3 */
@@ -41,6 +39,10 @@ export interface RetryOptions {
   /** Predicate that decides whether a thrown error is retryable.
    *  Defaults to {@link isRetryableError}. */
   isRetryable?: (error: unknown) => boolean;
+  /** Logger for retry diagnostics. Defaults to the shared
+   *  {@link Logger.default}, so consumers control verbosity via
+   *  `Logger.default.setLogLevel(...)`. */
+  logger?: ILogger;
 }
 
 const DEFAULT_MAX_ATTEMPTS = 3;
@@ -120,6 +122,7 @@ export async function withRetry<T>(
   const baseDelayMs = opts?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
   const maxDelayMs = opts?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
   const retryable = opts?.isRetryable ?? isRetryableError;
+  const logger = opts?.logger ?? Logger.default;
 
   let lastError: unknown;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -130,6 +133,15 @@ export async function withRetry<T>(
 
       const isLast = attempt === maxAttempts - 1;
       if (isLast || !retryable(error)) {
+        // Surface *why* we gave up. The rethrown error carries no retry
+        // context, so without this an operator cannot distinguish "failed
+        // once, not retryable" from "exhausted every attempt".
+        if (isLast && retryable(error)) {
+          logger.warn(
+            `[retry] exhausted ${maxAttempts} attempt(s), giving up`,
+            { error: String(error) },
+          );
+        }
         throw error;
       }
 

--- a/src/solana/retry.ts
+++ b/src/solana/retry.ts
@@ -144,9 +144,12 @@ export async function withRetry<T>(
         // error. Reaching the last attempt at all means earlier ones were
         // retried, which already implies the error was retryable.
         if (isLast && attempt > 0) {
-          logger.warn(`[retry] exhausted ${maxAttempts} attempt(s), giving up`, {
-            error: String(error),
-          });
+          logger.warn(
+            `[retry] exhausted ${maxAttempts} attempt(s), giving up`,
+            {
+              error: String(error),
+            },
+          );
         }
         throw error;
       }

--- a/src/solana/retry.ts
+++ b/src/solana/retry.ts
@@ -136,11 +136,17 @@ export async function withRetry<T>(
         // Surface *why* we gave up. The rethrown error carries no retry
         // context, so without this an operator cannot distinguish "failed
         // once, not retryable" from "exhausted every attempt".
-        if (isLast && retryable(error)) {
-          logger.warn(
-            `[retry] exhausted ${maxAttempts} attempt(s), giving up`,
-            { error: String(error) },
-          );
+        //
+        // `attempt > 0` is deliberately used instead of re-testing the
+        // predicate: `||` short-circuits, so on the final attempt
+        // `retryable()` has not been evaluated, and calling it here would
+        // let a throwing user-supplied predicate mask the operation's own
+        // error. Reaching the last attempt at all means earlier ones were
+        // retried, which already implies the error was retryable.
+        if (isLast && attempt > 0) {
+          logger.warn(`[retry] exhausted ${maxAttempts} attempt(s), giving up`, {
+            error: String(error),
+          });
         }
         throw error;
       }

--- a/src/solana/rpc-circuit-breaker.ts
+++ b/src/solana/rpc-circuit-breaker.ts
@@ -47,7 +47,11 @@ import CircuitBreaker from 'opossum';
 import { Logger } from '../common/logger.js';
 import type { SolanaRpc } from './types.js';
 
-const logger = new Logger({ level: 'error' });
+// Use the shared logger so consumers control verbosity via
+// `Logger.default.setLogLevel(...)`. A private `new Logger({ level: 'error' })`
+// silently swallowed every warn/info below, including circuit OPEN/CLOSE
+// transitions — the events an operator most needs during an RPC incident.
+const logger = Logger.default;
 
 // ---------------------------------------------------------------------------
 // Public types


### PR DESCRIPTION
## Problem

`solana/retry.ts` and `solana/rpc-circuit-breaker.ts` each construct a private logger:

```js
const logger = new Logger({ level: 'error' });
```

`Logger` suppresses any level numerically below its own, so **every `debug`/`info`/`warn` call in those two modules is unreachable code**:

| Module | Message | Level | Emitted? |
|---|---|---|---|
| `retry.ts` | `[retry] attempt N/M failed, retrying in Xms` | `debug` | never |
| `rpc-circuit-breaker.ts` | `circuit OPEN — routing to fallback RPC` | `warn` | never |
| `rpc-circuit-breaker.ts` | `circuit CLOSED — primary RPC recovered` | `info` | never |

Verified empirically — a `level: 'error'` Logger emits nothing for `debug`, `info` or `warn`.

More importantly this makes the modules **unobservable by design**. Consumers set SDK verbosity through `Logger.default.setLogLevel()` — `ar-io-node` does exactly this from `AR_IO_SDK_LOG_LEVEL` (`src/system.ts:177`) — but a private `Logger` instance ignores that call entirely. There is no supported way to observe a retry or a circuit transition.

### Why this mattered

Diagnosing a Solana RPC incident on a production turbo-gateway node, we needed to know whether repeated `TypeError: fetch failed` errors were HTTP 429s (provider throttling) or client-side aborts. `isRetryableError` distinguishes these, but nothing logs which branch was taken. Answering it required a **90-second `tcpdump`** — which showed 0 RSTs from the provider and 66 from us. One retry log line would have answered it.

## Changes

- Both modules use `Logger.default`, so `setLogLevel()` reaches them.
- `withRetry` accepts an optional `logger` (`ILogger`) for injection/testing.
- Added a `warn` when **all** attempts are exhausted. The rethrown error carries no retry context, so callers cannot otherwise distinguish "failed once, not retryable" from "exhausted every attempt".

**No behavioural change to retry semantics** — attempt counts, backoff, jitter and the retryable predicate are untouched.

## Tests

4 regression tests: per-attempt debug logs, exactly-once exhaustion warn, silence on non-retryable errors, and that the default path uses the shared `Logger` (the actual regression).

- `src/solana/retry.test.ts`: **19/19 pass**
- Full unit suite: **459 pass, 0 fail**, 1 pre-existing skip (`escrow-token`)
- `tsc --noEmit`: clean

## Note for consumers

`AR_IO_SDK_LOG_LEVEL` defaults to `none` in ar-io-node, so this fix makes the knob *work* — operators still need to set it (`warn` is a good default) to see the output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable logging for retry operations.
  * Retry warnings now include attempt counts and error details.
  * Circuit-breaker state changes respect configured logging levels.

* **Bug Fixes**
  * Improved fallback behavior by using the shared default logger when no custom logger is provided.
  * Prevented unnecessary logs for non-retryable errors.
  * Preserved the original operation error when retry evaluation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Checklist

- [x] My PR is against the correct branch (`main`)
- [x] My commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style
- [x] My commit messages clearly explain the reasons for the changes
- [x] I have followed the architecture guidelines
- [x] I have run all tests — `retry.test.ts` 21/21; full unit suite **461 pass, 0 fail**, 1 pre-existing skip (`escrow-token`); `tsc --noEmit` clean
- [x] I have checked for existing issues/PRs to avoid duplicates
- [ ] I have run lint and format checks — ⚠️ **could not run locally**: the pinned `@biomejs/cli-linux-x64` binary is dynamically linked and will not execute on NixOS (`nix.dev/permalink/stub-ld`), and the repo pins biome 1.9.4 while nixpkgs only carries 2.x, whose formatter defaults differ. Relying on CI, which ran `format:check` and `lint:check` on both 18.x and 20.x and passed. Happy to have a maintainer run `yarn format` if CI disagrees after the latest commit.

## Review follow-up

Second commit addresses CodeRabbit's findings:
- **Predicate could mask the operation error.** `if (isLast || !retryable(error))` short-circuits, so the final attempt was the only place a user-supplied `isRetryable` got invoked; a throwing predicate would replace the real error. Now uses `attempt > 0`, which implies retryability without re-consulting the predicate. Two tests added.
- **Test leaked log level.** The shared-logger test set `Logger.default` to `debug` and never restored it. Now restores `'info'` in a `finally`.