### PR TITLE
chore: enable CodeRabbit reviews on the branches we actually ship from

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+#
+# CodeRabbit only auto-reviews pull requests whose BASE is the repository's
+# default branch (`main`). This project's contribution flow targets `alpha`
+# (see CONTRIBUTING.md: branch from main, PR into alpha, team promotes
+# alpha -> main), so in practice essentially no PR here was ever reviewed —
+# CodeRabbit posted a passing status check with "Review skipped: reviews are
+# disabled for this base branch", which reads as a green review unless you
+# open the comment.
+#
+# `base_branches` is additive to the default branch, so `main` stays covered.
+reviews:
+  auto_review:
+    enabled: true
+    base_branches:
+      # The prerelease branches from .releaserc — anything that can ship to npm
+      # should be reviewed before it gets there.
+      - alpha
+      - solana


### PR DESCRIPTION
## The problem

CodeRabbit only auto-reviews PRs whose base is the repository's **default branch** (`main`). CONTRIBUTING tells contributors to branch from `main` and PR into `alpha`, so in practice essentially **no pull request in this repo has ever been reviewed by CodeRabbit**.

The failure mode is quiet. CodeRabbit still posts a *passing* status check:

```
CodeRabbit   pass   0     Review skipped: reviews are disabled for this base branch
```

`gh pr checks` renders that as green. The skip reason only appears if you open the comment body, where it says:

> **Review skipped** — Auto reviews are disabled on base/target branches other than the default branch.

I found this while checking three open PRs (#712, #713, #714) that all looked reviewed and none of which were.

## The fix

`reviews.auto_review.base_branches` is documented in the schema as *"Base branches (other than the default branch) to review"* — it is **additive**, so `main` keeps its existing coverage. Its default is `[]`, which is why nothing outside `main` was ever picked up.

Added `alpha` and `solana`: the two prerelease branches in `.releaserc`, on the principle that anything which can publish to npm should be reviewed before it does.

## Two caveats

1. **This cannot fix the currently open PRs.** CodeRabbit reads `.coderabbit.yaml` from a PR's *base* branch, so it only takes effect once this is merged into `alpha`. This PR itself won't be auto-reviewed either. Open PRs need a manual `@coderabbitai review` comment — I've already posted one on #712, #713 and #714.
2. **Stacked PRs still skip.** #714 targets `perf/rpc-call-reduction`, which isn't in the list. Using `.*` would cover every base branch, but it would also review every stacked and scratch PR. I chose the explicit release-branch list; easy to widen if you'd rather.

There is no existing `.coderabbit.yaml` in the repo — it has been running on defaults (profile CHILL, plan Pro Plus), which is how this went unnoticed. Worth double-checking the CodeRabbit UI settings too, since the skip message cites those as the other possible source of truth.
