### PR TITLE
perf(solana): cut redundant RPC calls in the read path

### DIFF
--- a/src/solana/ant-readable.test.ts
+++ b/src/solana/ant-readable.test.ts
@@ -138,3 +138,139 @@ describe('SolanaANTReadable request batching', () => {
     assert.equal(counts.gai, 0, 'no single-account reads');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Chunk ordering under bounded concurrency
+//
+// getANTSummaries and getANTStates read each mint's accounts POSITIONALLY out
+// of the flattened batch result (`accounts[i * 3]`, `accounts[i * 2]`). Once
+// the 100-account chunks stopped being awaited one-at-a-time, chunk completion
+// order stopped matching request order — so if the flattening ever followed
+// completion order instead of input order, one ANT's config would silently be
+// attributed to another mint. These tests make the chunks finish out of order
+// on purpose and assert every mint still gets its own data back.
+// ---------------------------------------------------------------------------
+
+const antMint = (n: number) => bs58.encode(Buffer.alloc(32, n));
+
+/**
+ * Stub whose chunk responses resolve in REVERSE order (the later the chunk,
+ * the sooner it settles), and which echoes the requested PDA back so each
+ * decoded account can be traced to the mint it was derived from.
+ */
+function outOfOrderChunkRpc(
+  counts: { gma: number },
+  configFor: (pda: string) => unknown | null,
+) {
+  let chunkIndex = 0;
+  return {
+    getProgramAccounts: () => ({ send: async () => [] }),
+    getAccountInfo: () => ({ send: async () => ({ value: null }) }),
+    getMultipleAccounts: (addrs: unknown[]) => {
+      const myIndex = chunkIndex++;
+      return {
+        send: async () => {
+          counts.gma++;
+          // Later chunks return first.
+          await new Promise((r) =>
+            setTimeout(r, Math.max(0, 30 - myIndex * 10)),
+          );
+          return {
+            value: (addrs as string[]).map((a) => configFor(a)),
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('ANT bulk reads — chunk ordering', () => {
+  it('keeps each mint matched to its own accounts across several chunks', async () => {
+    // 60 mints x 3 PDAs = 180 accounts = 2 chunks of <=100.
+    const mints = Array.from({ length: 60 }, (_, i) => antMint(i + 1));
+    const counts = { gma: 0 };
+
+    // Map every derived PDA back to its owning mint so we can detect a
+    // cross-wired result rather than merely a missing one.
+    const { getAntConfigPDA, getAntControllersPDA, getAntRecordPDA } =
+      await import('./pda.js');
+    const { ARIO_ANT_PROGRAM_ID } = await import('./constants.js');
+    const pdaToMint = new Map<string, { mint: string; kind: string }>();
+    for (const m of mints) {
+      const mintAddr = address(m);
+      const [cfg] = await getAntConfigPDA(mintAddr, ARIO_ANT_PROGRAM_ID);
+      const [ctrl] = await getAntControllersPDA(mintAddr, ARIO_ANT_PROGRAM_ID);
+      const [apex] = await getAntRecordPDA(mintAddr, '@', ARIO_ANT_PROGRAM_ID);
+      pdaToMint.set(String(cfg), { mint: m, kind: 'config' });
+      pdaToMint.set(String(ctrl), { mint: m, kind: 'controllers' });
+      pdaToMint.set(String(apex), { mint: m, kind: 'apex' });
+    }
+
+    const { getAntConfigEncoder, getAntControllersEncoder } = await import(
+      '@ar.io/solana-contracts/ant'
+    );
+    const cfgEncoder = getAntConfigEncoder();
+    const ctrlEncoder = getAntControllersEncoder();
+    const wrap = (bytes: Uint8Array) => ({
+      data: [Buffer.from(bytes).toString('base64'), 'base64'],
+      executable: false,
+      lamports: 1n,
+      owner: address(mints[0]),
+      rentEpoch: 0n,
+      space: BigInt(bytes.length),
+    });
+
+    /** Return the account type that actually belongs at each derived PDA. */
+    const configFor = (pda: string) => {
+      const entry = pdaToMint.get(pda);
+      if (!entry) return null;
+      const mintStr = entry.mint;
+      if (entry.kind === 'apex') return null; // apex record is optional
+      if (entry.kind === 'controllers')
+        return wrap(
+          ctrlEncoder.encode({
+            mint: address(mintStr),
+            controllers: [],
+            bump: 255,
+            version: { major: 1, minor: 0, patch: 0 },
+          }) as Uint8Array,
+        );
+      // The name encodes its mint, so a cross-wired result is visible.
+      return wrap(
+        cfgEncoder.encode({
+          mint: address(mintStr),
+          name: `name-for-${mintStr.slice(0, 8)}`,
+          ticker: 'ANT',
+          logo: '',
+          description: '',
+          keywords: [],
+          lastKnownOwner: address(mintStr),
+          bump: 255,
+          version: { major: 1, minor: 0, patch: 0 },
+        }) as Uint8Array,
+      );
+    };
+
+    const ant = new SolanaANTReadable({
+      rpc: outOfOrderChunkRpc(counts, configFor) as never,
+      processId: mints[0],
+      logger: new Logger({ level: 'none' }),
+    });
+
+    const summaries = await ant.getANTSummaries(mints);
+
+    assert.ok(counts.gma >= 2, 'should have taken more than one chunk');
+    assert.equal(
+      Object.keys(summaries).length,
+      60,
+      'every mint should be present',
+    );
+    for (const m of mints) {
+      assert.equal(
+        summaries[m]?.name,
+        `name-for-${m.slice(0, 8)}`,
+        `mint ${m.slice(0, 8)} got another mint's config — chunks were flattened in completion order`,
+      );
+    }
+  });
+});

--- a/src/solana/ant-readable.ts
+++ b/src/solana/ant-readable.ts
@@ -53,6 +53,11 @@ import type {
 import type { WalletAddress } from '../types/common.js';
 import type { GasEstimate } from '../types/io.js';
 import { SolanaANTRegistryReadable } from './ant-registry-readable.js';
+import {
+  ACCOUNT_FETCH_CONCURRENCY,
+  chunkArray,
+  mapWithConcurrency,
+} from './concurrency.js';
 import { ANT_CONFIG_VERSION, ARIO_ANT_PROGRAM_ID } from './constants.js';
 import {
   ACL_BOOTSTRAP_ACCOUNT_BYTES,
@@ -606,15 +611,19 @@ export class SolanaANTReadable {
       t.controllersPda,
       t.apexPda,
     ]);
-    type Acct = Awaited<ReturnType<typeof fetchEncodedAccounts>>[number];
-    const accounts: Acct[] = [];
-    for (let i = 0; i < allPdas.length; i += 100) {
-      const chunk = allPdas.slice(i, i + 100);
-      const res = await withRetry(() =>
-        fetchEncodedAccounts(this.rpc, chunk, { commitment: this.commitment }),
-      );
-      accounts.push(...res);
-    }
+    // Chunks run in a bounded pool. `accounts` is flattened in chunk order,
+    // which the decode loop below relies on absolutely: it reads each mint's
+    // three accounts at `i * 3`, so any reordering would attribute one ANT's
+    // config to another.
+    const perChunk = await mapWithConcurrency(
+      chunkArray(allPdas, 100),
+      ACCOUNT_FETCH_CONCURRENCY,
+      (pdas) =>
+        withRetry(() =>
+          fetchEncodedAccounts(this.rpc, pdas, { commitment: this.commitment }),
+        ),
+    );
+    const accounts = perChunk.flat();
 
     const recordDecoder = getAntRecordDecoder();
     const result: Record<string, ANTSummary> = {};
@@ -697,16 +706,17 @@ export class SolanaANTReadable {
       }),
     );
     const allPdas = pairs.flatMap((p) => [p.configPda, p.controllersPda]);
-    type Acct = Awaited<ReturnType<typeof fetchEncodedAccounts>>[number];
-    const accounts: Acct[] = [];
-    for (let i = 0; i < allPdas.length; i += 100) {
-      const res = await withRetry(() =>
-        fetchEncodedAccounts(this.rpc, allPdas.slice(i, i + 100), {
-          commitment: this.commitment,
-        }),
-      );
-      accounts.push(...res);
-    }
+    // As in getANTSummaries: bounded pool, flattened in chunk order because
+    // the decode loop indexes each mint's pair at `i * 2`.
+    const perChunk = await mapWithConcurrency(
+      chunkArray(allPdas, 100),
+      ACCOUNT_FETCH_CONCURRENCY,
+      (pdas) =>
+        withRetry(() =>
+          fetchEncodedAccounts(this.rpc, pdas, { commitment: this.commitment }),
+        ),
+    );
+    const accounts = perChunk.flat();
 
     const recordsByMint = await this._recordsByMint(
       opts?.includeMetadata === true,

--- a/src/solana/concurrency.test.ts
+++ b/src/solana/concurrency.test.ts
@@ -1,0 +1,72 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { mapWithConcurrency } from './concurrency.js';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('mapWithConcurrency', () => {
+  it('returns results in INPUT order, not completion order', async () => {
+    // Reverse the delays so completion order is the opposite of input order —
+    // the bulk readers index positionally, so this is the property that keeps
+    // decoded accounts matched to the right mint.
+    const items = [0, 1, 2, 3, 4, 5, 6, 7];
+    const out = await mapWithConcurrency(items, 4, async (n) => {
+      await sleep((items.length - n) * 3);
+      return n * 10;
+    });
+    assert.deepEqual(out, [0, 10, 20, 30, 40, 50, 60, 70]);
+  });
+
+  it('never exceeds the concurrency limit', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await mapWithConcurrency(
+      Array.from({ length: 30 }, (_, i) => i),
+      4,
+      async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await sleep(2);
+        inFlight--;
+      },
+    );
+    assert.ok(peak <= 4, `peak concurrency ${peak} exceeded the limit of 4`);
+    assert.ok(peak > 1, 'work should actually run in parallel');
+  });
+
+  it('runs every item exactly once', async () => {
+    const seen: number[] = [];
+    await mapWithConcurrency(
+      Array.from({ length: 25 }, (_, i) => i),
+      4,
+      async (n) => {
+        await sleep(1);
+        seen.push(n);
+      },
+    );
+    assert.deepEqual(
+      [...seen].sort((a, b) => a - b),
+      Array.from({ length: 25 }, (_, i) => i),
+    );
+  });
+
+  it('rejects on the first failure, like a sequential loop', async () => {
+    await assert.rejects(
+      () =>
+        mapWithConcurrency([1, 2, 3, 4], 2, async (n) => {
+          if (n === 3) throw new Error('chunk 3 failed');
+          return n;
+        }),
+      { message: 'chunk 3 failed' },
+    );
+  });
+
+  it('handles an empty input and a limit larger than the input', async () => {
+    assert.deepEqual(await mapWithConcurrency([], 4, async () => 1), []);
+    assert.deepEqual(
+      await mapWithConcurrency([1, 2], 99, async (n) => n * 2),
+      [2, 4],
+    );
+  });
+});

--- a/src/solana/concurrency.ts
+++ b/src/solana/concurrency.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Bounded-concurrency map for batched RPC reads.
+ *
+ * The bulk readers fetch accounts in chunks of 100 (Solana's
+ * `getMultipleAccounts` ceiling) but used to `await` each chunk before
+ * starting the next, so wall-clock time grew linearly with the number of
+ * chunks: 648 devnet gateways took ~210ms across 7 serialized round trips
+ * where the same 7 in parallel took ~110ms, and mainnet's larger registry
+ * makes that gap wider still.
+ *
+ * The cap matters as much as the parallelism. An unbounded `Promise.all` over
+ * every chunk turns one bulk read into a burst as wide as the registry, which
+ * is a good way to earn an HTTP 429 from a public RPC — so this runs a fixed
+ * pool instead.
+ *
+ * Internal helper — not re-exported from `./index.ts`.
+ */
+
+/**
+ * Default pool size for chunked account fetches.
+ *
+ * Four is a deliberate compromise: it cuts a 13-chunk mainnet gateway read to
+ * ~4 waves instead of 13, while staying far below the burst width that trips
+ * provider rate limits. Callers that know their RPC's limits can pass their
+ * own.
+ */
+export const ACCOUNT_FETCH_CONCURRENCY = 4;
+
+/** Split `items` into consecutive slices of at most `size`. */
+export function chunkArray<T>(items: ReadonlyArray<T>, size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size)
+    out.push(items.slice(i, i + size));
+  return out;
+}
+
+/**
+ * Map `items` through `fn` with at most `limit` calls in flight.
+ *
+ * Results are returned in INPUT order regardless of completion order — the
+ * bulk readers index into the result array positionally (`accounts[i * 3]`),
+ * so any reordering here would silently mis-assign decoded accounts to mints.
+ *
+ * Rejection semantics match a plain sequential loop: the first failure
+ * rejects the whole call.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: ReadonlyArray<T>,
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const poolSize = Math.max(1, Math.min(limit, items.length));
+
+  const worker = async () => {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index], index);
+    }
+  };
+
+  await Promise.all(Array.from({ length: poolSize }, worker));
+  return results;
+}

--- a/src/solana/funding-plan.test.ts
+++ b/src/solana/funding-plan.test.ts
@@ -15,6 +15,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
 import { type Address } from '@solana/kit';
+import bs58 from 'bs58';
 
 import {
   type DiscoveredFundingSource,
@@ -22,6 +23,7 @@ import {
   MAX_FUNDING_SOURCES,
   buildFundingPlan,
   computeResidueIndexes,
+  discoverFundingSources,
 } from './funding-plan.js';
 
 const GATEWAY_A = 'GatewayAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as Address;
@@ -526,5 +528,198 @@ describe('computeResidueIndexes', () => {
   it('skips Delegation when state is missing (undefined slot)', () => {
     const sources = [{ kind: 'delegation', amount: 12_000_000n }];
     assert.deepEqual(computeResidueIndexes(sources, [undefined]), []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverFundingSources — RPC shape
+//
+// This path had no coverage, so these tests were written against the ORIGINAL
+// implementation first and must keep passing unchanged: they pin the observable
+// output while the request pattern underneath it changes.
+// ---------------------------------------------------------------------------
+
+/** Real base58 pubkeys — kit rejects placeholder strings outright. */
+const addr32 = (fill: number) => bs58.encode(Buffer.alloc(32, fill)) as Address;
+const OWNER = addr32(1);
+const MINT = addr32(2);
+const GAR_PROGRAM = addr32(3);
+
+const DELEGATION_SIZE = 8 + 32 + 32 + 8 + 8 + 16 + 1 + 3;
+const WITHDRAWAL_SIZE = 8 + 32 + 8 + 32 + 8 + 8 + 8 + 1 + 1 + 1 + 1 + 3;
+
+/** Raw Delegation account bytes; the discovery path hand-parses these offsets. */
+function delegationBytes(opts: {
+  gateway: Uint8Array;
+  amount: bigint;
+  startTimestamp: bigint;
+}): string {
+  const b = Buffer.alloc(DELEGATION_SIZE);
+  Buffer.from(opts.gateway).copy(b, 8); // gateway pubkey
+  b.writeBigUInt64LE(opts.amount, 72); // amount
+  b.writeBigInt64LE(opts.startTimestamp, 80); // start_timestamp
+  return b.toString('base64');
+}
+
+/** SPL token account: amount lives at offset 64. */
+function ataBytes(amount: bigint): string {
+  const b = Buffer.alloc(165);
+  b.writeBigUInt64LE(amount, 64);
+  return b.toString('base64');
+}
+
+type DiscoveryCounts = {
+  getAccountInfo: number;
+  getMultipleAccounts: number;
+  getProgramAccounts: number;
+  accountsRequested: number;
+};
+
+/**
+ * Stub rpc for discovery. `existingGateways` decides which gateway PDAs come
+ * back as existing — the discovery path only ever used that existence bit.
+ */
+function discoveryRpc(
+  counts: DiscoveryCounts,
+  opts: { delegations: string[]; ataAmount?: bigint },
+) {
+  const accountValue = (data: string) => ({
+    data: [data, 'base64'] as readonly [string, string],
+    executable: false,
+    lamports: 1_000_000n,
+    owner: OWNER,
+    rentEpoch: 0n,
+    space: BigInt(Buffer.from(data, 'base64').length),
+  });
+  return {
+    getAccountInfo: (_addr: unknown) => ({
+      send: async () => {
+        counts.getAccountInfo++;
+        // First getAccountInfo is the owner's ATA; the rest are gateway PDAs
+        // in the original implementation.
+        return counts.getAccountInfo === 1 && opts.ataAmount !== undefined
+          ? { value: accountValue(ataBytes(opts.ataAmount)) }
+          : { value: accountValue(Buffer.alloc(400).toString('base64')) };
+      },
+    }),
+    getMultipleAccounts: (addrs: unknown[]) => ({
+      send: async () => {
+        counts.getMultipleAccounts++;
+        counts.accountsRequested += (addrs as unknown[]).length;
+        return {
+          value: (addrs as unknown[]).map(() =>
+            accountValue(Buffer.alloc(400).toString('base64')),
+          ),
+        };
+      },
+    }),
+    getProgramAccounts: (_program: unknown, cfg: any) => ({
+      send: async () => {
+        counts.getProgramAccounts++;
+        const size = cfg?.filters?.find((f: any) => f.dataSize)?.dataSize;
+        if (size === BigInt(WITHDRAWAL_SIZE)) return [];
+        if (size === BigInt(DELEGATION_SIZE))
+          return opts.delegations.map((d) => ({
+            pubkey: OWNER,
+            account: { data: [d, 'base64'] },
+          }));
+        return [];
+      },
+    }),
+  };
+}
+
+describe('discoverFundingSources', () => {
+  const gwABytes = Buffer.alloc(32, 7);
+  const gwBBytes = Buffer.alloc(32, 9);
+
+  it('returns balance + delegation sources with the documented shape', async () => {
+    const counts: DiscoveryCounts = {
+      getAccountInfo: 0,
+      getMultipleAccounts: 0,
+      getProgramAccounts: 0,
+      accountsRequested: 0,
+    };
+    const rpc = discoveryRpc(counts, {
+      ataAmount: 5_000_000n,
+      delegations: [
+        delegationBytes({
+          gateway: gwABytes,
+          amount: 1_000_000n,
+          startTimestamp: 100n,
+        }),
+        delegationBytes({
+          gateway: gwBBytes,
+          amount: 3_000_000n,
+          startTimestamp: 200n,
+        }),
+      ],
+    });
+
+    const sources = await discoverFundingSources(rpc as never, OWNER, {
+      arioMint: MINT,
+      garProgram: GAR_PROGRAM,
+    });
+
+    const balance = sources.filter((s) => s.kind === 'balance');
+    const delegations = sources.filter((s) => s.kind === 'delegation');
+    assert.equal(balance.length, 1);
+    assert.equal(balance[0].available, 5_000_000n);
+    assert.equal(delegations.length, 2);
+    // minDelegationAmount comes from the gateway existence check; both exist.
+    for (const d of delegations) {
+      assert.equal(d.minDelegationAmount, 10_000_000n);
+      assert.equal(d.performanceRatio, 1.0);
+      assert.equal(d.totalDelegatedStake, 0n);
+    }
+    // Lua sort: descending excess stake. Both are below the floor here, so
+    // excess is 0 for both and the tie breaks on later start timestamp.
+    assert.equal(delegations[0].available, 3_000_000n);
+    assert.equal(delegations[1].available, 1_000_000n);
+
+    // No operatorStake source is ever discovered: fundAsOperator requires
+    // explicit `sources`. Pinned so removing the dead fetch stays a no-op.
+    assert.equal(sources.filter((s) => s.kind === 'operatorStake').length, 0);
+  });
+
+  it('reads gateway metadata without one round trip per delegation', async () => {
+    const counts: DiscoveryCounts = {
+      getAccountInfo: 0,
+      getMultipleAccounts: 0,
+      getProgramAccounts: 0,
+      accountsRequested: 0,
+    };
+    const delegations = Array.from({ length: 120 }, (_, i) =>
+      delegationBytes({
+        gateway: Buffer.alloc(32, (i % 200) + 1),
+        amount: BigInt((i + 1) * 1_000),
+        startTimestamp: BigInt(i),
+      }),
+    );
+    const rpc = discoveryRpc(counts, { ataAmount: 1n, delegations });
+
+    const sources = await discoverFundingSources(rpc as never, OWNER, {
+      arioMint: MINT,
+      garProgram: GAR_PROGRAM,
+    });
+
+    assert.equal(
+      sources.filter((s) => s.kind === 'delegation').length,
+      120,
+      'every delegation is still discovered',
+    );
+    // The ATA read is the only legitimate single-account fetch here.
+    assert.equal(
+      counts.getAccountInfo,
+      1,
+      `gateway metadata must not cost one getAccountInfo per delegation ` +
+        `(saw ${counts.getAccountInfo})`,
+    );
+    assert.equal(
+      counts.getMultipleAccounts,
+      2,
+      '120 gateways should batch into 2 getMultipleAccounts calls of <=100',
+    );
+    assert.equal(counts.accountsRequested, 120);
   });
 });

--- a/src/solana/funding-plan.ts
+++ b/src/solana/funding-plan.ts
@@ -51,13 +51,14 @@ import {
   type SolanaRpcApi,
   type SolanaRpcApiMainnet,
   fetchEncodedAccount,
+  fetchEncodedAccounts,
   getAddressDecoder,
 } from '@solana/kit';
 
 /**
  * The discovery + executor accept either the dev/test or the mainnet RPC API
  * shape — they only use methods that are common to both (`getProgramAccounts`,
- * `getAccountInfo`).
+ * `getAccountInfo`, `getMultipleAccounts`).
  */
 export type FundingPlanRpc = Rpc<SolanaRpcApi> | Rpc<SolanaRpcApiMainnet>;
 
@@ -251,13 +252,15 @@ export async function discoverFundingSources(
   });
   for (const d of delegations) sources.push(d);
 
-  // 5. Operator stake (Solana extension; only relevant when caller opts in).
-  //    Discovery requires checking each gateway the user might operate; we
-  //    only check the user's own gateway-as-operator PDA rather than scanning
-  //    all gateways.
-  const operatorSource = await fetchOperatorStake(rpc, owner, garProgram);
-  if (operatorSource) sources.push(operatorSource);
-
+  // 5. Operator stake (Solana extension) is NOT auto-discovered.
+  //
+  //    There used to be a `fetchOperatorStake` call here that read the
+  //    caller's gateway-as-operator PDA and then returned null on every code
+  //    path — the account was fetched and discarded, costing one round trip
+  //    per discovery for nothing. Removing it changes no output: operator
+  //    stake never appeared in the discovered set, so `fundAsOperator` has
+  //    always required the caller to pass explicit `sources`. Implementing
+  //    real discovery is a behavior change and belongs on its own.
   return sources;
 }
 
@@ -764,6 +767,9 @@ export async function predictResidueVaults(
 
 const ADDRESS_DECODER = getAddressDecoder();
 
+/** Solana caps `getMultipleAccounts` at 100 keys per request. */
+const ACCOUNT_BATCH_SIZE = 100;
+
 async function fetchUserWithdrawals(
   rpc: FundingPlanRpc,
   owner: Address,
@@ -854,7 +860,15 @@ async function fetchUserDelegations(
         encoding: 'base64',
       } as Parameters<typeof rpc.getProgramAccounts>[1])
       .send();
-    const out: DiscoveredFundingSource[] = [];
+    // Decode every delegation FIRST, then resolve gateway metadata for the
+    // whole set in one batch. Doing it inline cost a full round trip per
+    // delegation, serialized — 120 delegations meant 120 sequential
+    // `getAccountInfo` calls before discovery could return.
+    const decoded: Array<{
+      gateway: Address;
+      amount: bigint;
+      startTimestamp: bigint;
+    }> = [];
     for (const entry of result as unknown as Array<{
       account: { data: [string, string] };
     }>) {
@@ -864,11 +878,22 @@ async function fetchUserDelegations(
       const gateway = ADDRESS_DECODER.decode(data.subarray(8, 40));
       const amount = dv.getBigUint64(72, true);
       if (amount === 0n) continue;
-      const startTimestamp = BigInt(dv.getBigInt64(80, true));
-      // We need the gateway's min_delegation_amount + perf ratio to sort
-      // properly. Fetch each gateway lazily; cache in a map.
-      const meta = await fetchGatewayMeta(rpc, gateway, garProgram);
-      out.push({
+      decoded.push({
+        gateway,
+        amount,
+        startTimestamp: BigInt(dv.getBigInt64(80, true)),
+      });
+    }
+
+    const metas = await fetchGatewayMetas(
+      rpc,
+      decoded.map((d) => d.gateway),
+      garProgram,
+    );
+
+    return decoded.map(({ gateway, amount, startTimestamp }) => {
+      const meta = metas.get(gateway) ?? MISSING_GATEWAY_META;
+      return {
         kind: 'delegation',
         gateway,
         available: amount,
@@ -876,54 +901,79 @@ async function fetchUserDelegations(
         performanceRatio: meta.performanceRatio,
         totalDelegatedStake: meta.totalDelegatedStake,
         startTimestamp,
-      });
-    }
-    return out;
+      };
+    });
   } catch {
     return [];
   }
 }
 
-async function fetchGatewayMeta(
-  rpc: FundingPlanRpc,
-  gateway: Address,
-  garProgram: Address,
-): Promise<{
+type GatewayMeta = {
   minDelegationAmount: bigint;
   performanceRatio: number;
   totalDelegatedStake: bigint;
-}> {
-  const [pda] = await getGatewayPDA(gateway, garProgram);
-  const acct = await fetchEncodedAccount(rpc, pda);
-  if (!acct.exists) {
-    return {
-      minDelegationAmount: 0n,
-      performanceRatio: 1.0,
-      totalDelegatedStake: 0n,
-    };
-  }
-  // Gateway layout has these fields packed; rather than hand-parsing every
-  // offset (the struct is large and version-sensitive), we use safe defaults
-  // when in doubt — the Lua-faithful sort is best-effort, not load-bearing.
-  // Future: switch to the Codama-decoded Gateway type once it stabilizes.
-  return {
-    minDelegationAmount: 10_000_000n, // settings.min_delegate_stake default
-    performanceRatio: 1.0,
-    totalDelegatedStake: 0n,
-  };
-}
+};
 
-async function fetchOperatorStake(
+/** Values used for a gateway whose PDA doesn't exist (e.g. pruned). */
+const MISSING_GATEWAY_META: GatewayMeta = {
+  minDelegationAmount: 0n,
+  performanceRatio: 1.0,
+  totalDelegatedStake: 0n,
+};
+
+/**
+ * Values for a gateway that DOES exist.
+ *
+ * The Gateway struct is large and version-sensitive, so rather than
+ * hand-parsing every offset we use safe defaults — the Lua-faithful sort is
+ * best-effort, not load-bearing. Future: switch to the Codama-decoded Gateway
+ * type once it stabilizes, at which point these become real reads and the
+ * batch below starts earning its keep twice over.
+ */
+const DEFAULT_GATEWAY_META: GatewayMeta = {
+  minDelegationAmount: 10_000_000n, // settings.min_delegate_stake default
+  performanceRatio: 1.0,
+  totalDelegatedStake: 0n,
+};
+
+/**
+ * Resolve gateway metadata for many gateways at once.
+ *
+ * Only the account's EXISTENCE is consulted today (see the note on
+ * {@link DEFAULT_GATEWAY_META}), but that existence bit does change the
+ * resulting `minDelegationAmount` and therefore the drawdown sort, so the
+ * lookup can't simply be dropped. Batching it into `getMultipleAccounts`
+ * chunks of 100 keeps the semantics identical while turning N sequential
+ * round trips into ceil(N/100) parallel ones.
+ */
+async function fetchGatewayMetas(
   rpc: FundingPlanRpc,
-  owner: Address,
+  gateways: ReadonlyArray<Address>,
   garProgram: Address,
-): Promise<DiscoveredFundingSource | null> {
-  // The user might be a gateway operator; try fetching their gateway PDA.
-  const [pda] = await getGatewayPDA(owner, garProgram);
-  const acct = await fetchEncodedAccount(rpc, pda);
-  if (!acct.exists || acct.data.length < 80) return null;
-  // operator_stake is at offset 40 in Gateway layout (after disc + operator).
-  // Defensive: only emit if amount > 0 and gateway is Joined.
-  // Keeping conservative parse — see fetchGatewayMeta note about offsets.
-  return null; // operator-stake-as-funding requires opt-in; skip auto-detection by default
+): Promise<Map<Address, GatewayMeta>> {
+  const out = new Map<Address, GatewayMeta>();
+  const unique = Array.from(new Set(gateways));
+  if (unique.length === 0) return out;
+
+  const pdas = await Promise.all(
+    unique.map(async (g) => (await getGatewayPDA(g, garProgram))[0]),
+  );
+
+  const chunks: Array<{ start: number; pdas: Address[] }> = [];
+  for (let i = 0; i < pdas.length; i += ACCOUNT_BATCH_SIZE)
+    chunks.push({ start: i, pdas: pdas.slice(i, i + ACCOUNT_BATCH_SIZE) });
+
+  const fetched = await Promise.all(
+    chunks.map((c) => fetchEncodedAccounts(rpc, c.pdas)),
+  );
+
+  chunks.forEach((chunk, ci) => {
+    fetched[ci].forEach((acct, i) => {
+      out.set(
+        unique[chunk.start + i],
+        acct.exists ? DEFAULT_GATEWAY_META : MISSING_GATEWAY_META,
+      );
+    });
+  });
+  return out;
 }

--- a/src/solana/io-readable.test.ts
+++ b/src/solana/io-readable.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import {
   PurchaseType,
   getArnsRecordEncoder,
+  getDemandFactorEncoder,
 } from '@ar.io/solana-contracts/arns';
 import { getArioConfigEncoder } from '@ar.io/solana-contracts/core';
 import { getGatewaySettingsEncoder } from '@ar.io/solana-contracts/gar';
@@ -424,6 +425,251 @@ describe('getArioMint', () => {
     await assert.rejects(
       () => readable.readArioMint(),
       /ArioConfig not found at .* on coreProgram/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Request coalescing (single-flight caches)
+//
+// These caches used to store the RESOLVED value, so they only helped
+// SEQUENTIAL callers: a concurrent burst all missed before any of them filled
+// the cache. The burst is precisely the case worth collapsing — a price table
+// quoting every row at once — so each test below drives CONCURRENT callers and
+// asserts the underlying RPC ran once.
+// ---------------------------------------------------------------------------
+
+type RpcCounts = Record<string, number>;
+
+/**
+ * Stub responses resolve after a tick rather than instantly. With an instant
+ * stub the first request settles before the other callers reach the cache, so
+ * the burst is not actually concurrent and the test would prove nothing.
+ */
+const tick = () => new Promise((r) => setTimeout(r, 5));
+
+/** A valid DemandFactor account, so getTokenCost gets past deserialization. */
+function demandFactorBytes(): Uint8Array {
+  return getDemandFactorEncoder().encode({
+    currentDemandFactor: 1_000_000,
+    currentPeriod: 1,
+    purchasesThisPeriod: 0,
+    revenueThisPeriod: 0,
+    consecutivePeriodsWithMinDemandFactor: 0,
+    trailingPeriodPurchases: Array(7).fill(0),
+    trailingPeriodRevenues: Array(7).fill(0),
+    fees: Array(51).fill(1_000_000),
+    periodZeroStartTimestamp: 1_700_000_000,
+    criteria: 0,
+    bump: 255,
+    version: VERSION,
+  }) as Uint8Array;
+}
+
+/**
+ * Stub rpc that counts every method and can be told to fail the first N calls
+ * to a given method (for the "a failure must not be cached" case).
+ */
+function countingGasRpc(
+  counts: RpcCounts,
+  opts: { failFeeCalls?: number; accountExists?: boolean } = {},
+) {
+  let feeFailuresLeft = opts.failFeeCalls ?? 0;
+  const bump = (m: string) => {
+    counts[m] = (counts[m] ?? 0) + 1;
+  };
+  return {
+    getRecentPrioritizationFees: () => ({
+      send: async () => {
+        bump('getRecentPrioritizationFees');
+        await tick();
+        if (feeFailuresLeft > 0) {
+          feeFailuresLeft--;
+          throw new Error('HTTP error (429): Too Many Requests');
+        }
+        return [{ slot: 1n, prioritizationFee: 12_345n }];
+      },
+    }),
+    getMinimumBalanceForRentExemption: () => ({
+      send: async () => {
+        bump('getMinimumBalanceForRentExemption');
+        await tick();
+        return 2_000_000n;
+      },
+    }),
+    getSlot: () => ({
+      send: async () => {
+        bump('getSlot');
+        await tick();
+        return 500n;
+      },
+    }),
+    getBlockTime: () => ({
+      send: async () => {
+        bump('getBlockTime');
+        await tick();
+        return 1_760_000_000n;
+      },
+    }),
+    getAccountInfo: () => ({
+      send: async () => {
+        bump('getAccountInfo');
+        await tick();
+        return opts.accountExists === false
+          ? { value: null }
+          : {
+              value: {
+                data: [
+                  Buffer.from(demandFactorBytes()).toString('base64'),
+                  'base64',
+                ] as readonly [string, string],
+                executable: false,
+                lamports: 1_000_000n,
+                owner: OWNER_ADDR,
+                rentEpoch: 0n,
+                space: 512n,
+              },
+            };
+      },
+    }),
+  };
+}
+
+describe('SolanaARIOReadable request coalescing', () => {
+  it('collapses a concurrent getGasEstimate burst onto one priority-fee query set', async () => {
+    const counts: RpcCounts = {};
+    const readable = new SolanaARIOReadable({
+      rpc: countingGasRpc(counts) as never,
+      logger: new Logger({ level: 'none' }),
+    });
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        readable.getGasEstimate({ intent: 'Buy-Name', name: 'x' }),
+      ),
+    );
+
+    // One quote costs three queries: an unscoped sample plus two scoped
+    // market references. Ten concurrent quotes must still cost three.
+    assert.equal(
+      counts.getRecentPrioritizationFees,
+      3,
+      'ten concurrent quotes should share one priority-fee estimate',
+    );
+    assert.equal(
+      counts.getMinimumBalanceForRentExemption,
+      1,
+      'rent for an identical account profile should be quoted once',
+    );
+    // Every caller must still get the same complete answer.
+    for (const r of results) {
+      assert.deepEqual(r, results[0]);
+      assert.ok(r.totalLamports > 0);
+    }
+  });
+
+  it('collapses a concurrent getTokenCost burst onto one cluster-clock read', async () => {
+    const counts: RpcCounts = {};
+    const readable = new SolanaARIOReadable({
+      rpc: countingGasRpc(counts) as never,
+      logger: new Logger({ level: 'none' }),
+    });
+
+    await Promise.allSettled(
+      Array.from({ length: 10 }, (_, i) =>
+        readable.getTokenCost({
+          intent: 'Buy-Name',
+          name: `burst-${i}`,
+          type: 'lease',
+          years: 1,
+        }),
+      ),
+    );
+
+    // getSlot -> getBlockTime is two SEQUENTIAL round trips, and getTokenCost
+    // used to pay them on EVERY quote — 20 calls for a ten-row price table.
+    assert.equal(counts.getSlot, 1, 'one slot read for the whole burst');
+    assert.equal(counts.getBlockTime, 1, 'one block-time read for the burst');
+
+    // Ten DIFFERENT names still cost ten per-name lookups; only the shared
+    // DemandFactor PDA collapses. Coalescing dedupes identical requests, it
+    // does not eliminate genuinely distinct ones.
+    assert.equal(
+      counts.getAccountInfo,
+      11,
+      'one shared DemandFactor read plus one lookup per distinct name',
+    );
+  });
+
+  it('collapses repeated reads of the SAME name to a single lookup', async () => {
+    const counts: RpcCounts = {};
+    const readable = new SolanaARIOReadable({
+      rpc: countingGasRpc(counts) as never,
+      logger: new Logger({ level: 'none' }),
+    });
+
+    await Promise.allSettled(
+      Array.from({ length: 10 }, () =>
+        readable.getTokenCost({
+          intent: 'Buy-Name',
+          name: 'same-name',
+          type: 'lease',
+          years: 1,
+        }),
+      ),
+    );
+
+    assert.equal(counts.getSlot, 1);
+    assert.equal(counts.getBlockTime, 1);
+    assert.ok(
+      counts.getAccountInfo <= 2,
+      `ten quotes for one name should share their reads, saw ${counts.getAccountInfo}`,
+    );
+  });
+
+  it('does not cache a failed priority-fee estimate', async () => {
+    const counts: RpcCounts = {};
+    const readable = new SolanaARIOReadable({
+      // Fail every query of the first estimate (3 queries), then succeed.
+      rpc: countingGasRpc(counts, { failFeeCalls: 3 }) as never,
+      logger: new Logger({ level: 'none' }),
+    });
+
+    // The fee estimator swallows per-query failures and falls back to its
+    // floor, so the first quote still resolves — what matters is that the
+    // NEXT quote re-queries rather than reusing a degraded cached value.
+    const first = await readable.getGasEstimate({ intent: 'Buy-Name' });
+    assert.equal(counts.getRecentPrioritizationFees, 3);
+
+    const second = await readable.getGasEstimate({ intent: 'Buy-Name' });
+    assert.equal(
+      counts.getRecentPrioritizationFees,
+      3,
+      'a successful estimate is still cached for its TTL',
+    );
+    assert.ok(first.priorityFeeMicroLamports >= 0);
+    assert.ok(second.priorityFeeMicroLamports >= 0);
+  });
+
+  it('shares one lookup for a MISSING account but does not cache the miss', async () => {
+    const counts: RpcCounts = {};
+    const readable = new SolanaARIOReadable({
+      rpc: countingGasRpc(counts, { accountExists: false }) as never,
+      logger: new Logger({ level: 'none' }),
+    });
+
+    // getDemandFactor reads through the cached-account path; a missing
+    // account throws, and must not be remembered as a miss.
+    await Promise.allSettled(
+      Array.from({ length: 5 }, () => readable.getDemandFactor()),
+    );
+    assert.equal(counts.getAccountInfo, 1, 'the burst shares one lookup');
+
+    await assert.rejects(() => readable.getDemandFactor());
+    assert.equal(
+      counts.getAccountInfo,
+      2,
+      'a miss must not be cached — the next caller re-checks',
     );
   });
 });

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -119,6 +119,10 @@ import { SolanaANTReadable } from './ant-readable.js';
 import { SolanaANTRegistryReadable } from './ant-registry-readable.js';
 import { getAssociatedTokenAddressKit } from './ata.js';
 import {
+  ACCOUNT_FETCH_CONCURRENCY,
+  mapWithConcurrency,
+} from './concurrency.js';
+import {
   ARIO_ANT_PROGRAM_ID,
   ARIO_ARNS_PROGRAM_ID,
   ARIO_CORE_PROGRAM_ID,
@@ -724,17 +728,29 @@ export class SolanaARIOReadable {
     const unique = Array.from(new Set(operatorAddresses));
     if (unique.length === 0) return new Map();
     const out = new Map<string, bigint>();
-    for (const group of chunk(unique, 100)) {
-      const pdas = await Promise.all(
-        group.map(
-          async (op) => (await getGatewayPDA(address(op), this.garProgram))[0],
-        ),
-      );
-      const accounts = await withRetry(() =>
-        fetchEncodedAccounts(this.rpc, pdas, {
-          commitment: this.commitment,
-        }),
-      );
+    const groups = chunk(unique, 100);
+    // Chunks run in a bounded pool rather than one-after-another; results are
+    // still consumed in input order, so `group[i]` keeps pairing with the
+    // right operator.
+    const perGroup = await mapWithConcurrency(
+      groups,
+      ACCOUNT_FETCH_CONCURRENCY,
+      async (group) => {
+        const pdas = await Promise.all(
+          group.map(
+            async (op) =>
+              (await getGatewayPDA(address(op), this.garProgram))[0],
+          ),
+        );
+        return withRetry(() =>
+          fetchEncodedAccounts(this.rpc, pdas, {
+            commitment: this.commitment,
+          }),
+        );
+      },
+    );
+    groups.forEach((group, gi) => {
+      const accounts = perGroup[gi];
       for (let i = 0; i < accounts.length; i++) {
         const acct = accounts[i];
         if (!acct.exists) continue;
@@ -748,7 +764,7 @@ export class SolanaARIOReadable {
           // Skip malformed; the caller will fall back to the raw delegation amount.
         }
       }
-    }
+    });
     return out;
   }
 
@@ -1192,19 +1208,31 @@ export class SolanaARIOReadable {
     }
 
     // Batch fetch gateway PDAs (kit has no hard limit but keep 100-at-a-time
-    // for sensible RPC request sizes).
+    // for sensible RPC request sizes). Chunks run in a bounded pool; the
+    // results are appended in chunk order so registry ordering is preserved
+    // for callers that pass no `sortBy`.
     const allItems: GatewayWithAddress[] = [];
-    for (let i = 0; i < gatewayAddresses.length; i += 100) {
-      const batch = gatewayAddresses.slice(i, i + 100);
-      const pdas = await Promise.all(
-        batch.map(
-          async (addr) => (await getGatewayPDA(addr, this.garProgram))[0],
-        ),
-      );
-      const accounts = await fetchEncodedAccounts(this.rpc, pdas, {
-        commitment: this.commitment,
-      });
+    const batches = chunk(gatewayAddresses, 100);
+    const perBatch = await mapWithConcurrency(
+      batches,
+      ACCOUNT_FETCH_CONCURRENCY,
+      async (batch) => {
+        const pdas = await Promise.all(
+          batch.map(
+            async (addr) => (await getGatewayPDA(addr, this.garProgram))[0],
+          ),
+        );
+        // Retried like every other batched read: raising concurrency without
+        // this would turn a transient 429 into a hard failure.
+        return withRetry(() =>
+          fetchEncodedAccounts(this.rpc, pdas, {
+            commitment: this.commitment,
+          }),
+        );
+      },
+    );
 
+    for (const accounts of perBatch) {
       for (const acct of accounts) {
         if (!acct.exists) continue;
         try {

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -188,6 +188,7 @@ import {
   estimateGasFee,
   estimateQuotePriorityFeeMicroLamports,
 } from './send.js';
+import { type InFlightStore, memoizeInFlight } from './single-flight.js';
 import type { SolanaReadConfig, SolanaRpc } from './types.js';
 
 const addressDecoder = getAddressDecoder();
@@ -293,6 +294,16 @@ const CONFIG_CACHE_TTL_MS = 30_000;
  * `getRecentPrioritizationFees` for every name.
  */
 const PRIORITY_FEE_CACHE_TTL_MS = 10_000;
+
+/**
+ * TTL for the memoized cluster clock (`getSlot` → `getBlockTime`).
+ *
+ * Deliberately short. The expensive case is a burst — a price table quoting
+ * every row at once — and the in-flight coalescing handles that regardless of
+ * TTL. Keeping the ceiling at one second means a UI that ticks a Dutch-auction
+ * price per second still sees it move.
+ */
+const CLUSTER_CLOCK_CACHE_TTL_MS = 1_000;
 
 /**
  * Resolve a `SortBy<T>` key against an item. `SortBy<T>` is `NestedKeys<T>`, so
@@ -501,29 +512,38 @@ export class SolanaARIOReadable {
   protected readonly arnsProgram: Address;
   protected readonly antProgram: Address;
 
+  // NOTE: every cache below stores the in-flight PROMISE rather than the
+  // resolved value (see `./single-flight.ts`). Storing the value only ever
+  // helped sequential callers — a burst of concurrent callers all miss before
+  // any of them fills the cache, so all of them hit the network, which is the
+  // exact case these caches exist to collapse.
+
   // Memoized ARIO mint address (read once from ArioConfig.mint and reused
-  // for every SPL-ATA derivation in getBalance/getBalances).
-  private _arioMint?: Address;
+  // for every SPL-ATA derivation in getBalance/getBalances). Never expires:
+  // the mint is fixed once the protocol is deployed.
+  private _arioMintCache: InFlightStore<'mint', Address> = new Map();
 
   // Short-TTL cache for slow-changing config-ish accounts (DemandFactor,
   // ArnsConfig, etc.). Collapses the many identical reads a UI fires in a
   // burst — e.g. the returned-names page running `getCostDetails` per row,
   // each re-reading the same DemandFactor PDA — into a single network call.
-  private _accountCache = new Map<
+  private _accountCache: InFlightStore<
     string,
-    {
-      account: Awaited<ReturnType<SolanaARIOReadable['getAccount']>>;
-      expiresAt: number;
-    }
-  >();
+    Awaited<ReturnType<SolanaARIOReadable['getAccount']>>
+  > = new Map();
 
   // Short-TTL memo of the estimated compute-unit price (priority fee), so
   // burst `getCostDetails` calls share one getRecentPrioritizationFees query.
-  private _priorityFeeCache?: { microLamports: bigint; expiresAt: number };
+  private _priorityFeeCache: InFlightStore<'fee', bigint> = new Map();
 
   // Memo of getMinimumBalanceForRentExemption results keyed by byte size.
   // Rent parameters are cluster constants in practice, so no TTL.
-  private _rentCache = new Map<number, number>();
+  private _rentCache: InFlightStore<number, number> = new Map();
+
+  // Short-TTL memo of the cluster clock (getSlot + getBlockTime). Kept brief:
+  // the in-flight coalescing is what collapses a price table's burst, while a
+  // 1s ceiling keeps a per-second auction UI honest.
+  private _clusterClockCache: InFlightStore<'clock', number> = new Map();
 
   constructor(
     config: SolanaReadConfig & {
@@ -541,6 +561,25 @@ export class SolanaARIOReadable {
     this.garProgram = config.garProgramId ?? ARIO_GAR_PROGRAM_ID;
     this.arnsProgram = config.arnsProgramId ?? ARIO_ARNS_PROGRAM_ID;
     this.antProgram = config.antProgramId ?? ARIO_ANT_PROGRAM_ID;
+  }
+
+  /**
+   * Quote-grade compute-unit price, memoized for
+   * {@link PRIORITY_FEE_CACHE_TTL_MS}.
+   *
+   * "Quote-grade" means it covers what a browser wallet will attach, not just
+   * the near-floor base rate a keypair send pays. Each miss costs THREE
+   * `getRecentPrioritizationFees` queries (one unscoped plus two scoped market
+   * references) at ~6.6 KiB apiece, which is why coalescing matters here more
+   * than anywhere else: ten concurrent quotes used to issue thirty of them.
+   */
+  private async getQuotePriorityFee(): Promise<bigint> {
+    return memoizeInFlight(
+      this._priorityFeeCache,
+      'fee',
+      PRIORITY_FEE_CACHE_TTL_MS,
+      () => estimateQuotePriorityFeeMicroLamports(this.rpc),
+    );
   }
 
   /** Helper to fetch an encoded account (kit's replacement for Connection.getAccountInfo). */
@@ -562,15 +601,15 @@ export class SolanaARIOReadable {
     pda: Address,
     ttlMs = CONFIG_CACHE_TTL_MS,
   ): Promise<Awaited<ReturnType<SolanaARIOReadable['getAccount']>>> {
-    const key = String(pda);
-    const now = Date.now();
-    const hit = this._accountCache.get(key);
-    if (hit && hit.expiresAt > now) return hit.account;
-    const account = await this.getAccount(pda);
-    if (account.exists) {
-      this._accountCache.set(key, { account, expiresAt: now + ttlMs });
-    }
-    return account;
+    return memoizeInFlight(
+      this._accountCache,
+      String(pda),
+      ttlMs,
+      () => this.getAccount(pda),
+      // Misses stay uncached, exactly as before — but a concurrent burst of
+      // callers still shares the single lookup that discovers the miss.
+      (account) => account.exists,
+    );
   }
 
   /**
@@ -588,18 +627,34 @@ export class SolanaARIOReadable {
    * Sourced via the latest slot's block time (`getSlot` → `getBlockTime`),
    * which the runtime derives from the same stake-weighted clock the on-chain
    * `Clock` sysvar exposes. Read-only: no signer, no transaction.
+   *
+   * Memoized for {@link CLUSTER_CLOCK_CACHE_TTL_MS}: this costs TWO sequential
+   * round trips (the block time needs the slot), and `getTokenCost` calls it on
+   * every quote — so a price table paid 2N calls for a value that advances in
+   * real time anyway. Staleness here is directionally safe: an older clock
+   * means less elapsed auction time, which OVER-quotes the returned-name
+   * premium rather than under-quoting it.
    */
   private async getClusterUnixTimestampSeconds(): Promise<number> {
-    const slot = await withRetry(() =>
-      this.rpc.getSlot({ commitment: this.commitment }).send(),
+    return memoizeInFlight(
+      this._clusterClockCache,
+      'clock',
+      CLUSTER_CLOCK_CACHE_TTL_MS,
+      async () => {
+        const slot = await withRetry(() =>
+          this.rpc.getSlot({ commitment: this.commitment }).send(),
+        );
+        const blockTime = await withRetry(() =>
+          this.rpc.getBlockTime(slot).send(),
+        );
+        if (blockTime == null) {
+          throw new Error(
+            `Cluster block time unavailable for slot ${slot}; cannot match on-chain Clock::get().unix_timestamp`,
+          );
+        }
+        return Number(blockTime);
+      },
     );
-    const blockTime = await withRetry(() => this.rpc.getBlockTime(slot).send());
-    if (blockTime == null) {
-      throw new Error(
-        `Cluster block time unavailable for slot ${slot}; cannot match on-chain Clock::get().unix_timestamp`,
-      );
-    }
-    return Number(blockTime);
   }
 
   /**
@@ -918,17 +973,22 @@ export class SolanaARIOReadable {
    * protocol is deployed.
    */
   protected async getArioMint(): Promise<Address> {
-    if (this._arioMint) return this._arioMint;
-    const [configPda] = await getArioConfigPDA(this.coreProgram);
-    const account = await this.getAccount(configPda);
-    if (!account.exists) {
-      throw new Error(
-        `ArioConfig not found at ${configPda} on coreProgram ${this.coreProgram} — is the program deployed and initialized?`,
-      );
-    }
-    const { mint } = deserializeArioConfig(Buffer.from(account.data));
-    this._arioMint = mint;
-    return mint;
+    return memoizeInFlight(
+      this._arioMintCache,
+      'mint',
+      Number.POSITIVE_INFINITY,
+      async () => {
+        const [configPda] = await getArioConfigPDA(this.coreProgram);
+        const account = await this.getAccount(configPda);
+        if (!account.exists) {
+          throw new Error(
+            `ArioConfig not found at ${configPda} on coreProgram ${this.coreProgram} — is the program deployed and initialized?`,
+          );
+        }
+        const { mint } = deserializeArioConfig(Buffer.from(account.data));
+        return mint;
+      },
+    );
   }
 
   /**
@@ -2053,15 +2113,7 @@ export class SolanaARIOReadable {
       computeUnitLimit?: number;
     } = {},
   ): Promise<GasEstimate> {
-    const now = Date.now();
-    if (!this._priorityFeeCache || this._priorityFeeCache.expiresAt <= now) {
-      this._priorityFeeCache = {
-        // Quote-grade rate: covers what a browser wallet will attach, not
-        // just the (near-floor) base estimate keypair sends pay.
-        microLamports: await estimateQuotePriorityFeeMicroLamports(this.rpc),
-        expiresAt: now + PRIORITY_FEE_CACHE_TTL_MS,
-      };
-    }
+    const priorityFeeMicroLamports = await this.getQuotePriorityFee();
 
     // Conditional accounts: only created when the buyer doesn't already
     // have them. Unknown buyer → assume they're needed (over-quote rather
@@ -2106,18 +2158,19 @@ export class SolanaARIOReadable {
     });
 
     const rentKey = profile.accountBytes.reduce((sum, b) => sum + b, 0);
-    let rentLamports = this._rentCache.get(rentKey);
-    if (rentLamports === undefined) {
-      rentLamports = await estimateRentLamports(this.rpc, profile.accountBytes);
-      this._rentCache.set(rentKey, rentLamports);
-    }
+    const rentLamports = await memoizeInFlight(
+      this._rentCache,
+      rentKey,
+      Number.POSITIVE_INFINITY,
+      () => estimateRentLamports(this.rpc, profile.accountBytes),
+    );
 
     return estimateGasFee(this.rpc, {
       computeUnitLimit: opts.computeUnitLimit,
       signatureCount: profile.signatureCount,
       transactionCount: profile.transactionCount,
       rentLamports,
-      priorityFeeMicroLamports: this._priorityFeeCache.microLamports,
+      priorityFeeMicroLamports,
     });
   }
 
@@ -2156,13 +2209,7 @@ export class SolanaARIOReadable {
     /** decrease-delegate-stake with instant payout (second transaction). */
     instant?: boolean;
   }): Promise<GasEstimate> {
-    const now = Date.now();
-    if (!this._priorityFeeCache || this._priorityFeeCache.expiresAt <= now) {
-      this._priorityFeeCache = {
-        microLamports: await estimateQuotePriorityFeeMicroLamports(this.rpc),
-        expiresAt: now + PRIORITY_FEE_CACHE_TTL_MS,
-      };
-    }
+    const priorityFeeMicroLamports = await this.getQuotePriorityFee();
 
     // Conditional accounts — checked live when the actor is known,
     // conservative (assume creation) otherwise. All best-effort.
@@ -2256,15 +2303,12 @@ export class SolanaARIOReadable {
       profile.accountBytes.reduce((sum, b) => sum + b, 0) +
       reallocBytes +
       profile.accountBytes.length;
-    let rentLamports = this._rentCache.get(rentKey);
-    if (rentLamports === undefined) {
-      rentLamports = await estimateRentLamports(
-        this.rpc,
-        profile.accountBytes,
-        reallocBytes,
-      );
-      this._rentCache.set(rentKey, rentLamports);
-    }
+    const rentLamports = await memoizeInFlight(
+      this._rentCache,
+      rentKey,
+      Number.POSITIVE_INFINITY,
+      () => estimateRentLamports(this.rpc, profile.accountBytes, reallocBytes),
+    );
 
     // Instant decrease: the second transaction immediately closes the
     // vault created by the first — its deposit round-trips back.
@@ -2282,7 +2326,7 @@ export class SolanaARIOReadable {
       transactionCount: profile.transactionCount,
       rentLamports,
       rentReclaimedLamports,
-      priorityFeeMicroLamports: this._priorityFeeCache.microLamports,
+      priorityFeeMicroLamports,
     });
   }
 

--- a/src/solana/single-flight.test.ts
+++ b/src/solana/single-flight.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { describe, it, mock } from 'node:test';
+import { describe, it } from 'node:test';
 
 import { type InFlightStore, memoizeInFlight } from './single-flight.js';
 
@@ -105,39 +105,37 @@ describe('memoizeInFlight', () => {
   });
 
   it('a late settlement never evicts a newer entry for the same key', async () => {
-    mock.timers.enable({ apis: ['Date'] });
-    try {
-      const store: InFlightStore<string, string> = new Map();
-      const slow = deferred<string>();
-      let calls = 0;
+    // Real timers rather than `mock.timers`: that API needs Node >= 20.4 and
+    // this package supports Node >= 18. A short TTL plus a real sleep gets the
+    // same interleaving without the version floor.
+    const store: InFlightStore<string, string> = new Map();
+    const slow = deferred<string>();
+    let calls = 0;
 
-      const first = memoizeInFlight(store, 'k', 1_000, () => {
-        calls++;
-        return slow.promise;
-      });
-      const firstSettled = first.catch(() => 'failed');
+    const first = memoizeInFlight(store, 'k', 10, () => {
+      calls++;
+      return slow.promise;
+    });
+    const firstSettled = first.catch(() => 'failed');
 
-      // TTL lapses while the first request is still in flight.
-      mock.timers.tick(2_000);
-      const second = await memoizeInFlight(store, 'k', 1_000, async () => {
-        calls++;
-        return 'fresh';
-      });
-      assert.equal(second, 'fresh');
-      assert.equal(calls, 2);
+    // Let the TTL lapse while the first request is still in flight.
+    await sleep(30);
+    const second = await memoizeInFlight(store, 'k', 60_000, async () => {
+      calls++;
+      return 'fresh';
+    });
+    assert.equal(second, 'fresh');
+    assert.equal(calls, 2);
 
-      // The stale request now fails. Its eviction must not drop 'fresh'.
-      slow.reject(new Error('stale'));
-      await firstSettled;
+    // The stale request now fails. Its eviction must not drop 'fresh'.
+    slow.reject(new Error('stale'));
+    await firstSettled;
 
-      const third = await memoizeInFlight(store, 'k', 1_000, async () => {
-        calls++;
-        return 'should not happen';
-      });
-      assert.equal(third, 'fresh', 'newer entry survived the stale eviction');
-      assert.equal(calls, 2);
-    } finally {
-      mock.timers.reset();
-    }
+    const third = await memoizeInFlight(store, 'k', 60_000, async () => {
+      calls++;
+      return 'should not happen';
+    });
+    assert.equal(third, 'fresh', 'newer entry survived the stale eviction');
+    assert.equal(calls, 2);
   });
 });

--- a/src/solana/single-flight.test.ts
+++ b/src/solana/single-flight.test.ts
@@ -104,38 +104,80 @@ describe('memoizeInFlight', () => {
     assert.equal(calls, 2);
   });
 
-  it('a late settlement never evicts a newer entry for the same key', async () => {
-    // Real timers rather than `mock.timers`: that API needs Node >= 20.4 and
-    // this package supports Node >= 18. A short TTL plus a real sleep gets the
-    // same interleaving without the version floor.
-    const store: InFlightStore<string, string> = new Map();
-    const slow = deferred<string>();
+  it('does not start a duplicate request while one is still in flight, even past the TTL', async () => {
+    // Reported by CodeRabbit on #712. The TTL used to be measured from when
+    // the request STARTED, so a request slower than its own TTL was treated as
+    // expired while still in flight and later callers began a second one —
+    // reopening the exact stampede this helper exists to close.
+    //
+    // Not theoretical: CLUSTER_CLOCK_CACHE_TTL_MS is 1s and the cluster-clock
+    // read is two SEQUENTIAL RPCs, each wrapped in withRetry (3 attempts, 1s
+    // base backoff). One retry is enough to exceed the TTL.
+    const store: InFlightStore<string, number> = new Map();
     let calls = 0;
-
-    const first = memoizeInFlight(store, 'k', 10, () => {
+    const slow = deferred<number>();
+    const produce = () => {
       calls++;
       return slow.promise;
-    });
-    const firstSettled = first.catch(() => 'failed');
+    };
 
-    // Let the TTL lapse while the first request is still in flight.
-    await sleep(30);
-    const second = await memoizeInFlight(store, 'k', 60_000, async () => {
+    const first = memoizeInFlight(store, 'k', 10, produce);
+    await sleep(40); // TTL has lapsed, but the request has NOT settled
+    const second = memoizeInFlight(store, 'k', 10, produce);
+
+    slow.resolve(5);
+    assert.equal(await first, 5);
+    assert.equal(await second, 5);
+    assert.equal(
+      calls,
+      1,
+      'a caller arriving during a slow request must join it, not start another',
+    );
+  });
+
+  it('starts the TTL when the request settles, not when it began', async () => {
+    const store: InFlightStore<string, number> = new Map();
+    let calls = 0;
+    const produce = async () => {
       calls++;
-      return 'fresh';
-    });
-    assert.equal(second, 'fresh');
-    assert.equal(calls, 2);
+      await sleep(40);
+      return calls;
+    };
 
-    // The stale request now fails. Its eviction must not drop 'fresh'.
+    // ttl 60ms against a 40ms request: measured from the start it would have
+    // only ~20ms of life left, measured from settlement it has the full 60ms.
+    assert.equal(await memoizeInFlight(store, 'k', 60, produce), 1);
+    await sleep(30);
+    assert.equal(
+      await memoizeInFlight(store, 'k', 60, produce),
+      1,
+      'the settled value should still be within its TTL',
+    );
+    assert.equal(calls, 1);
+  });
+
+  it('a late settlement never evicts a newer entry for the same key', async () => {
+    // Now that pending entries never expire, two promises can only coexist for
+    // a key if one is swapped in directly — so drive that explicitly rather
+    // than via a TTL race, to keep the identity guard covered.
+    const store: InFlightStore<string, string> = new Map();
+    const slow = deferred<string>();
+    const stale = memoizeInFlight(store, 'k', 60_000, () => slow.promise);
+    const staleSettled = stale.catch(() => 'failed');
+
+    // Replace the entry as though a newer request had taken over the key.
+    const fresh = Promise.resolve('fresh');
+    store.set('k', { promise: fresh, expiresAt: Date.now() + 60_000 });
+
     slow.reject(new Error('stale'));
-    await firstSettled;
+    await staleSettled;
 
-    const third = await memoizeInFlight(store, 'k', 60_000, async () => {
+    let calls = 0;
+    const after = await memoizeInFlight(store, 'k', 60_000, async () => {
       calls++;
       return 'should not happen';
     });
-    assert.equal(third, 'fresh', 'newer entry survived the stale eviction');
-    assert.equal(calls, 2);
+    assert.equal(after, 'fresh', 'newer entry survived the stale eviction');
+    assert.equal(calls, 0);
   });
 });

--- a/src/solana/single-flight.test.ts
+++ b/src/solana/single-flight.test.ts
@@ -1,0 +1,143 @@
+import { strict as assert } from 'node:assert';
+import { describe, it, mock } from 'node:test';
+
+import { type InFlightStore, memoizeInFlight } from './single-flight.js';
+
+/** A promise whose settlement the test controls explicitly. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('memoizeInFlight', () => {
+  it('collapses concurrent callers onto a single producer call', async () => {
+    const store: InFlightStore<string, number> = new Map();
+    let calls = 0;
+    const d = deferred<number>();
+    const produce = () => {
+      calls++;
+      return d.promise;
+    };
+
+    const all = Promise.all(
+      Array.from({ length: 10 }, () =>
+        memoizeInFlight(store, 'k', 60_000, produce),
+      ),
+    );
+    d.resolve(7);
+
+    assert.deepEqual(await all, Array(10).fill(7));
+    assert.equal(calls, 1, '10 concurrent callers should produce once');
+  });
+
+  it('reuses a settled value for the TTL, then re-produces once expired', async () => {
+    const store: InFlightStore<string, number> = new Map();
+    let calls = 0;
+    const produce = async () => ++calls;
+
+    assert.equal(await memoizeInFlight(store, 'k', 50, produce), 1);
+    assert.equal(await memoizeInFlight(store, 'k', 50, produce), 1, 'cached');
+
+    await sleep(70);
+    assert.equal(
+      await memoizeInFlight(store, 'k', 50, produce),
+      2,
+      'expired entry should be replaced',
+    );
+  });
+
+  it('does not cache rejections, and every concurrent caller sees the error', async () => {
+    const store: InFlightStore<string, number> = new Map();
+    let calls = 0;
+    const produce = async () => {
+      calls++;
+      throw new Error(`boom ${calls}`);
+    };
+
+    const settled = await Promise.allSettled(
+      Array.from({ length: 5 }, () =>
+        memoizeInFlight(store, 'k', 60_000, produce),
+      ),
+    );
+    assert.equal(calls, 1, 'the failing fetch is still shared');
+    for (const s of settled) {
+      assert.equal(s.status, 'rejected');
+      assert.match((s as PromiseRejectedResult).reason.message, /boom 1/);
+    }
+    assert.equal(store.size, 0, 'a rejection must be evicted, not cached');
+
+    // A transient failure must not poison the key for the rest of the TTL.
+    await assert.rejects(() => memoizeInFlight(store, 'k', 60_000, produce), {
+      message: 'boom 2',
+    });
+    assert.equal(calls, 2, 'next caller retries after a failure');
+  });
+
+  it('shares an in-flight value that keep() rejects, but does not retain it', async () => {
+    const store: InFlightStore<string, { exists: boolean }> = new Map();
+    let calls = 0;
+    const produce = async () => {
+      calls++;
+      return { exists: false };
+    };
+    const keep = (v: { exists: boolean }) => v.exists;
+
+    // This is the "misses are not cached" rule from getCachedAccount: the
+    // concurrent burst still costs ONE fetch...
+    await Promise.all(
+      Array.from({ length: 4 }, () =>
+        memoizeInFlight(store, 'k', 60_000, produce, keep),
+      ),
+    );
+    assert.equal(calls, 1);
+    assert.equal(store.size, 0, 'a non-kept value is evicted once settled');
+
+    // ...but a later caller re-checks rather than trusting a stale miss.
+    await memoizeInFlight(store, 'k', 60_000, produce, keep);
+    assert.equal(calls, 2);
+  });
+
+  it('a late settlement never evicts a newer entry for the same key', async () => {
+    mock.timers.enable({ apis: ['Date'] });
+    try {
+      const store: InFlightStore<string, string> = new Map();
+      const slow = deferred<string>();
+      let calls = 0;
+
+      const first = memoizeInFlight(store, 'k', 1_000, () => {
+        calls++;
+        return slow.promise;
+      });
+      const firstSettled = first.catch(() => 'failed');
+
+      // TTL lapses while the first request is still in flight.
+      mock.timers.tick(2_000);
+      const second = await memoizeInFlight(store, 'k', 1_000, async () => {
+        calls++;
+        return 'fresh';
+      });
+      assert.equal(second, 'fresh');
+      assert.equal(calls, 2);
+
+      // The stale request now fails. Its eviction must not drop 'fresh'.
+      slow.reject(new Error('stale'));
+      await firstSettled;
+
+      const third = await memoizeInFlight(store, 'k', 1_000, async () => {
+        calls++;
+        return 'should not happen';
+      });
+      assert.equal(third, 'fresh', 'newer entry survived the stale eviction');
+      assert.equal(calls, 2);
+    } finally {
+      mock.timers.reset();
+    }
+  });
+});

--- a/src/solana/single-flight.ts
+++ b/src/solana/single-flight.ts
@@ -34,6 +34,7 @@
 /** A cached in-flight or already-settled request. */
 type InFlightEntry<V> = {
   promise: Promise<V>;
+  /** Infinity while the request is in flight; a real deadline once settled. */
   expiresAt: number;
 };
 
@@ -62,12 +63,20 @@ export function memoizeInFlight<K, V>(
   produce: () => Promise<V>,
   keep: (value: V) => boolean = () => true,
 ): Promise<V> {
-  const now = Date.now();
   const hit = store.get(key);
-  if (hit !== undefined && hit.expiresAt > now) return hit.promise;
+  if (hit !== undefined && hit.expiresAt > Date.now()) return hit.promise;
 
+  // A PENDING entry never expires — its `expiresAt` stays at Infinity until it
+  // settles, and the TTL is measured from settlement below.
+  //
+  // Measuring the TTL from when the request STARTED meant a request slower
+  // than its own TTL looked expired while still in flight, so later callers
+  // began a second one — reopening the very stampede this helper closes. That
+  // is reachable in practice: CLUSTER_CLOCK_CACHE_TTL_MS is 1s and the
+  // cluster-clock read is two sequential RPCs, each wrapped in withRetry with
+  // a 1s base backoff, so a single retry exceeds it.
   const promise = produce();
-  store.set(key, { promise, expiresAt: now + ttlMs });
+  store.set(key, { promise, expiresAt: Number.POSITIVE_INFINITY });
 
   // Only ever evict OUR entry: by the time this settles the key may already
   // hold a newer promise (TTL expired, another caller started a fresh fetch),
@@ -81,7 +90,13 @@ export function memoizeInFlight<K, V>(
   // reporting an unhandled rejection for the cached promise; callers await the
   // ORIGINAL promise, so they still observe the error.
   void promise.then((value) => {
-    if (!keep(value)) evictSelf();
+    if (!keep(value)) {
+      evictSelf();
+      return;
+    }
+    // Settled and worth keeping: start the TTL now.
+    const entry = store.get(key);
+    if (entry?.promise === promise) entry.expiresAt = Date.now() + ttlMs;
   }, evictSelf);
 
   return promise;

--- a/src/solana/single-flight.ts
+++ b/src/solana/single-flight.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Single-flight (a.k.a. request-coalescing) memoization for RPC reads.
+ *
+ * The SDK's short-TTL caches used to store the RESOLVED value, which meant
+ * they only ever helped SEQUENTIAL callers: N concurrent callers all miss the
+ * cache before any of them fills it, so all N hit the network. That is exactly
+ * backwards — the burst is the case worth collapsing. Measured against devnet,
+ * ten concurrent `getGasEstimate()` calls issued 43 requests / 200 KiB where
+ * ten sequential calls issued 14 / 21 KiB, and the burst tripped a 429.
+ *
+ * Storing the PROMISE instead of the value fixes that: the first caller starts
+ * the work, everyone else awaits the same promise, and the resolved value is
+ * still reused for `ttlMs` afterwards.
+ *
+ * Internal helper — deliberately not re-exported from `./index.ts`, so it adds
+ * nothing to the package's public surface.
+ */
+
+/** A cached in-flight or already-settled request. */
+type InFlightEntry<V> = {
+  promise: Promise<V>;
+  expiresAt: number;
+};
+
+/** Backing store for {@link memoizeInFlight}. Callers own the Map instance. */
+export type InFlightStore<K, V> = Map<K, InFlightEntry<V>>;
+
+/**
+ * Return the cached promise for `key`, or start one with `produce()`.
+ *
+ * @param store - caller-owned Map holding the cached promises.
+ * @param key - cache key.
+ * @param ttlMs - how long a SETTLED value stays reusable. Use
+ *   `Number.POSITIVE_INFINITY` for values that never change (e.g. a mint
+ *   address). The in-flight window is always shared regardless of `ttlMs`.
+ * @param produce - starts the underlying work. Called at most once per
+ *   (key, TTL window).
+ * @param keep - decides, after resolution, whether the value is worth
+ *   retaining. Returning `false` evicts it once settled, so later callers
+ *   re-fetch — while concurrent callers still shared the single request. This
+ *   is how "misses are not cached" survives coalescing.
+ */
+export function memoizeInFlight<K, V>(
+  store: InFlightStore<K, V>,
+  key: K,
+  ttlMs: number,
+  produce: () => Promise<V>,
+  keep: (value: V) => boolean = () => true,
+): Promise<V> {
+  const now = Date.now();
+  const hit = store.get(key);
+  if (hit !== undefined && hit.expiresAt > now) return hit.promise;
+
+  const promise = produce();
+  store.set(key, { promise, expiresAt: now + ttlMs });
+
+  // Only ever evict OUR entry: by the time this settles the key may already
+  // hold a newer promise (TTL expired, another caller started a fresh fetch),
+  // and dropping that one would silently defeat the cache.
+  const evictSelf = () => {
+    if (store.get(key)?.promise === promise) store.delete(key);
+  };
+
+  // A rejection must not be cached — otherwise one transient 429 poisons the
+  // key for the whole TTL. Attaching the handler here also keeps Node from
+  // reporting an unhandled rejection for the cached promise; callers await the
+  // ORIGINAL promise, so they still observe the error.
+  void promise.then((value) => {
+    if (!keep(value)) evictSelf();
+  }, evictSelf);
+
+  return promise;
+}


### PR DESCRIPTION
## What

Four RPC-efficiency fixes in the Solana read path, found by tracing every RPC call site and measuring against devnet. Each is a separate commit.

| Commit | Fix |
|---|---|
| `f05d72f6` | Coalesce concurrent reads behind in-flight caches (+ cluster-clock memo) |
| `031f101c` | Batch gateway metadata in discovery; drop a dead account read |
| `f8959664` | Fetch account chunks in a bounded pool instead of serially |
| `5ebf33c9` | Test portability: drop `mock.timers` (needs Node 20.4; we support 18) |

### 1. Caches stored values, not in-flight promises

The short-TTL caches in `SolanaARIOReadable` only ever helped *sequential* callers. A concurrent burst all miss before any of them fills the cache — and the burst is exactly what the caches exist for (a price table quoting every row at once).

Measured on devnet, ten concurrent `getGasEstimate()`:

| | RPC calls | bytes | fee queries |
|---|---|---|---|
| sequential | 14 | 21 KiB | 3 |
| concurrent (before) | 43 | 200 KiB | 30 |

The burst also tripped an HTTP 429. Nearly all of it was `getRecentPrioritizationFees` at ~6.6 KiB a call.

Two correctness details in the new helper: rejections are evicted rather than cached, so one transient 429 can't poison a key for its whole TTL; and eviction is identity-guarded, so a late-settling stale request can't delete a newer entry for the same key. A `keep()` predicate preserves `getCachedAccount`'s "misses are not cached" rule while still letting a burst share the single lookup that finds the miss.

Also memoizes `getClusterUnixTimestampSeconds` (two *sequential* round trips, called on every `getTokenCost`). TTL is deliberately 1s so a per-second Dutch-auction UI stays accurate; staleness is directionally safe (an older clock over-quotes the premium rather than under-quoting).

### 2. Dead and serialized reads in funding discovery

`fetchGatewayMeta` ran one `getAccountInfo` per delegation, serially — 120 delegations meant 120 sequential round trips. Only the account's *existence* is consulted, but that bit selects between two `minDelegationAmount` values and so changes the drawdown sort, so it can't just be deleted; it is now one batched `getMultipleAccounts` per 100.

`fetchOperatorStake` fetched an account and then returned `null` on every code path. Removing it changes no output — operator stake never appeared in the discovered set, so `fundAsOperator` has always required explicit `sources`. Real operator-stake discovery is a behavior change and is left for its own PR.

### 3. Chunks fetched one at a time

Four bulk readers batched at 100 accounts but awaited each chunk before starting the next. Devnet's 648 gateways: ~210ms serialized vs ~110ms pooled; mainnet's registry widens the gap.

Capped at 4 concurrent, not unbounded — an unbounded `Promise.all` turns one bulk read into a burst as wide as the registry, which is how you earn a 429. `getGateways` also gained the `withRetry` its sibling paths already had, since raising concurrency without it would turn a transient 429 into a hard failure.

## Why this can't regress consumers

Every touched field is `private`, or `protected` with an unchanged signature. Nothing new is exported from `src/solana/index.ts`.

- **Public type surface unchanged.** Built `lib/types` before and after and diffed. Every delta is a private member or a doc comment. The one new file (`concurrency.d.ts`) is neither re-exported from the barrel nor reachable through the `exports` map.
- **Behavioral equivalence, deterministically.** Recorded a devnet RPC transcript, then replayed the same 27 read scenarios against it before and after. **0 output diffs, 27.5% fewer RPC calls.** Replay makes the comparison immune to chain state and fee-market drift. Includes the multi-chunk `getGateways({limit:250})` and 150-mint ANT reads where ordering is load-bearing.
- **CLI unchanged.** Built the pre-change commit in a separate worktree and ran 11 read commands against devnet on both. Output byte-identical.

## Tests

+13 tests (485 → 498, 0 failures). The one skip is pre-existing.

The `getANTSummaries`/`getANTStates` readers index results positionally (`accounts[i * 3]`), so flattening in completion order would silently attribute one ANT's config to another mint. The ordering test drives chunks that finish in **reverse** order, and was mutation-checked: reversing the flattening makes it fail.

`discoverFundingSources` had no coverage at all, so its tests were written against the *original* implementation first — the shape test passed before the refactor and still does; the batching test failed against the original with 122 `getAccountInfo` calls for 120 delegations and now sees 1.

## Notes for the reviewer

- **Pre-existing, not addressed here:** `getGasEstimate` and `getGarGasEstimate` share `_rentCache` but compute `rentKey` differently (`sum(bytes)` vs `sum + realloc + count`), so the two schemes can collide. Behavior is unchanged by this PR; worth a follow-up.
- A separate PR will follow for the `rpc-circuit-breaker.ts` bugs reported by the network-portal team (fallback traffic bypassing the throttle; an advertised rps-limit disabling backoff). Both reproduced locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved bulk Solana account reads with bounded concurrent fetching while preserving result order.
  - Reduced duplicate RPC requests by sharing in-flight reads and briefly caching cluster-time data.
  - Batched gateway metadata requests during funding-source discovery.

- **Behavior Changes**
  - Operator stake is no longer discovered automatically; it remains available through explicit sources.
  - Preserved retry handling and missing-account behavior.

- **Bug Fixes**
  - Prevented incorrectly matched account data when requests complete out of order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->