### PR TITLE
fix(solana): make the RPC throttle back off when it actually matters

### DIFF
--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -796,6 +796,22 @@ export class SolanaARIOReadable {
   // Protocol info
   // =========================================
 
+  /**
+   * Protocol info: on-chain supply/balance figures plus static protocol
+   * metadata.
+   *
+   * COSTS TWO ACCOUNT READS (ArioConfig + EpochSettings), which is worth
+   * knowing because only some of the result comes from chain:
+   *
+   * - From chain: `totalSupply`, `protocolBalance`, `epochSettings`.
+   * - Fixed literals: `Ticker` (`'ARIO'`), `Name` (`'AR.IO'`),
+   *   `Denomination` (`6`), `Handlers` (`[]`), `LastCreatedEpochIndex` (`0`).
+   *
+   * If all you need are the literals — a ticker or denomination for display —
+   * don't call this; hard-code them or read {@link TOKEN_DECIMALS}. Two RPC
+   * round trips for a string constant is a poor trade, and callers have
+   * reached for this method not realising that is what they were paying.
+   */
   async getInfo() {
     const [[configPda], [epochSettingsPda]] = await Promise.all([
       getArioConfigPDA(this.coreProgram),

--- a/src/solana/rpc-circuit-breaker.test.ts
+++ b/src/solana/rpc-circuit-breaker.test.ts
@@ -254,6 +254,130 @@ describe('createCircuitBreakerRpc', () => {
   });
 });
 
+describe('createCircuitBreakerRpc — adaptive throttle', () => {
+  const servers: Array<{ close: () => Promise<void> }> = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.map((s) => s.close()));
+    servers.length = 0;
+  });
+
+  /** A port with nothing listening, so the primary transport always fails. */
+  async function deadUrl(): Promise<string> {
+    const s = await createStatusMockServer(() => ({ statusCode: 200 }));
+    await s.close();
+    return s.url;
+  }
+
+  /** Drive `concurrency` callers for `ms`, swallowing the expected errors. */
+  async function drive(
+    rpc: ReturnType<typeof createCircuitBreakerRpc>,
+    ms: number,
+    concurrency: number,
+  ) {
+    const stop = Date.now() + ms;
+    await Promise.all(
+      Array.from({ length: concurrency }, async () => {
+        while (Date.now() < stop) {
+          try {
+            await rpc
+              .getSlot()
+              .send({ abortSignal: AbortSignal.timeout(5_000) });
+          } catch {
+            /* 429s and dead-primary errors are the point of these tests */
+          }
+        }
+      }),
+    );
+  }
+
+  it('throttles when the FALLBACK 429s and the circuit is open', async () => {
+    // The existing 429 test pins volumeThreshold high to keep the circuit
+    // CLOSED. That path works: opossum emits `failure`, which feeds the
+    // backoff. When the circuit is OPEN it emits `reject` and calls the
+    // fallback directly — no `failure` — so fallback 429s were invisible to
+    // the throttle and it stayed pinned at the ceiling for as long as the
+    // primary was down.
+    let fallbackHits = 0;
+    const fallback = await createStatusMockServer(() => {
+      fallbackHits++;
+      return { statusCode: 429, headers: { 'retry-after': '1' } };
+    });
+    servers.push(fallback);
+
+    const rpc = createCircuitBreakerRpc({
+      primaryUrl: await deadUrl(),
+      fallbackUrl: fallback.url,
+      circuitBreakerOptions: {
+        volumeThreshold: 1,
+        errorThresholdPercentage: 1,
+        timeout: false,
+        maxRequestsPerSecond: 20,
+        resetTimeout: 60_000,
+      },
+    });
+
+    await drive(rpc, 2_500, 4);
+
+    // At 20 r/s with no backoff this is ~50 requests. Backing off on the
+    // fallback's 429s should keep it far below that.
+    assert.ok(
+      fallbackHits < 20,
+      `fallback took ${fallbackHits} requests in 2.5s — the throttle never ` +
+        'saw its 429s (ceiling 20 r/s would allow ~50)',
+    );
+  });
+
+  it('treats an advertised rps-limit as a ceiling, never as permission to keep going', async () => {
+    // A 429 always means slow down. When the provider advertises a limit far
+    // above our ceiling (api.mainnet-beta.solana.com sends 250 against a
+    // default ceiling of 10) the header path resolved to the ceiling itself,
+    // so the rate never moved.
+    //
+    // `retry-after: 0` is deliberate: the per-429 cooldown otherwise dominates
+    // throughput and masks the rate entirely — measured, an absolute-count
+    // assertion could not tell the two cases apart. Removing the cooldown
+    // leaves throughput governed purely by the adaptive rate, which is what
+    // this bug is about. Compared against the known-good headerless case
+    // rather than an absolute number, so the assertion does not depend on
+    // machine speed.
+    async function hitsOver(headers: Record<string, string>): Promise<number> {
+      let hits = 0;
+      const primary = await createStatusMockServer(() => {
+        hits++;
+        return { statusCode: 429, headers: { 'retry-after': '0', ...headers } };
+      });
+      const fallback = await createStatusMockServer(() => ({
+        statusCode: 429,
+        headers: { 'retry-after': '0' },
+      }));
+      servers.push(primary, fallback);
+      const rpc = createCircuitBreakerRpc({
+        primaryUrl: primary.url,
+        fallbackUrl: fallback.url,
+        circuitBreakerOptions: {
+          volumeThreshold: 100, // keep the circuit closed so the primary keeps 429ing
+          timeout: false,
+          maxRequestsPerSecond: 20,
+          resetTimeout: 60_000,
+        },
+      });
+      await drive(rpc, 3_000, 4);
+      return hits;
+    }
+
+    const headerless = await hitsOver({});
+    const advertised = await hitsOver({ 'x-ratelimit-rps-limit': '250' });
+
+    assert.ok(
+      advertised <= headerless * 2,
+      `429s advertising rps-limit 250 served ${advertised} requests versus ` +
+        `${headerless} for identical headerless 429s — the advertised limit ` +
+        'is holding the rate at the ceiling instead of lowering it',
+    );
+  });
+});
+
 describe('defaultFallbackUrl', () => {
   it('returns devnet URL for devnet primary', () => {
     assert.equal(

--- a/src/solana/rpc-circuit-breaker.test.ts
+++ b/src/solana/rpc-circuit-breaker.test.ts
@@ -378,6 +378,71 @@ describe('createCircuitBreakerRpc — adaptive throttle', () => {
   });
 });
 
+describe('createCircuitBreakerRpc — optional fallback', () => {
+  const servers: Array<{ close: () => Promise<void> }> = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.map((s) => s.close()));
+    servers.length = 0;
+  });
+
+  it('works with no fallbackUrl at all', async () => {
+    const primary = await createStatusMockServer(() => ({
+      statusCode: 200,
+      result: { value: 'primary' },
+    }));
+    servers.push(primary);
+
+    const rpc = createCircuitBreakerRpc({ primaryUrl: primary.url });
+    const r = await rpc
+      .getLatestBlockhash()
+      .send({ abortSignal: AbortSignal.timeout(10_000) });
+    assert.deepStrictEqual(r, { value: 'primary' });
+  });
+
+  it('fails fast instead of routing anywhere when the circuit opens', async () => {
+    // The point of making fallbackUrl optional: a consumer with one endpoint
+    // should be able to decline a fallback rather than be pushed onto public
+    // infrastructure whenever their primary degrades.
+    let primaryHits = 0;
+    const primary = await createStatusMockServer(() => {
+      primaryHits++;
+      return { statusCode: 500 };
+    });
+    servers.push(primary);
+
+    const rpc = createCircuitBreakerRpc({
+      primaryUrl: primary.url,
+      circuitBreakerOptions: {
+        volumeThreshold: 1,
+        errorThresholdPercentage: 1,
+        timeout: false,
+        maxRequestsPerSecond: 50,
+        resetTimeout: 60_000,
+      },
+    });
+
+    // Trip the circuit.
+    for (let i = 0; i < 3; i++) {
+      await assert.rejects(() =>
+        rpc.getSlot().send({ abortSignal: AbortSignal.timeout(5_000) }),
+      );
+    }
+    const hitsWhenOpen = primaryHits;
+
+    // Open circuit: the call must reject rather than resolve via some other
+    // endpoint, and must not keep hammering the primary either.
+    await assert.rejects(() =>
+      rpc.getSlot().send({ abortSignal: AbortSignal.timeout(5_000) }),
+    );
+    assert.equal(
+      primaryHits,
+      hitsWhenOpen,
+      'an open circuit should not forward to the primary',
+    );
+  });
+});
+
 describe('defaultFallbackUrl', () => {
   it('returns devnet URL for devnet primary', () => {
     assert.equal(

--- a/src/solana/rpc-circuit-breaker.ts
+++ b/src/solana/rpc-circuit-breaker.ts
@@ -296,14 +296,25 @@ export function createCircuitBreakerRpc({
     if (!headers) return; // only adapt to rate-limit (429) failures
     successStreak = 0;
 
+    // A 429 ALWAYS means slow down, so an advertised limit may only pull the
+    // rate further DOWN — it must never hold it up.
+    //
+    // This used to be `min(ceiling, advertised * SAFETY)`, which resolves to
+    // the ceiling itself whenever the provider advertises a limit above ours.
+    // api.mainnet-beta.solana.com sends `x-ratelimit-rps-limit: 250` against a
+    // default ceiling of 10, so the header path was a no-op there: the rate
+    // stayed pinned at the ceiling and only the cooldown applied. Measured
+    // with the cooldown removed, that served 68 requests where identical
+    // headerless 429s served 9.
     const advertised = parseRpsLimit(headers);
-    const next =
+    const fromHeader =
       advertised !== null
-        ? Math.min(
-            ceilingRate,
-            Math.max(MIN_RATE, advertised * RATE_SAFETY_FACTOR),
-          )
-        : Math.max(MIN_RATE, currentRate * AIMD_DECREASE);
+        ? advertised * RATE_SAFETY_FACTOR
+        : Number.POSITIVE_INFINITY;
+    const next = Math.max(
+      MIN_RATE,
+      Math.min(fromHeader, currentRate * AIMD_DECREASE),
+    );
     if (next !== currentRate) {
       currentRate = next;
       gate.setRate(currentRate);
@@ -339,7 +350,27 @@ export function createCircuitBreakerRpc({
     },
   );
 
-  breaker.fallback((request: TransportRequest) => fallbackTransport(request));
+  // The fallback's OWN failures have to feed the backoff too.
+  //
+  // opossum only emits `failure` on the closed-circuit path (`fail()` in
+  // lib/circuit.js). Once the circuit is OPEN it emits `reject` and calls this
+  // fallback directly, so nothing the fallback returns — 429s included — ever
+  // reached `onError`. The rate gate therefore stayed pinned at its ceiling
+  // for exactly as long as the primary was down, which is when backpressure
+  // matters most. Measured before this fix: a fallback returning nothing but
+  // 429s absorbed 58 requests in 2.5s at a ceiling of 20 r/s.
+  //
+  // Note both transports share one rate gate, so backing off on the fallback
+  // also slows primary retries. That is the conservative direction, but a
+  // per-transport gate would be a reasonable follow-up.
+  breaker.fallback(async (request: TransportRequest) => {
+    try {
+      return await fallbackTransport(request);
+    } catch (err) {
+      onError(err);
+      throw err;
+    }
+  });
 
   breaker.on('open', () => {
     logger.warn('[rpc-circuit-breaker] circuit OPEN — routing to fallback RPC');
@@ -358,6 +389,10 @@ export function createCircuitBreakerRpc({
   // fallback then masks it by resolving `fire()`, and `success` fires on a
   // healthy primary call. A plain try/catch around `fire()` would miss the
   // fallback-masked 429s entirely.
+  //
+  // This covers the CLOSED-circuit path only. Once the circuit opens, opossum
+  // stops emitting `failure` altogether — the fallback wrapper above is what
+  // keeps the backoff alive in that state.
   breaker.on('failure', (err: unknown) => onError(err));
   breaker.on('success', () => onSuccess());
 

--- a/src/solana/rpc-circuit-breaker.ts
+++ b/src/solana/rpc-circuit-breaker.ts
@@ -29,9 +29,16 @@
  * ```ts
  * import { ARIO, createCircuitBreakerRpc } from '@ar.io/sdk';
  *
+ * // With a second endpoint to fall back to:
  * const rpc = createCircuitBreakerRpc({
  *   primaryUrl: 'https://my-premium-rpc.example.com',
- *   fallbackUrl: 'https://api.mainnet-beta.solana.com',
+ *   fallbackUrl: 'https://my-other-rpc.example.com',
+ * });
+ *
+ * // With only one endpoint — the circuit still protects it, and open-circuit
+ * // calls fail fast rather than being routed onto someone else's RPC:
+ * const rpc = createCircuitBreakerRpc({
+ *   primaryUrl: 'https://my-premium-rpc.example.com',
  * });
  *
  * const ario = ARIO.init({ rpc });
@@ -112,8 +119,21 @@ export interface CircuitBreakerRpcOptions {
 export interface CircuitBreakerRpcConfig {
   /** URL for the primary (preferred) RPC endpoint. */
   primaryUrl: string;
-  /** URL for the fallback RPC endpoint (used when the circuit opens). */
-  fallbackUrl: string;
+  /**
+   * URL for the fallback RPC endpoint, used while the circuit is open.
+   *
+   * OPTIONAL. Omit it when you have no second endpoint: the circuit still
+   * protects the primary, and calls made while it is open reject immediately
+   * (fail fast) instead of being routed anywhere else.
+   *
+   * Requiring this used to be a forcing function — a consumer with a single
+   * paid endpoint had nowhere to point it but a public RPC, so a degraded
+   * primary quietly turned into traffic aimed at shared infrastructure. Pass a
+   * fallback only when you actually have one to spare; {@link
+   * defaultFallbackUrl} exists for that case but is deliberately not applied
+   * for you.
+   */
+  fallbackUrl?: string;
   /** Opossum circuit-breaker tuning knobs. */
   circuitBreakerOptions?: CircuitBreakerRpcOptions;
 }
@@ -275,7 +295,10 @@ export function createCircuitBreakerRpc({
   circuitBreakerOptions: opts = {},
 }: CircuitBreakerRpcConfig): SolanaRpc {
   const primaryTransport = createDefaultRpcTransport({ url: primaryUrl });
-  const fallbackTransport = createDefaultRpcTransport({ url: fallbackUrl });
+  const fallbackTransport =
+    fallbackUrl !== undefined
+      ? createDefaultRpcTransport({ url: fallbackUrl })
+      : undefined;
 
   type TransportRequest = Parameters<typeof primaryTransport>[0];
 
@@ -363,17 +386,25 @@ export function createCircuitBreakerRpc({
   // Note both transports share one rate gate, so backing off on the fallback
   // also slows primary retries. That is the conservative direction, but a
   // per-transport gate would be a reasonable follow-up.
-  breaker.fallback(async (request: TransportRequest) => {
-    try {
-      return await fallbackTransport(request);
-    } catch (err) {
-      onError(err);
-      throw err;
-    }
-  });
+  // With no fallback configured we register none at all, so opossum rejects
+  // open-circuit calls outright rather than routing them anywhere.
+  if (fallbackTransport !== undefined) {
+    breaker.fallback(async (request: TransportRequest) => {
+      try {
+        return await fallbackTransport(request);
+      } catch (err) {
+        onError(err);
+        throw err;
+      }
+    });
+  }
 
   breaker.on('open', () => {
-    logger.warn('[rpc-circuit-breaker] circuit OPEN — routing to fallback RPC');
+    logger.warn(
+      fallbackTransport !== undefined
+        ? '[rpc-circuit-breaker] circuit OPEN — routing to fallback RPC'
+        : '[rpc-circuit-breaker] circuit OPEN — failing fast (no fallback configured)',
+    );
   });
   breaker.on('halfOpen', () => {
     logger.info(


### PR DESCRIPTION
Fixes reported by the ar.io network-portal team, which has already shipped a local workaround (it no longer uses `createCircuitBreakerRpc`). I reproduced every claim before touching anything; two of the six turned out to be worth fixing here, and the rest are triaged at the bottom.

## 1. Fallback traffic bypassed the throttle entirely

opossum only emits `failure` on the **closed**-circuit path. Once the circuit is OPEN it emits `reject` and calls the fallback directly (`lib/circuit.js`, the `!this.closed && !this.pendingClose` branch), so nothing the fallback returned — 429s included — ever reached the backoff handler. The rate gate stayed pinned at its ceiling for exactly as long as the primary was down, which is when backpressure matters most.

Measured before the fix: a fallback serving nothing but 429s absorbed **58 requests in 2.5s** at a ceiling of 20 r/s. The fallback is now wrapped so its own failures feed the same backoff.

Both transports still share one rate gate, so backing off on the fallback also slows primary retries. That's the conservative direction; a per-transport gate would be a reasonable follow-up.

## 2. A provider-advertised rps limit disabled the backoff

`min(ceiling, advertised * SAFETY)` resolves to the ceiling itself whenever the provider advertises a limit above ours. `api.mainnet-beta.solana.com` sends `x-ratelimit-rps-limit: 250` against a default ceiling of 10, so the header path was a **no-op** there.

A 429 always means slow down, so an advertised limit may now only pull the rate *down*: `max(MIN_RATE, min(advertised * SAFETY, current * AIMD))`.

**Trade-off:** a 429 can no longer jump the rate *up* toward a provider's advertised capability, so recovery to that rate goes through the slow additive path. That's the intent — a rate-limit response should never raise throughput — but it is a behavior change.

## 3. `fallbackUrl` is now optional

Requiring it was a forcing function: a consumer with one paid endpoint had nowhere to point it but a public RPC, so a degraded primary quietly became traffic aimed at shared infrastructure. With no fallback configured, none is registered — the circuit still protects the primary and open-circuit calls fail fast rather than being routed elsewhere.

Backward compatible: widening required → optional keeps every existing caller compiling. The `.d.ts` diff is exactly one line.

## Testing notes — this seam is easy to test wrongly

Worth reading before reviewing the tests, because two of my own attempts were wrong first:

- **The existing 429 test sets `volumeThreshold: 100` specifically to keep the circuit CLOSED.** That's why it never caught bug 1. The new test drives the OPEN path.
- **Bug 2 cannot be caught by an absolute request count.** The per-429 cooldown dominates throughput and masks the rate — measured, broken and fixed builds were *indistinguishable* that way, and my first test for it passed against the broken code. The test uses `retry-after: 0` to remove the cooldown, leaving throughput governed purely by the adaptive rate, and asserts against the known-good headerless case rather than a fixed number so it doesn't depend on machine speed. With the cooldown removed the bug is stark: **68 requests versus 9**.

Both new throttle tests fail against the previous implementation with clear diagnostics, and pass after. The six pre-existing tests are unchanged and still pass.

## Also in here

`getInfo()`'s cost is now documented: it spends two account reads while returning `Ticker`, `Name`, `Denomination`, `Handlers` and `LastCreatedEpochIndex` as fixed literals — only `totalSupply`, `protocolBalance` and `epochSettings` come from chain. Documented rather than given a separate static-metadata accessor; permanently growing the public surface to save two reads in a marginal case is the worse trade.

## Reported but deliberately not fixed

- **10s opossum timeout.** The stated premise doesn't hold: mainnet has **2650** ARIO token accounts and a full `getBalances` scan moves ~**0.67 MB**, landing a few seconds in — comfortably inside 10s. (The reported "2349 accounts / 1.13 MB" is the *devnet* figure.) The real concern next door is trip sensitivity — `volumeThreshold: 3` with `errorThresholdPercentage: 25` means one timeout in four requests opens the circuit for 60s. Worth revisiting, but not by inflating the timeout on a false premise, and not as a default change smuggled into a bugfix PR.
- **`getAllDelegates` always fetching accumulators.** A `{ liveBalances?: boolean }` opt-out is cheap and additive, but only pays off if a consumer genuinely wants addresses without balances. Happy to add it if the portal still wants it.

## Verification

- Full suite: 484 tests, 0 failures. `lint:check`, `format:check`, `build` all clean.
- Public type surface: one intended line (`fallbackUrl?`). `io-readable.d.ts` otherwise unchanged.
- Blast radius: one source file plus a docstring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Circuit breaker configurations can now operate without a fallback endpoint.
  * Requests fail fast with clearer behavior when no fallback is available and the circuit is open.
  * Rate limiting adapts more reliably to HTTP 429 responses and provider-advertised limits.

* **Documentation**
  * Added documentation describing on-chain fields, static metadata, and RPC costs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->