### PR TITLE
ci: run build/test on PRs targeting main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,14 @@ on:
       - main
       - alpha
       - solana
+  # Promotion PRs (alpha -> main) have `alpha` as their head, which the
+  # branches-ignore above skips — so they produced NO build/test checks at all
+  # and `main`'s required status checks could never be satisfied. Scoped to
+  # PRs targeting main so feature -> alpha PRs keep relying on the push run
+  # above instead of running the whole matrix twice.
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
   workflow_call:
 


### PR DESCRIPTION
## Problem

`main`'s branch protection requires three status checks. **None of them can ever report on an alpha → main promotion PR**, so every promotion has to be admin-merged. #710 was.

Two independent defects:

**1. No workflow runs at all on promotion PRs.** `build.yml` triggers only on `push` with `branches-ignore: [main, alpha, solana]`. A promotion PR's head *is* `alpha`, so no run is created — the PR shows only CodeQL / Analyze / CodeRabbit. (Feature → alpha PRs are fine; their head branch isn't ignored, which is why #708 was green.)

**2. Two required context names match no job.** Protection asks for:

| required by `main` | actually produced |
|---|---|
| `build (20.x, build)` | ✅ `build (20.x, build)` |
| `build (20.x, format)` | ❌ matrix emits `build (20.x, format:check)` |
| `build (20.x, lint)` | ❌ matrix emits `build (20.x, lint:check)` |

## This PR

Fixes defect 1: adds a `pull_request` trigger scoped to PRs targeting `main`.

Scoped deliberately — feature → alpha PRs already get checks from the `push` trigger, so an unscoped `pull_request` would run the full 6-job matrix twice on every one of them.

## Still required: a repo-settings change

Defect 2 cannot be fixed in code. After this merges, `main`'s required status checks need correcting to the names actually produced:

```
build (20.x, build)
build (20.x, format:check)
build (20.x, lint:check)
test (unit)
```

**Note `test (unit)` is not currently required.** As configured, `main` is protected by linting and formatting but **not by tests**. Worth adding while the list is being corrected — that looks more like an oversight than a decision.

## Verification

YAML parses; trigger set is `push`, `pull_request` (branches: `[main]`), `workflow_dispatch`, `workflow_call`. Job names enumerated from the matrix confirm the mismatch above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKeNoHyV6m1Z3sh81Jykkf
