### PR TITLE
chore(release): alpha → main (4.2.0)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+#
+# CodeRabbit only auto-reviews pull requests whose BASE is the repository's
+# default branch (`main`). This project's contribution flow targets `alpha`
+# (see CONTRIBUTING.md: branch from main, PR into alpha, team promotes
+# alpha -> main), so in practice essentially no PR here was ever reviewed —
+# CodeRabbit posted a passing status check with "Review skipped: reviews are
+# disabled for this base branch", which reads as a green review unless you
+# open the comment.
+#
+# `base_branches` is additive to the default branch, so `main` stays covered.
+reviews:
+  auto_review:
+    enabled: true
+    base_branches:
+      # The prerelease branches from .releaserc — anything that can ship to npm
+      # should be reviewed before it gets there.
+      - alpha
+      - solana

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,14 @@ on:
       - main
       - alpha
       - solana
+  # Promotion PRs (alpha -> main) have `alpha` as their head, which the
+  # branches-ignore above skips — so they produced NO build/test checks at all
+  # and `main`'s required status checks could never be satisfied. Scoped to
+  # PRs targeting main so feature -> alpha PRs keep relying on the push run
+  # above instead of running the whole matrix twice.
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
   workflow_call:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [4.2.0-alpha.2](https://github.com/ar-io/ar-io-sdk/compare/v4.2.0-alpha.1...v4.2.0-alpha.2) (2026-08-25)
+
+
+### Bug Fixes
+
+* **solana:** decode registry slot timestamps without BigInt Buffer readers ([f821226](https://github.com/ar-io/ar-io-sdk/commit/f821226d141b36629339f9d77115ec76757dfa9a))
+* **solana:** refuse observation slots stamped with the epoch start second ([fdbf20a](https://github.com/ar-io/ar-io-sdk/commit/fdbf20af79c955aa234f31d5f349066f370f64c6))
+* **solana:** send the epoch's frozen gateway count in save_observations ([4820c3b](https://github.com/ar-io/ar-io-sdk/commit/4820c3bfec7d92eb981503fc2653e429d3ce5716))
+* **solana:** target the active epoch when saveObservations defaults the index ([450c9f6](https://github.com/ar-io/ar-io-sdk/commit/450c9f6c046e3dc90b6ecf26aada8cd2ecc6d42a))
+
 # [4.2.0-alpha.1](https://github.com/ar-io/ar-io-sdk/compare/v4.1.4-alpha.3...v4.2.0-alpha.1) (2026-08-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [4.2.0-alpha.1](https://github.com/ar-io/ar-io-sdk/compare/v4.1.4-alpha.3...v4.2.0-alpha.1) (2026-08-23)
+
+
+### Bug Fixes
+
+* **solana:** make the RPC throttle back off when it actually matters ([70dd2f6](https://github.com/ar-io/ar-io-sdk/commit/70dd2f6b2bf871ae7b37b168f471384edde4f656))
+
+
+### Features
+
+* **solana:** let consumers decline a public RPC fallback ([a1020c2](https://github.com/ar-io/ar-io-sdk/commit/a1020c2298241b50757e7835ac714209ca2fe0e9))
+
 ## [4.1.4-alpha.3](https://github.com/ar-io/ar-io-sdk/compare/v4.1.4-alpha.2...v4.1.4-alpha.3) (2026-08-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.1.4-alpha.3](https://github.com/ar-io/ar-io-sdk/compare/v4.1.4-alpha.2...v4.1.4-alpha.3) (2026-08-23)
+
+
+### Bug Fixes
+
+* **solana:** don't report zero funding sources when discovery fails ([ab1b7fc](https://github.com/ar-io/ar-io-sdk/commit/ab1b7fc92368e90ecd64003c51b09c273976347c))
+
 ## [4.1.4-alpha.2](https://github.com/ar-io/ar-io-sdk/compare/v4.1.4-alpha.1...v4.1.4-alpha.2) (2026-08-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [4.2.0-alpha.3](https://github.com/ar-io/ar-io-sdk/compare/v4.2.0-alpha.2...v4.2.0-alpha.3) (2026-08-25)
+
+
+### Bug Fixes
+
+* **solana:** don't re-evaluate the retry predicate on the final attempt ([30ec333](https://github.com/ar-io/ar-io-sdk/commit/30ec33363794bc2bada4f91e4d9c8eeb01184df4))
+* **solana:** route retry/circuit-breaker logs through the shared Logger ([adefaa5](https://github.com/ar-io/ar-io-sdk/commit/adefaa5f1cab15b9797ff3659facfe05fcd791ed))
+
 # [4.2.0-alpha.2](https://github.com/ar-io/ar-io-sdk/compare/v4.2.0-alpha.1...v4.2.0-alpha.2) (2026-08-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [4.1.4-alpha.2](https://github.com/ar-io/ar-io-sdk/compare/v4.1.4-alpha.1...v4.1.4-alpha.2) (2026-08-23)
+
+
+### Bug Fixes
+
+* **solana:** measure the single-flight TTL from settlement, not from start ([fa48766](https://github.com/ar-io/ar-io-sdk/commit/fa48766cbf1d624efb2405e241953071d1bd012d)), closes [#712](https://github.com/ar-io/ar-io-sdk/issues/712)
+
+
+### Performance Improvements
+
+* **solana:** batch gateway metadata and drop a dead read in discovery ([e89a871](https://github.com/ar-io/ar-io-sdk/commit/e89a8717348f10c1e52cfb039ec0adaf43d9ae5d))
+* **solana:** coalesce concurrent RPC reads behind in-flight caches ([2fbe69b](https://github.com/ar-io/ar-io-sdk/commit/2fbe69bf09b3b1a24547c15e30abbe79e776e9ae))
+* **solana:** fetch account chunks in a bounded pool, not one at a time ([0179255](https://github.com/ar-io/ar-io-sdk/commit/0179255688f326332f55c204e1411f4e2352a9cc))
+
 ## [4.1.4-alpha.1](https://github.com/ar-io/ar-io-sdk/compare/v4.1.3...v4.1.4-alpha.1) (2026-08-14)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.2.0-alpha.1",
+  "version": "4.2.0-alpha.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.2.0-alpha.2",
+  "version": "4.2.0-alpha.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.1.4-alpha.1",
+  "version": "4.1.4-alpha.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.1.4-alpha.2",
+  "version": "4.1.4-alpha.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.1.4-alpha.3",
+  "version": "4.2.0-alpha.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/src/solana/ant-readable.test.ts
+++ b/src/solana/ant-readable.test.ts
@@ -138,3 +138,139 @@ describe('SolanaANTReadable request batching', () => {
     assert.equal(counts.gai, 0, 'no single-account reads');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Chunk ordering under bounded concurrency
+//
+// getANTSummaries and getANTStates read each mint's accounts POSITIONALLY out
+// of the flattened batch result (`accounts[i * 3]`, `accounts[i * 2]`). Once
+// the 100-account chunks stopped being awaited one-at-a-time, chunk completion
+// order stopped matching request order — so if the flattening ever followed
+// completion order instead of input order, one ANT's config would silently be
+// attributed to another mint. These tests make the chunks finish out of order
+// on purpose and assert every mint still gets its own data back.
+// ---------------------------------------------------------------------------
+
+const antMint = (n: number) => bs58.encode(Buffer.alloc(32, n));
+
+/**
+ * Stub whose chunk responses resolve in REVERSE order (the later the chunk,
+ * the sooner it settles), and which echoes the requested PDA back so each
+ * decoded account can be traced to the mint it was derived from.
+ */
+function outOfOrderChunkRpc(
+  counts: { gma: number },
+  configFor: (pda: string) => unknown | null,
+) {
+  let chunkIndex = 0;
+  return {
+    getProgramAccounts: () => ({ send: async () => [] }),
+    getAccountInfo: () => ({ send: async () => ({ value: null }) }),
+    getMultipleAccounts: (addrs: unknown[]) => {
+      const myIndex = chunkIndex++;
+      return {
+        send: async () => {
+          counts.gma++;
+          // Later chunks return first.
+          await new Promise((r) =>
+            setTimeout(r, Math.max(0, 30 - myIndex * 10)),
+          );
+          return {
+            value: (addrs as string[]).map((a) => configFor(a)),
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('ANT bulk reads — chunk ordering', () => {
+  it('keeps each mint matched to its own accounts across several chunks', async () => {
+    // 60 mints x 3 PDAs = 180 accounts = 2 chunks of <=100.
+    const mints = Array.from({ length: 60 }, (_, i) => antMint(i + 1));
+    const counts = { gma: 0 };
+
+    // Map every derived PDA back to its owning mint so we can detect a
+    // cross-wired result rather than merely a missing one.
+    const { getAntConfigPDA, getAntControllersPDA, getAntRecordPDA } =
+      await import('./pda.js');
+    const { ARIO_ANT_PROGRAM_ID } = await import('./constants.js');
+    const pdaToMint = new Map<string, { mint: string; kind: string }>();
+    for (const m of mints) {
+      const mintAddr = address(m);
+      const [cfg] = await getAntConfigPDA(mintAddr, ARIO_ANT_PROGRAM_ID);
+      const [ctrl] = await getAntControllersPDA(mintAddr, ARIO_ANT_PROGRAM_ID);
+      const [apex] = await getAntRecordPDA(mintAddr, '@', ARIO_ANT_PROGRAM_ID);
+      pdaToMint.set(String(cfg), { mint: m, kind: 'config' });
+      pdaToMint.set(String(ctrl), { mint: m, kind: 'controllers' });
+      pdaToMint.set(String(apex), { mint: m, kind: 'apex' });
+    }
+
+    const { getAntConfigEncoder, getAntControllersEncoder } = await import(
+      '@ar.io/solana-contracts/ant'
+    );
+    const cfgEncoder = getAntConfigEncoder();
+    const ctrlEncoder = getAntControllersEncoder();
+    const wrap = (bytes: Uint8Array) => ({
+      data: [Buffer.from(bytes).toString('base64'), 'base64'],
+      executable: false,
+      lamports: 1n,
+      owner: address(mints[0]),
+      rentEpoch: 0n,
+      space: BigInt(bytes.length),
+    });
+
+    /** Return the account type that actually belongs at each derived PDA. */
+    const configFor = (pda: string) => {
+      const entry = pdaToMint.get(pda);
+      if (!entry) return null;
+      const mintStr = entry.mint;
+      if (entry.kind === 'apex') return null; // apex record is optional
+      if (entry.kind === 'controllers')
+        return wrap(
+          ctrlEncoder.encode({
+            mint: address(mintStr),
+            controllers: [],
+            bump: 255,
+            version: { major: 1, minor: 0, patch: 0 },
+          }) as Uint8Array,
+        );
+      // The name encodes its mint, so a cross-wired result is visible.
+      return wrap(
+        cfgEncoder.encode({
+          mint: address(mintStr),
+          name: `name-for-${mintStr.slice(0, 8)}`,
+          ticker: 'ANT',
+          logo: '',
+          description: '',
+          keywords: [],
+          lastKnownOwner: address(mintStr),
+          bump: 255,
+          version: { major: 1, minor: 0, patch: 0 },
+        }) as Uint8Array,
+      );
+    };
+
+    const ant = new SolanaANTReadable({
+      rpc: outOfOrderChunkRpc(counts, configFor) as never,
+      processId: mints[0],
+      logger: new Logger({ level: 'none' }),
+    });
+
+    const summaries = await ant.getANTSummaries(mints);
+
+    assert.ok(counts.gma >= 2, 'should have taken more than one chunk');
+    assert.equal(
+      Object.keys(summaries).length,
+      60,
+      'every mint should be present',
+    );
+    for (const m of mints) {
+      assert.equal(
+        summaries[m]?.name,
+        `name-for-${m.slice(0, 8)}`,
+        `mint ${m.slice(0, 8)} got another mint's config — chunks were flattened in completion order`,
+      );
+    }
+  });
+});

--- a/src/solana/ant-readable.ts
+++ b/src/solana/ant-readable.ts
@@ -53,6 +53,11 @@ import type {
 import type { WalletAddress } from '../types/common.js';
 import type { GasEstimate } from '../types/io.js';
 import { SolanaANTRegistryReadable } from './ant-registry-readable.js';
+import {
+  ACCOUNT_FETCH_CONCURRENCY,
+  chunkArray,
+  mapWithConcurrency,
+} from './concurrency.js';
 import { ANT_CONFIG_VERSION, ARIO_ANT_PROGRAM_ID } from './constants.js';
 import {
   ACL_BOOTSTRAP_ACCOUNT_BYTES,
@@ -606,15 +611,19 @@ export class SolanaANTReadable {
       t.controllersPda,
       t.apexPda,
     ]);
-    type Acct = Awaited<ReturnType<typeof fetchEncodedAccounts>>[number];
-    const accounts: Acct[] = [];
-    for (let i = 0; i < allPdas.length; i += 100) {
-      const chunk = allPdas.slice(i, i + 100);
-      const res = await withRetry(() =>
-        fetchEncodedAccounts(this.rpc, chunk, { commitment: this.commitment }),
-      );
-      accounts.push(...res);
-    }
+    // Chunks run in a bounded pool. `accounts` is flattened in chunk order,
+    // which the decode loop below relies on absolutely: it reads each mint's
+    // three accounts at `i * 3`, so any reordering would attribute one ANT's
+    // config to another.
+    const perChunk = await mapWithConcurrency(
+      chunkArray(allPdas, 100),
+      ACCOUNT_FETCH_CONCURRENCY,
+      (pdas) =>
+        withRetry(() =>
+          fetchEncodedAccounts(this.rpc, pdas, { commitment: this.commitment }),
+        ),
+    );
+    const accounts = perChunk.flat();
 
     const recordDecoder = getAntRecordDecoder();
     const result: Record<string, ANTSummary> = {};
@@ -697,16 +706,17 @@ export class SolanaANTReadable {
       }),
     );
     const allPdas = pairs.flatMap((p) => [p.configPda, p.controllersPda]);
-    type Acct = Awaited<ReturnType<typeof fetchEncodedAccounts>>[number];
-    const accounts: Acct[] = [];
-    for (let i = 0; i < allPdas.length; i += 100) {
-      const res = await withRetry(() =>
-        fetchEncodedAccounts(this.rpc, allPdas.slice(i, i + 100), {
-          commitment: this.commitment,
-        }),
-      );
-      accounts.push(...res);
-    }
+    // As in getANTSummaries: bounded pool, flattened in chunk order because
+    // the decode loop indexes each mint's pair at `i * 2`.
+    const perChunk = await mapWithConcurrency(
+      chunkArray(allPdas, 100),
+      ACCOUNT_FETCH_CONCURRENCY,
+      (pdas) =>
+        withRetry(() =>
+          fetchEncodedAccounts(this.rpc, pdas, { commitment: this.commitment }),
+        ),
+    );
+    const accounts = perChunk.flat();
 
     const recordsByMint = await this._recordsByMint(
       opts?.includeMetadata === true,

--- a/src/solana/concurrency.test.ts
+++ b/src/solana/concurrency.test.ts
@@ -1,0 +1,72 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { mapWithConcurrency } from './concurrency.js';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('mapWithConcurrency', () => {
+  it('returns results in INPUT order, not completion order', async () => {
+    // Reverse the delays so completion order is the opposite of input order —
+    // the bulk readers index positionally, so this is the property that keeps
+    // decoded accounts matched to the right mint.
+    const items = [0, 1, 2, 3, 4, 5, 6, 7];
+    const out = await mapWithConcurrency(items, 4, async (n) => {
+      await sleep((items.length - n) * 3);
+      return n * 10;
+    });
+    assert.deepEqual(out, [0, 10, 20, 30, 40, 50, 60, 70]);
+  });
+
+  it('never exceeds the concurrency limit', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await mapWithConcurrency(
+      Array.from({ length: 30 }, (_, i) => i),
+      4,
+      async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await sleep(2);
+        inFlight--;
+      },
+    );
+    assert.ok(peak <= 4, `peak concurrency ${peak} exceeded the limit of 4`);
+    assert.ok(peak > 1, 'work should actually run in parallel');
+  });
+
+  it('runs every item exactly once', async () => {
+    const seen: number[] = [];
+    await mapWithConcurrency(
+      Array.from({ length: 25 }, (_, i) => i),
+      4,
+      async (n) => {
+        await sleep(1);
+        seen.push(n);
+      },
+    );
+    assert.deepEqual(
+      [...seen].sort((a, b) => a - b),
+      Array.from({ length: 25 }, (_, i) => i),
+    );
+  });
+
+  it('rejects on the first failure, like a sequential loop', async () => {
+    await assert.rejects(
+      () =>
+        mapWithConcurrency([1, 2, 3, 4], 2, async (n) => {
+          if (n === 3) throw new Error('chunk 3 failed');
+          return n;
+        }),
+      { message: 'chunk 3 failed' },
+    );
+  });
+
+  it('handles an empty input and a limit larger than the input', async () => {
+    assert.deepEqual(await mapWithConcurrency([], 4, async () => 1), []);
+    assert.deepEqual(
+      await mapWithConcurrency([1, 2], 99, async (n) => n * 2),
+      [2, 4],
+    );
+  });
+});

--- a/src/solana/concurrency.ts
+++ b/src/solana/concurrency.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Bounded-concurrency map for batched RPC reads.
+ *
+ * The bulk readers fetch accounts in chunks of 100 (Solana's
+ * `getMultipleAccounts` ceiling) but used to `await` each chunk before
+ * starting the next, so wall-clock time grew linearly with the number of
+ * chunks: 648 devnet gateways took ~210ms across 7 serialized round trips
+ * where the same 7 in parallel took ~110ms, and mainnet's larger registry
+ * makes that gap wider still.
+ *
+ * The cap matters as much as the parallelism. An unbounded `Promise.all` over
+ * every chunk turns one bulk read into a burst as wide as the registry, which
+ * is a good way to earn an HTTP 429 from a public RPC — so this runs a fixed
+ * pool instead.
+ *
+ * Internal helper — not re-exported from `./index.ts`.
+ */
+
+/**
+ * Default pool size for chunked account fetches.
+ *
+ * Four is a deliberate compromise: it cuts a 13-chunk mainnet gateway read to
+ * ~4 waves instead of 13, while staying far below the burst width that trips
+ * provider rate limits. Callers that know their RPC's limits can pass their
+ * own.
+ */
+export const ACCOUNT_FETCH_CONCURRENCY = 4;
+
+/** Split `items` into consecutive slices of at most `size`. */
+export function chunkArray<T>(items: ReadonlyArray<T>, size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size)
+    out.push(items.slice(i, i + size));
+  return out;
+}
+
+/**
+ * Map `items` through `fn` with at most `limit` calls in flight.
+ *
+ * Results are returned in INPUT order regardless of completion order — the
+ * bulk readers index into the result array positionally (`accounts[i * 3]`),
+ * so any reordering here would silently mis-assign decoded accounts to mints.
+ *
+ * Rejection semantics match a plain sequential loop: the first failure
+ * rejects the whole call.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: ReadonlyArray<T>,
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const poolSize = Math.max(1, Math.min(limit, items.length));
+
+  const worker = async () => {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index], index);
+    }
+  };
+
+  await Promise.all(Array.from({ length: poolSize }, worker));
+  return results;
+}

--- a/src/solana/funding-plan.test.ts
+++ b/src/solana/funding-plan.test.ts
@@ -15,6 +15,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
 import { type Address } from '@solana/kit';
+import bs58 from 'bs58';
 
 import {
   type DiscoveredFundingSource,
@@ -22,6 +23,7 @@ import {
   MAX_FUNDING_SOURCES,
   buildFundingPlan,
   computeResidueIndexes,
+  discoverFundingSources,
 } from './funding-plan.js';
 
 const GATEWAY_A = 'GatewayAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as Address;
@@ -526,5 +528,198 @@ describe('computeResidueIndexes', () => {
   it('skips Delegation when state is missing (undefined slot)', () => {
     const sources = [{ kind: 'delegation', amount: 12_000_000n }];
     assert.deepEqual(computeResidueIndexes(sources, [undefined]), []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverFundingSources — RPC shape
+//
+// This path had no coverage, so these tests were written against the ORIGINAL
+// implementation first and must keep passing unchanged: they pin the observable
+// output while the request pattern underneath it changes.
+// ---------------------------------------------------------------------------
+
+/** Real base58 pubkeys — kit rejects placeholder strings outright. */
+const addr32 = (fill: number) => bs58.encode(Buffer.alloc(32, fill)) as Address;
+const OWNER = addr32(1);
+const MINT = addr32(2);
+const GAR_PROGRAM = addr32(3);
+
+const DELEGATION_SIZE = 8 + 32 + 32 + 8 + 8 + 16 + 1 + 3;
+const WITHDRAWAL_SIZE = 8 + 32 + 8 + 32 + 8 + 8 + 8 + 1 + 1 + 1 + 1 + 3;
+
+/** Raw Delegation account bytes; the discovery path hand-parses these offsets. */
+function delegationBytes(opts: {
+  gateway: Uint8Array;
+  amount: bigint;
+  startTimestamp: bigint;
+}): string {
+  const b = Buffer.alloc(DELEGATION_SIZE);
+  Buffer.from(opts.gateway).copy(b, 8); // gateway pubkey
+  b.writeBigUInt64LE(opts.amount, 72); // amount
+  b.writeBigInt64LE(opts.startTimestamp, 80); // start_timestamp
+  return b.toString('base64');
+}
+
+/** SPL token account: amount lives at offset 64. */
+function ataBytes(amount: bigint): string {
+  const b = Buffer.alloc(165);
+  b.writeBigUInt64LE(amount, 64);
+  return b.toString('base64');
+}
+
+type DiscoveryCounts = {
+  getAccountInfo: number;
+  getMultipleAccounts: number;
+  getProgramAccounts: number;
+  accountsRequested: number;
+};
+
+/**
+ * Stub rpc for discovery. `existingGateways` decides which gateway PDAs come
+ * back as existing — the discovery path only ever used that existence bit.
+ */
+function discoveryRpc(
+  counts: DiscoveryCounts,
+  opts: { delegations: string[]; ataAmount?: bigint },
+) {
+  const accountValue = (data: string) => ({
+    data: [data, 'base64'] as readonly [string, string],
+    executable: false,
+    lamports: 1_000_000n,
+    owner: OWNER,
+    rentEpoch: 0n,
+    space: BigInt(Buffer.from(data, 'base64').length),
+  });
+  return {
+    getAccountInfo: (_addr: unknown) => ({
+      send: async () => {
+        counts.getAccountInfo++;
+        // First getAccountInfo is the owner's ATA; the rest are gateway PDAs
+        // in the original implementation.
+        return counts.getAccountInfo === 1 && opts.ataAmount !== undefined
+          ? { value: accountValue(ataBytes(opts.ataAmount)) }
+          : { value: accountValue(Buffer.alloc(400).toString('base64')) };
+      },
+    }),
+    getMultipleAccounts: (addrs: unknown[]) => ({
+      send: async () => {
+        counts.getMultipleAccounts++;
+        counts.accountsRequested += (addrs as unknown[]).length;
+        return {
+          value: (addrs as unknown[]).map(() =>
+            accountValue(Buffer.alloc(400).toString('base64')),
+          ),
+        };
+      },
+    }),
+    getProgramAccounts: (_program: unknown, cfg: any) => ({
+      send: async () => {
+        counts.getProgramAccounts++;
+        const size = cfg?.filters?.find((f: any) => f.dataSize)?.dataSize;
+        if (size === BigInt(WITHDRAWAL_SIZE)) return [];
+        if (size === BigInt(DELEGATION_SIZE))
+          return opts.delegations.map((d) => ({
+            pubkey: OWNER,
+            account: { data: [d, 'base64'] },
+          }));
+        return [];
+      },
+    }),
+  };
+}
+
+describe('discoverFundingSources', () => {
+  const gwABytes = Buffer.alloc(32, 7);
+  const gwBBytes = Buffer.alloc(32, 9);
+
+  it('returns balance + delegation sources with the documented shape', async () => {
+    const counts: DiscoveryCounts = {
+      getAccountInfo: 0,
+      getMultipleAccounts: 0,
+      getProgramAccounts: 0,
+      accountsRequested: 0,
+    };
+    const rpc = discoveryRpc(counts, {
+      ataAmount: 5_000_000n,
+      delegations: [
+        delegationBytes({
+          gateway: gwABytes,
+          amount: 1_000_000n,
+          startTimestamp: 100n,
+        }),
+        delegationBytes({
+          gateway: gwBBytes,
+          amount: 3_000_000n,
+          startTimestamp: 200n,
+        }),
+      ],
+    });
+
+    const sources = await discoverFundingSources(rpc as never, OWNER, {
+      arioMint: MINT,
+      garProgram: GAR_PROGRAM,
+    });
+
+    const balance = sources.filter((s) => s.kind === 'balance');
+    const delegations = sources.filter((s) => s.kind === 'delegation');
+    assert.equal(balance.length, 1);
+    assert.equal(balance[0].available, 5_000_000n);
+    assert.equal(delegations.length, 2);
+    // minDelegationAmount comes from the gateway existence check; both exist.
+    for (const d of delegations) {
+      assert.equal(d.minDelegationAmount, 10_000_000n);
+      assert.equal(d.performanceRatio, 1.0);
+      assert.equal(d.totalDelegatedStake, 0n);
+    }
+    // Lua sort: descending excess stake. Both are below the floor here, so
+    // excess is 0 for both and the tie breaks on later start timestamp.
+    assert.equal(delegations[0].available, 3_000_000n);
+    assert.equal(delegations[1].available, 1_000_000n);
+
+    // No operatorStake source is ever discovered: fundAsOperator requires
+    // explicit `sources`. Pinned so removing the dead fetch stays a no-op.
+    assert.equal(sources.filter((s) => s.kind === 'operatorStake').length, 0);
+  });
+
+  it('reads gateway metadata without one round trip per delegation', async () => {
+    const counts: DiscoveryCounts = {
+      getAccountInfo: 0,
+      getMultipleAccounts: 0,
+      getProgramAccounts: 0,
+      accountsRequested: 0,
+    };
+    const delegations = Array.from({ length: 120 }, (_, i) =>
+      delegationBytes({
+        gateway: Buffer.alloc(32, (i % 200) + 1),
+        amount: BigInt((i + 1) * 1_000),
+        startTimestamp: BigInt(i),
+      }),
+    );
+    const rpc = discoveryRpc(counts, { ataAmount: 1n, delegations });
+
+    const sources = await discoverFundingSources(rpc as never, OWNER, {
+      arioMint: MINT,
+      garProgram: GAR_PROGRAM,
+    });
+
+    assert.equal(
+      sources.filter((s) => s.kind === 'delegation').length,
+      120,
+      'every delegation is still discovered',
+    );
+    // The ATA read is the only legitimate single-account fetch here.
+    assert.equal(
+      counts.getAccountInfo,
+      1,
+      `gateway metadata must not cost one getAccountInfo per delegation ` +
+        `(saw ${counts.getAccountInfo})`,
+    );
+    assert.equal(
+      counts.getMultipleAccounts,
+      2,
+      '120 gateways should batch into 2 getMultipleAccounts calls of <=100',
+    );
+    assert.equal(counts.accountsRequested, 120);
   });
 });

--- a/src/solana/funding-plan.test.ts
+++ b/src/solana/funding-plan.test.ts
@@ -722,4 +722,71 @@ describe('discoverFundingSources', () => {
     );
     assert.equal(counts.accountsRequested, 120);
   });
+
+  it('surfaces a transient RPC failure instead of reporting zero sources', async () => {
+    // The whole point: a 429 must not be indistinguishable from "this wallet
+    // has no delegations". Observed live against public devnet — a wallet
+    // holding seven delegations reported none, silently, and the planner would
+    // have under-funded from it.
+    const counts: DiscoveryCounts = {
+      getAccountInfo: 0,
+      getMultipleAccounts: 0,
+      getProgramAccounts: 0,
+      accountsRequested: 0,
+    };
+    const rpc = discoveryRpc(counts, { ataAmount: 1n, delegations: [] });
+    // Every getProgramAccounts 429s, through the retries.
+    rpc.getProgramAccounts = () => ({
+      send: async () => {
+        counts.getProgramAccounts++;
+        throw new Error('HTTP error (429): Too Many Requests');
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        discoverFundingSources(rpc as never, OWNER, {
+          arioMint: MINT,
+          garProgram: GAR_PROGRAM,
+        }),
+      /Refusing to report zero sources for a transient failure/,
+    );
+    assert.ok(
+      counts.getProgramAccounts > 1,
+      `a transient failure should be retried before giving up, saw ${counts.getProgramAccounts} attempt(s)`,
+    );
+  });
+
+  it('still degrades to an empty list when getProgramAccounts is unsupported', async () => {
+    // Many public RPCs disable gPA outright. That is permanent, not transient,
+    // so the graceful fallback is still correct there — it just says so now.
+    const counts: DiscoveryCounts = {
+      getAccountInfo: 0,
+      getMultipleAccounts: 0,
+      getProgramAccounts: 0,
+      accountsRequested: 0,
+    };
+    const rpc = discoveryRpc(counts, { ataAmount: 7n, delegations: [] });
+    rpc.getProgramAccounts = () => ({
+      send: async () => {
+        counts.getProgramAccounts++;
+        throw new Error('Method not supported: getProgramAccounts');
+      },
+    });
+
+    const sources = await discoverFundingSources(rpc as never, OWNER, {
+      arioMint: MINT,
+      garProgram: GAR_PROGRAM,
+    });
+    // Balance still discovered; the gPA-backed sources are simply absent.
+    assert.deepEqual(
+      sources.map((s) => s.kind),
+      ['balance'],
+    );
+    assert.equal(
+      counts.getProgramAccounts,
+      2,
+      'a permanent error should not be retried (one attempt per scan)',
+    );
+  });
 });

--- a/src/solana/funding-plan.ts
+++ b/src/solana/funding-plan.ts
@@ -51,13 +51,14 @@ import {
   type SolanaRpcApi,
   type SolanaRpcApiMainnet,
   fetchEncodedAccount,
+  fetchEncodedAccounts,
   getAddressDecoder,
 } from '@solana/kit';
 
 /**
  * The discovery + executor accept either the dev/test or the mainnet RPC API
  * shape — they only use methods that are common to both (`getProgramAccounts`,
- * `getAccountInfo`).
+ * `getAccountInfo`, `getMultipleAccounts`).
  */
 export type FundingPlanRpc = Rpc<SolanaRpcApi> | Rpc<SolanaRpcApiMainnet>;
 
@@ -251,13 +252,15 @@ export async function discoverFundingSources(
   });
   for (const d of delegations) sources.push(d);
 
-  // 5. Operator stake (Solana extension; only relevant when caller opts in).
-  //    Discovery requires checking each gateway the user might operate; we
-  //    only check the user's own gateway-as-operator PDA rather than scanning
-  //    all gateways.
-  const operatorSource = await fetchOperatorStake(rpc, owner, garProgram);
-  if (operatorSource) sources.push(operatorSource);
-
+  // 5. Operator stake (Solana extension) is NOT auto-discovered.
+  //
+  //    There used to be a `fetchOperatorStake` call here that read the
+  //    caller's gateway-as-operator PDA and then returned null on every code
+  //    path — the account was fetched and discarded, costing one round trip
+  //    per discovery for nothing. Removing it changes no output: operator
+  //    stake never appeared in the discovered set, so `fundAsOperator` has
+  //    always required the caller to pass explicit `sources`. Implementing
+  //    real discovery is a behavior change and belongs on its own.
   return sources;
 }
 
@@ -764,6 +767,9 @@ export async function predictResidueVaults(
 
 const ADDRESS_DECODER = getAddressDecoder();
 
+/** Solana caps `getMultipleAccounts` at 100 keys per request. */
+const ACCOUNT_BATCH_SIZE = 100;
+
 async function fetchUserWithdrawals(
   rpc: FundingPlanRpc,
   owner: Address,
@@ -854,7 +860,15 @@ async function fetchUserDelegations(
         encoding: 'base64',
       } as Parameters<typeof rpc.getProgramAccounts>[1])
       .send();
-    const out: DiscoveredFundingSource[] = [];
+    // Decode every delegation FIRST, then resolve gateway metadata for the
+    // whole set in one batch. Doing it inline cost a full round trip per
+    // delegation, serialized — 120 delegations meant 120 sequential
+    // `getAccountInfo` calls before discovery could return.
+    const decoded: Array<{
+      gateway: Address;
+      amount: bigint;
+      startTimestamp: bigint;
+    }> = [];
     for (const entry of result as unknown as Array<{
       account: { data: [string, string] };
     }>) {
@@ -864,11 +878,22 @@ async function fetchUserDelegations(
       const gateway = ADDRESS_DECODER.decode(data.subarray(8, 40));
       const amount = dv.getBigUint64(72, true);
       if (amount === 0n) continue;
-      const startTimestamp = BigInt(dv.getBigInt64(80, true));
-      // We need the gateway's min_delegation_amount + perf ratio to sort
-      // properly. Fetch each gateway lazily; cache in a map.
-      const meta = await fetchGatewayMeta(rpc, gateway, garProgram);
-      out.push({
+      decoded.push({
+        gateway,
+        amount,
+        startTimestamp: BigInt(dv.getBigInt64(80, true)),
+      });
+    }
+
+    const metas = await fetchGatewayMetas(
+      rpc,
+      decoded.map((d) => d.gateway),
+      garProgram,
+    );
+
+    return decoded.map(({ gateway, amount, startTimestamp }) => {
+      const meta = metas.get(gateway) ?? MISSING_GATEWAY_META;
+      return {
         kind: 'delegation',
         gateway,
         available: amount,
@@ -876,54 +901,79 @@ async function fetchUserDelegations(
         performanceRatio: meta.performanceRatio,
         totalDelegatedStake: meta.totalDelegatedStake,
         startTimestamp,
-      });
-    }
-    return out;
+      };
+    });
   } catch {
     return [];
   }
 }
 
-async function fetchGatewayMeta(
-  rpc: FundingPlanRpc,
-  gateway: Address,
-  garProgram: Address,
-): Promise<{
+type GatewayMeta = {
   minDelegationAmount: bigint;
   performanceRatio: number;
   totalDelegatedStake: bigint;
-}> {
-  const [pda] = await getGatewayPDA(gateway, garProgram);
-  const acct = await fetchEncodedAccount(rpc, pda);
-  if (!acct.exists) {
-    return {
-      minDelegationAmount: 0n,
-      performanceRatio: 1.0,
-      totalDelegatedStake: 0n,
-    };
-  }
-  // Gateway layout has these fields packed; rather than hand-parsing every
-  // offset (the struct is large and version-sensitive), we use safe defaults
-  // when in doubt — the Lua-faithful sort is best-effort, not load-bearing.
-  // Future: switch to the Codama-decoded Gateway type once it stabilizes.
-  return {
-    minDelegationAmount: 10_000_000n, // settings.min_delegate_stake default
-    performanceRatio: 1.0,
-    totalDelegatedStake: 0n,
-  };
-}
+};
 
-async function fetchOperatorStake(
+/** Values used for a gateway whose PDA doesn't exist (e.g. pruned). */
+const MISSING_GATEWAY_META: GatewayMeta = {
+  minDelegationAmount: 0n,
+  performanceRatio: 1.0,
+  totalDelegatedStake: 0n,
+};
+
+/**
+ * Values for a gateway that DOES exist.
+ *
+ * The Gateway struct is large and version-sensitive, so rather than
+ * hand-parsing every offset we use safe defaults — the Lua-faithful sort is
+ * best-effort, not load-bearing. Future: switch to the Codama-decoded Gateway
+ * type once it stabilizes, at which point these become real reads and the
+ * batch below starts earning its keep twice over.
+ */
+const DEFAULT_GATEWAY_META: GatewayMeta = {
+  minDelegationAmount: 10_000_000n, // settings.min_delegate_stake default
+  performanceRatio: 1.0,
+  totalDelegatedStake: 0n,
+};
+
+/**
+ * Resolve gateway metadata for many gateways at once.
+ *
+ * Only the account's EXISTENCE is consulted today (see the note on
+ * {@link DEFAULT_GATEWAY_META}), but that existence bit does change the
+ * resulting `minDelegationAmount` and therefore the drawdown sort, so the
+ * lookup can't simply be dropped. Batching it into `getMultipleAccounts`
+ * chunks of 100 keeps the semantics identical while turning N sequential
+ * round trips into ceil(N/100) parallel ones.
+ */
+async function fetchGatewayMetas(
   rpc: FundingPlanRpc,
-  owner: Address,
+  gateways: ReadonlyArray<Address>,
   garProgram: Address,
-): Promise<DiscoveredFundingSource | null> {
-  // The user might be a gateway operator; try fetching their gateway PDA.
-  const [pda] = await getGatewayPDA(owner, garProgram);
-  const acct = await fetchEncodedAccount(rpc, pda);
-  if (!acct.exists || acct.data.length < 80) return null;
-  // operator_stake is at offset 40 in Gateway layout (after disc + operator).
-  // Defensive: only emit if amount > 0 and gateway is Joined.
-  // Keeping conservative parse — see fetchGatewayMeta note about offsets.
-  return null; // operator-stake-as-funding requires opt-in; skip auto-detection by default
+): Promise<Map<Address, GatewayMeta>> {
+  const out = new Map<Address, GatewayMeta>();
+  const unique = Array.from(new Set(gateways));
+  if (unique.length === 0) return out;
+
+  const pdas = await Promise.all(
+    unique.map(async (g) => (await getGatewayPDA(g, garProgram))[0]),
+  );
+
+  const chunks: Array<{ start: number; pdas: Address[] }> = [];
+  for (let i = 0; i < pdas.length; i += ACCOUNT_BATCH_SIZE)
+    chunks.push({ start: i, pdas: pdas.slice(i, i + ACCOUNT_BATCH_SIZE) });
+
+  const fetched = await Promise.all(
+    chunks.map((c) => fetchEncodedAccounts(rpc, c.pdas)),
+  );
+
+  chunks.forEach((chunk, ci) => {
+    fetched[ci].forEach((acct, i) => {
+      out.set(
+        unique[chunk.start + i],
+        acct.exists ? DEFAULT_GATEWAY_META : MISSING_GATEWAY_META,
+      );
+    });
+  });
+  return out;
 }

--- a/src/solana/funding-plan.ts
+++ b/src/solana/funding-plan.ts
@@ -63,6 +63,7 @@ import {
 export type FundingPlanRpc = Rpc<SolanaRpcApi> | Rpc<SolanaRpcApiMainnet>;
 
 import { ARIO_GAR_PROGRAM_ADDRESS as ARIO_GAR_PROGRAM_ID } from '@ar.io/solana-contracts/gar';
+import { Logger } from '../common/logger.js';
 import { type FundingSourceKind, type FundingSourceSpec } from '../types/io.js';
 import {
   getDelegationPDA,
@@ -70,6 +71,9 @@ import {
   getWithdrawalCounterPDA,
   getWithdrawalPDA,
 } from './pda.js';
+import { isRetryableError, withRetry } from './retry.js';
+
+const logger = Logger.default;
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -770,6 +774,44 @@ const ADDRESS_DECODER = getAddressDecoder();
 /** Solana caps `getMultipleAccounts` at 100 keys per request. */
 const ACCOUNT_BATCH_SIZE = 100;
 
+/**
+ * Decide what an errored discovery query should return.
+ *
+ * These queries used to swallow EVERY failure and return `[]`, which made a
+ * transient rate-limit indistinguishable from "this wallet has no delegations".
+ * The planner would then build a plan from incomplete sources and quietly
+ * under-fund it — no error, no log, on the path that pays for ArNS purchases.
+ * Observed live: a burst of 429s from public devnet turned a wallet holding
+ * seven delegations into one reporting none.
+ *
+ * The empty-list fallback exists for a real case — many public RPCs disable
+ * `getProgramAccounts` outright — so it is kept for errors that are genuinely
+ * permanent, and now says so out loud. Transient failures (429/5xx/network)
+ * have already been retried by {@link withRetry} at the call site by the time
+ * they reach here, so they are surfaced instead of being reported as "no
+ * funds": a caller can retry or pass explicit `sources`, but it must not be
+ * told zero when the truth is unknown.
+ */
+function handleDiscoveryFailure(what: string, err: unknown): never[] {
+  if (isRetryableError(err)) {
+    throw new Error(
+      `Funding-source discovery (${what}) failed after retries: ${
+        err instanceof Error ? err.message : String(err)
+      }. Refusing to report zero sources for a transient failure — that would ` +
+        'silently under-fund the plan. Retry, or pass explicit `sources` to ' +
+        'skip discovery.',
+      { cause: err },
+    );
+  }
+  logger.warn(
+    `[funding-plan] ${what} discovery unavailable — continuing without those ` +
+      'sources. This is expected when the RPC disables getProgramAccounts; ' +
+      'pass explicit `sources` for a complete plan.',
+    { error: err instanceof Error ? err.message : String(err) },
+  );
+  return [];
+}
+
 async function fetchUserWithdrawals(
   rpc: FundingPlanRpc,
   owner: Address,
@@ -790,17 +832,21 @@ async function fetchUserWithdrawals(
   //   107..108 bump: u8
   //   108..111 version: SchemaVersion { major, minor, patch }
   try {
-    const result = await rpc
-      .getProgramAccounts(garProgram, {
-        filters: [
-          {
-            memcmp: { offset: 8n, bytes: owner, encoding: 'base58' as const },
-          },
-          { dataSize: BigInt(8 + 32 + 8 + 32 + 8 + 8 + 8 + 1 + 1 + 1 + 1 + 3) },
-        ],
-        encoding: 'base64',
-      } as Parameters<typeof rpc.getProgramAccounts>[1])
-      .send();
+    const result = await withRetry(() =>
+      rpc
+        .getProgramAccounts(garProgram, {
+          filters: [
+            {
+              memcmp: { offset: 8n, bytes: owner, encoding: 'base58' as const },
+            },
+            {
+              dataSize: BigInt(8 + 32 + 8 + 32 + 8 + 8 + 8 + 1 + 1 + 1 + 1 + 3),
+            },
+          ],
+          encoding: 'base64',
+        } as Parameters<typeof rpc.getProgramAccounts>[1])
+        .send(),
+    );
     const out: DiscoveredFundingSource[] = [];
     for (const entry of result as unknown as Array<{
       account: { data: [string, string] };
@@ -828,9 +874,8 @@ async function fetchUserWithdrawals(
       });
     }
     return out;
-  } catch {
-    // RPC doesn't support getProgramAccounts — caller must pass explicit sources.
-    return [];
+  } catch (err) {
+    return handleDiscoveryFailure('withdrawal vault', err);
   }
 }
 
@@ -849,17 +894,23 @@ async function fetchUserDelegations(
   //   104..105 bump: u8
   //   105..108 version: SchemaVersion { major, minor, patch }
   try {
-    const result = await rpc
-      .getProgramAccounts(garProgram, {
-        filters: [
-          {
-            memcmp: { offset: 40n, bytes: owner, encoding: 'base58' as const },
-          },
-          { dataSize: BigInt(8 + 32 + 32 + 8 + 8 + 16 + 1 + 3) },
-        ],
-        encoding: 'base64',
-      } as Parameters<typeof rpc.getProgramAccounts>[1])
-      .send();
+    const result = await withRetry(() =>
+      rpc
+        .getProgramAccounts(garProgram, {
+          filters: [
+            {
+              memcmp: {
+                offset: 40n,
+                bytes: owner,
+                encoding: 'base58' as const,
+              },
+            },
+            { dataSize: BigInt(8 + 32 + 32 + 8 + 8 + 16 + 1 + 3) },
+          ],
+          encoding: 'base64',
+        } as Parameters<typeof rpc.getProgramAccounts>[1])
+        .send(),
+    );
     // Decode every delegation FIRST, then resolve gateway metadata for the
     // whole set in one batch. Doing it inline cost a full round trip per
     // delegation, serialized — 120 delegations meant 120 sequential
@@ -903,8 +954,8 @@ async function fetchUserDelegations(
         startTimestamp,
       };
     });
-  } catch {
-    return [];
+  } catch (err) {
+    return handleDiscoveryFailure('delegation', err);
   }
 }
 
@@ -964,7 +1015,7 @@ async function fetchGatewayMetas(
     chunks.push({ start: i, pdas: pdas.slice(i, i + ACCOUNT_BATCH_SIZE) });
 
   const fetched = await Promise.all(
-    chunks.map((c) => fetchEncodedAccounts(rpc, c.pdas)),
+    chunks.map((c) => withRetry(() => fetchEncodedAccounts(rpc, c.pdas))),
   );
 
   chunks.forEach((chunk, ci) => {

--- a/src/solana/io-readable.test.ts
+++ b/src/solana/io-readable.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import {
   PurchaseType,
   getArnsRecordEncoder,
+  getDemandFactorEncoder,
 } from '@ar.io/solana-contracts/arns';
 import { getArioConfigEncoder } from '@ar.io/solana-contracts/core';
 import { getGatewaySettingsEncoder } from '@ar.io/solana-contracts/gar';
@@ -424,6 +425,251 @@ describe('getArioMint', () => {
     await assert.rejects(
       () => readable.readArioMint(),
       /ArioConfig not found at .* on coreProgram/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Request coalescing (single-flight caches)
+//
+// These caches used to store the RESOLVED value, so they only helped
+// SEQUENTIAL callers: a concurrent burst all missed before any of them filled
+// the cache. The burst is precisely the case worth collapsing — a price table
+// quoting every row at once — so each test below drives CONCURRENT callers and
+// asserts the underlying RPC ran once.
+// ---------------------------------------------------------------------------
+
+type RpcCounts = Record<string, number>;
+
+/**
+ * Stub responses resolve after a tick rather than instantly. With an instant
+ * stub the first request settles before the other callers reach the cache, so
+ * the burst is not actually concurrent and the test would prove nothing.
+ */
+const tick = () => new Promise((r) => setTimeout(r, 5));
+
+/** A valid DemandFactor account, so getTokenCost gets past deserialization. */
+function demandFactorBytes(): Uint8Array {
+  return getDemandFactorEncoder().encode({
+    currentDemandFactor: 1_000_000,
+    currentPeriod: 1,
+    purchasesThisPeriod: 0,
+    revenueThisPeriod: 0,
+    consecutivePeriodsWithMinDemandFactor: 0,
+    trailingPeriodPurchases: Array(7).fill(0),
+    trailingPeriodRevenues: Array(7).fill(0),
+    fees: Array(51).fill(1_000_000),
+    periodZeroStartTimestamp: 1_700_000_000,
+    criteria: 0,
+    bump: 255,
+    version: VERSION,
+  }) as Uint8Array;
+}
+
+/**
+ * Stub rpc that counts every method and can be told to fail the first N calls
+ * to a given method (for the "a failure must not be cached" case).
+ */
+function countingGasRpc(
+  counts: RpcCounts,
+  opts: { failFeeCalls?: number; accountExists?: boolean } = {},
+) {
+  let feeFailuresLeft = opts.failFeeCalls ?? 0;
+  const bump = (m: string) => {
+    counts[m] = (counts[m] ?? 0) + 1;
+  };
+  return {
+    getRecentPrioritizationFees: () => ({
+      send: async () => {
+        bump('getRecentPrioritizationFees');
+        await tick();
+        if (feeFailuresLeft > 0) {
+          feeFailuresLeft--;
+          throw new Error('HTTP error (429): Too Many Requests');
+        }
+        return [{ slot: 1n, prioritizationFee: 12_345n }];
+      },
+    }),
+    getMinimumBalanceForRentExemption: () => ({
+      send: async () => {
+        bump('getMinimumBalanceForRentExemption');
+        await tick();
+        return 2_000_000n;
+      },
+    }),
+    getSlot: () => ({
+      send: async () => {
+        bump('getSlot');
+        await tick();
+        return 500n;
+      },
+    }),
+    getBlockTime: () => ({
+      send: async () => {
+        bump('getBlockTime');
+        await tick();
+        return 1_760_000_000n;
+      },
+    }),
+    getAccountInfo: () => ({
+      send: async () => {
+        bump('getAccountInfo');
+        await tick();
+        return opts.accountExists === false
+          ? { value: null }
+          : {
+              value: {
+                data: [
+                  Buffer.from(demandFactorBytes()).toString('base64'),
+                  'base64',
+                ] as readonly [string, string],
+                executable: false,
+                lamports: 1_000_000n,
+                owner: OWNER_ADDR,
+                rentEpoch: 0n,
+                space: 512n,
+              },
+            };
+      },
+    }),
+  };
+}
+
+describe('SolanaARIOReadable request coalescing', () => {
+  it('collapses a concurrent getGasEstimate burst onto one priority-fee query set', async () => {
+    const counts: RpcCounts = {};
+    const readable = new SolanaARIOReadable({
+      rpc: countingGasRpc(counts) as never,
+      logger: new Logger({ level: 'none' }),
+    });
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        readable.getGasEstimate({ intent: 'Buy-Name', name: 'x' }),
+      ),
+    );
+
+    // One quote costs three queries: an unscoped sample plus two scoped
+    // market references. Ten concurrent quotes must still cost three.
+    assert.equal(
+      counts.getRecentPrioritizationFees,
+      3,
+      'ten concurrent quotes should share one priority-fee estimate',
+    );
+    assert.equal(
+      counts.getMinimumBalanceForRentExemption,
+      1,
+      'rent for an identical account profile should be quoted once',
+    );
+    // Every caller must still get the same complete answer.
+    for (const r of results) {
+      assert.deepEqual(r, results[0]);
+      assert.ok(r.totalLamports > 0);
+    }
+  });
+
+  it('collapses a concurrent getTokenCost burst onto one cluster-clock read', async () => {
+    const counts: RpcCounts = {};
+    const readable = new SolanaARIOReadable({
+      rpc: countingGasRpc(counts) as never,
+      logger: new Logger({ level: 'none' }),
+    });
+
+    await Promise.allSettled(
+      Array.from({ length: 10 }, (_, i) =>
+        readable.getTokenCost({
+          intent: 'Buy-Name',
+          name: `burst-${i}`,
+          type: 'lease',
+          years: 1,
+        }),
+      ),
+    );
+
+    // getSlot -> getBlockTime is two SEQUENTIAL round trips, and getTokenCost
+    // used to pay them on EVERY quote — 20 calls for a ten-row price table.
+    assert.equal(counts.getSlot, 1, 'one slot read for the whole burst');
+    assert.equal(counts.getBlockTime, 1, 'one block-time read for the burst');
+
+    // Ten DIFFERENT names still cost ten per-name lookups; only the shared
+    // DemandFactor PDA collapses. Coalescing dedupes identical requests, it
+    // does not eliminate genuinely distinct ones.
+    assert.equal(
+      counts.getAccountInfo,
+      11,
+      'one shared DemandFactor read plus one lookup per distinct name',
+    );
+  });
+
+  it('collapses repeated reads of the SAME name to a single lookup', async () => {
+    const counts: RpcCounts = {};
+    const readable = new SolanaARIOReadable({
+      rpc: countingGasRpc(counts) as never,
+      logger: new Logger({ level: 'none' }),
+    });
+
+    await Promise.allSettled(
+      Array.from({ length: 10 }, () =>
+        readable.getTokenCost({
+          intent: 'Buy-Name',
+          name: 'same-name',
+          type: 'lease',
+          years: 1,
+        }),
+      ),
+    );
+
+    assert.equal(counts.getSlot, 1);
+    assert.equal(counts.getBlockTime, 1);
+    assert.ok(
+      counts.getAccountInfo <= 2,
+      `ten quotes for one name should share their reads, saw ${counts.getAccountInfo}`,
+    );
+  });
+
+  it('does not cache a failed priority-fee estimate', async () => {
+    const counts: RpcCounts = {};
+    const readable = new SolanaARIOReadable({
+      // Fail every query of the first estimate (3 queries), then succeed.
+      rpc: countingGasRpc(counts, { failFeeCalls: 3 }) as never,
+      logger: new Logger({ level: 'none' }),
+    });
+
+    // The fee estimator swallows per-query failures and falls back to its
+    // floor, so the first quote still resolves — what matters is that the
+    // NEXT quote re-queries rather than reusing a degraded cached value.
+    const first = await readable.getGasEstimate({ intent: 'Buy-Name' });
+    assert.equal(counts.getRecentPrioritizationFees, 3);
+
+    const second = await readable.getGasEstimate({ intent: 'Buy-Name' });
+    assert.equal(
+      counts.getRecentPrioritizationFees,
+      3,
+      'a successful estimate is still cached for its TTL',
+    );
+    assert.ok(first.priorityFeeMicroLamports >= 0);
+    assert.ok(second.priorityFeeMicroLamports >= 0);
+  });
+
+  it('shares one lookup for a MISSING account but does not cache the miss', async () => {
+    const counts: RpcCounts = {};
+    const readable = new SolanaARIOReadable({
+      rpc: countingGasRpc(counts, { accountExists: false }) as never,
+      logger: new Logger({ level: 'none' }),
+    });
+
+    // getDemandFactor reads through the cached-account path; a missing
+    // account throws, and must not be remembered as a miss.
+    await Promise.allSettled(
+      Array.from({ length: 5 }, () => readable.getDemandFactor()),
+    );
+    assert.equal(counts.getAccountInfo, 1, 'the burst shares one lookup');
+
+    await assert.rejects(() => readable.getDemandFactor());
+    assert.equal(
+      counts.getAccountInfo,
+      2,
+      'a miss must not be cached — the next caller re-checks',
     );
   });
 });

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -119,6 +119,10 @@ import { SolanaANTReadable } from './ant-readable.js';
 import { SolanaANTRegistryReadable } from './ant-registry-readable.js';
 import { getAssociatedTokenAddressKit } from './ata.js';
 import {
+  ACCOUNT_FETCH_CONCURRENCY,
+  mapWithConcurrency,
+} from './concurrency.js';
+import {
   ARIO_ANT_PROGRAM_ID,
   ARIO_ARNS_PROGRAM_ID,
   ARIO_CORE_PROGRAM_ID,
@@ -724,17 +728,29 @@ export class SolanaARIOReadable {
     const unique = Array.from(new Set(operatorAddresses));
     if (unique.length === 0) return new Map();
     const out = new Map<string, bigint>();
-    for (const group of chunk(unique, 100)) {
-      const pdas = await Promise.all(
-        group.map(
-          async (op) => (await getGatewayPDA(address(op), this.garProgram))[0],
-        ),
-      );
-      const accounts = await withRetry(() =>
-        fetchEncodedAccounts(this.rpc, pdas, {
-          commitment: this.commitment,
-        }),
-      );
+    const groups = chunk(unique, 100);
+    // Chunks run in a bounded pool rather than one-after-another; results are
+    // still consumed in input order, so `group[i]` keeps pairing with the
+    // right operator.
+    const perGroup = await mapWithConcurrency(
+      groups,
+      ACCOUNT_FETCH_CONCURRENCY,
+      async (group) => {
+        const pdas = await Promise.all(
+          group.map(
+            async (op) =>
+              (await getGatewayPDA(address(op), this.garProgram))[0],
+          ),
+        );
+        return withRetry(() =>
+          fetchEncodedAccounts(this.rpc, pdas, {
+            commitment: this.commitment,
+          }),
+        );
+      },
+    );
+    groups.forEach((group, gi) => {
+      const accounts = perGroup[gi];
       for (let i = 0; i < accounts.length; i++) {
         const acct = accounts[i];
         if (!acct.exists) continue;
@@ -748,7 +764,7 @@ export class SolanaARIOReadable {
           // Skip malformed; the caller will fall back to the raw delegation amount.
         }
       }
-    }
+    });
     return out;
   }
 
@@ -1192,19 +1208,31 @@ export class SolanaARIOReadable {
     }
 
     // Batch fetch gateway PDAs (kit has no hard limit but keep 100-at-a-time
-    // for sensible RPC request sizes).
+    // for sensible RPC request sizes). Chunks run in a bounded pool; the
+    // results are appended in chunk order so registry ordering is preserved
+    // for callers that pass no `sortBy`.
     const allItems: GatewayWithAddress[] = [];
-    for (let i = 0; i < gatewayAddresses.length; i += 100) {
-      const batch = gatewayAddresses.slice(i, i + 100);
-      const pdas = await Promise.all(
-        batch.map(
-          async (addr) => (await getGatewayPDA(addr, this.garProgram))[0],
-        ),
-      );
-      const accounts = await fetchEncodedAccounts(this.rpc, pdas, {
-        commitment: this.commitment,
-      });
+    const batches = chunk(gatewayAddresses, 100);
+    const perBatch = await mapWithConcurrency(
+      batches,
+      ACCOUNT_FETCH_CONCURRENCY,
+      async (batch) => {
+        const pdas = await Promise.all(
+          batch.map(
+            async (addr) => (await getGatewayPDA(addr, this.garProgram))[0],
+          ),
+        );
+        // Retried like every other batched read: raising concurrency without
+        // this would turn a transient 429 into a hard failure.
+        return withRetry(() =>
+          fetchEncodedAccounts(this.rpc, pdas, {
+            commitment: this.commitment,
+          }),
+        );
+      },
+    );
 
+    for (const accounts of perBatch) {
       for (const acct of accounts) {
         if (!acct.exists) continue;
         try {

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -188,6 +188,7 @@ import {
   estimateGasFee,
   estimateQuotePriorityFeeMicroLamports,
 } from './send.js';
+import { type InFlightStore, memoizeInFlight } from './single-flight.js';
 import type { SolanaReadConfig, SolanaRpc } from './types.js';
 
 const addressDecoder = getAddressDecoder();
@@ -293,6 +294,16 @@ const CONFIG_CACHE_TTL_MS = 30_000;
  * `getRecentPrioritizationFees` for every name.
  */
 const PRIORITY_FEE_CACHE_TTL_MS = 10_000;
+
+/**
+ * TTL for the memoized cluster clock (`getSlot` → `getBlockTime`).
+ *
+ * Deliberately short. The expensive case is a burst — a price table quoting
+ * every row at once — and the in-flight coalescing handles that regardless of
+ * TTL. Keeping the ceiling at one second means a UI that ticks a Dutch-auction
+ * price per second still sees it move.
+ */
+const CLUSTER_CLOCK_CACHE_TTL_MS = 1_000;
 
 /**
  * Resolve a `SortBy<T>` key against an item. `SortBy<T>` is `NestedKeys<T>`, so
@@ -501,29 +512,38 @@ export class SolanaARIOReadable {
   protected readonly arnsProgram: Address;
   protected readonly antProgram: Address;
 
+  // NOTE: every cache below stores the in-flight PROMISE rather than the
+  // resolved value (see `./single-flight.ts`). Storing the value only ever
+  // helped sequential callers — a burst of concurrent callers all miss before
+  // any of them fills the cache, so all of them hit the network, which is the
+  // exact case these caches exist to collapse.
+
   // Memoized ARIO mint address (read once from ArioConfig.mint and reused
-  // for every SPL-ATA derivation in getBalance/getBalances).
-  private _arioMint?: Address;
+  // for every SPL-ATA derivation in getBalance/getBalances). Never expires:
+  // the mint is fixed once the protocol is deployed.
+  private _arioMintCache: InFlightStore<'mint', Address> = new Map();
 
   // Short-TTL cache for slow-changing config-ish accounts (DemandFactor,
   // ArnsConfig, etc.). Collapses the many identical reads a UI fires in a
   // burst — e.g. the returned-names page running `getCostDetails` per row,
   // each re-reading the same DemandFactor PDA — into a single network call.
-  private _accountCache = new Map<
+  private _accountCache: InFlightStore<
     string,
-    {
-      account: Awaited<ReturnType<SolanaARIOReadable['getAccount']>>;
-      expiresAt: number;
-    }
-  >();
+    Awaited<ReturnType<SolanaARIOReadable['getAccount']>>
+  > = new Map();
 
   // Short-TTL memo of the estimated compute-unit price (priority fee), so
   // burst `getCostDetails` calls share one getRecentPrioritizationFees query.
-  private _priorityFeeCache?: { microLamports: bigint; expiresAt: number };
+  private _priorityFeeCache: InFlightStore<'fee', bigint> = new Map();
 
   // Memo of getMinimumBalanceForRentExemption results keyed by byte size.
   // Rent parameters are cluster constants in practice, so no TTL.
-  private _rentCache = new Map<number, number>();
+  private _rentCache: InFlightStore<number, number> = new Map();
+
+  // Short-TTL memo of the cluster clock (getSlot + getBlockTime). Kept brief:
+  // the in-flight coalescing is what collapses a price table's burst, while a
+  // 1s ceiling keeps a per-second auction UI honest.
+  private _clusterClockCache: InFlightStore<'clock', number> = new Map();
 
   constructor(
     config: SolanaReadConfig & {
@@ -541,6 +561,25 @@ export class SolanaARIOReadable {
     this.garProgram = config.garProgramId ?? ARIO_GAR_PROGRAM_ID;
     this.arnsProgram = config.arnsProgramId ?? ARIO_ARNS_PROGRAM_ID;
     this.antProgram = config.antProgramId ?? ARIO_ANT_PROGRAM_ID;
+  }
+
+  /**
+   * Quote-grade compute-unit price, memoized for
+   * {@link PRIORITY_FEE_CACHE_TTL_MS}.
+   *
+   * "Quote-grade" means it covers what a browser wallet will attach, not just
+   * the near-floor base rate a keypair send pays. Each miss costs THREE
+   * `getRecentPrioritizationFees` queries (one unscoped plus two scoped market
+   * references) at ~6.6 KiB apiece, which is why coalescing matters here more
+   * than anywhere else: ten concurrent quotes used to issue thirty of them.
+   */
+  private async getQuotePriorityFee(): Promise<bigint> {
+    return memoizeInFlight(
+      this._priorityFeeCache,
+      'fee',
+      PRIORITY_FEE_CACHE_TTL_MS,
+      () => estimateQuotePriorityFeeMicroLamports(this.rpc),
+    );
   }
 
   /** Helper to fetch an encoded account (kit's replacement for Connection.getAccountInfo). */
@@ -562,15 +601,15 @@ export class SolanaARIOReadable {
     pda: Address,
     ttlMs = CONFIG_CACHE_TTL_MS,
   ): Promise<Awaited<ReturnType<SolanaARIOReadable['getAccount']>>> {
-    const key = String(pda);
-    const now = Date.now();
-    const hit = this._accountCache.get(key);
-    if (hit && hit.expiresAt > now) return hit.account;
-    const account = await this.getAccount(pda);
-    if (account.exists) {
-      this._accountCache.set(key, { account, expiresAt: now + ttlMs });
-    }
-    return account;
+    return memoizeInFlight(
+      this._accountCache,
+      String(pda),
+      ttlMs,
+      () => this.getAccount(pda),
+      // Misses stay uncached, exactly as before — but a concurrent burst of
+      // callers still shares the single lookup that discovers the miss.
+      (account) => account.exists,
+    );
   }
 
   /**
@@ -588,18 +627,34 @@ export class SolanaARIOReadable {
    * Sourced via the latest slot's block time (`getSlot` → `getBlockTime`),
    * which the runtime derives from the same stake-weighted clock the on-chain
    * `Clock` sysvar exposes. Read-only: no signer, no transaction.
+   *
+   * Memoized for {@link CLUSTER_CLOCK_CACHE_TTL_MS}: this costs TWO sequential
+   * round trips (the block time needs the slot), and `getTokenCost` calls it on
+   * every quote — so a price table paid 2N calls for a value that advances in
+   * real time anyway. Staleness here is directionally safe: an older clock
+   * means less elapsed auction time, which OVER-quotes the returned-name
+   * premium rather than under-quoting it.
    */
   private async getClusterUnixTimestampSeconds(): Promise<number> {
-    const slot = await withRetry(() =>
-      this.rpc.getSlot({ commitment: this.commitment }).send(),
+    return memoizeInFlight(
+      this._clusterClockCache,
+      'clock',
+      CLUSTER_CLOCK_CACHE_TTL_MS,
+      async () => {
+        const slot = await withRetry(() =>
+          this.rpc.getSlot({ commitment: this.commitment }).send(),
+        );
+        const blockTime = await withRetry(() =>
+          this.rpc.getBlockTime(slot).send(),
+        );
+        if (blockTime == null) {
+          throw new Error(
+            `Cluster block time unavailable for slot ${slot}; cannot match on-chain Clock::get().unix_timestamp`,
+          );
+        }
+        return Number(blockTime);
+      },
     );
-    const blockTime = await withRetry(() => this.rpc.getBlockTime(slot).send());
-    if (blockTime == null) {
-      throw new Error(
-        `Cluster block time unavailable for slot ${slot}; cannot match on-chain Clock::get().unix_timestamp`,
-      );
-    }
-    return Number(blockTime);
   }
 
   /**
@@ -918,17 +973,22 @@ export class SolanaARIOReadable {
    * protocol is deployed.
    */
   protected async getArioMint(): Promise<Address> {
-    if (this._arioMint) return this._arioMint;
-    const [configPda] = await getArioConfigPDA(this.coreProgram);
-    const account = await this.getAccount(configPda);
-    if (!account.exists) {
-      throw new Error(
-        `ArioConfig not found at ${configPda} on coreProgram ${this.coreProgram} — is the program deployed and initialized?`,
-      );
-    }
-    const { mint } = deserializeArioConfig(Buffer.from(account.data));
-    this._arioMint = mint;
-    return mint;
+    return memoizeInFlight(
+      this._arioMintCache,
+      'mint',
+      Number.POSITIVE_INFINITY,
+      async () => {
+        const [configPda] = await getArioConfigPDA(this.coreProgram);
+        const account = await this.getAccount(configPda);
+        if (!account.exists) {
+          throw new Error(
+            `ArioConfig not found at ${configPda} on coreProgram ${this.coreProgram} — is the program deployed and initialized?`,
+          );
+        }
+        const { mint } = deserializeArioConfig(Buffer.from(account.data));
+        return mint;
+      },
+    );
   }
 
   /**
@@ -2053,15 +2113,7 @@ export class SolanaARIOReadable {
       computeUnitLimit?: number;
     } = {},
   ): Promise<GasEstimate> {
-    const now = Date.now();
-    if (!this._priorityFeeCache || this._priorityFeeCache.expiresAt <= now) {
-      this._priorityFeeCache = {
-        // Quote-grade rate: covers what a browser wallet will attach, not
-        // just the (near-floor) base estimate keypair sends pay.
-        microLamports: await estimateQuotePriorityFeeMicroLamports(this.rpc),
-        expiresAt: now + PRIORITY_FEE_CACHE_TTL_MS,
-      };
-    }
+    const priorityFeeMicroLamports = await this.getQuotePriorityFee();
 
     // Conditional accounts: only created when the buyer doesn't already
     // have them. Unknown buyer → assume they're needed (over-quote rather
@@ -2106,18 +2158,19 @@ export class SolanaARIOReadable {
     });
 
     const rentKey = profile.accountBytes.reduce((sum, b) => sum + b, 0);
-    let rentLamports = this._rentCache.get(rentKey);
-    if (rentLamports === undefined) {
-      rentLamports = await estimateRentLamports(this.rpc, profile.accountBytes);
-      this._rentCache.set(rentKey, rentLamports);
-    }
+    const rentLamports = await memoizeInFlight(
+      this._rentCache,
+      rentKey,
+      Number.POSITIVE_INFINITY,
+      () => estimateRentLamports(this.rpc, profile.accountBytes),
+    );
 
     return estimateGasFee(this.rpc, {
       computeUnitLimit: opts.computeUnitLimit,
       signatureCount: profile.signatureCount,
       transactionCount: profile.transactionCount,
       rentLamports,
-      priorityFeeMicroLamports: this._priorityFeeCache.microLamports,
+      priorityFeeMicroLamports,
     });
   }
 
@@ -2156,13 +2209,7 @@ export class SolanaARIOReadable {
     /** decrease-delegate-stake with instant payout (second transaction). */
     instant?: boolean;
   }): Promise<GasEstimate> {
-    const now = Date.now();
-    if (!this._priorityFeeCache || this._priorityFeeCache.expiresAt <= now) {
-      this._priorityFeeCache = {
-        microLamports: await estimateQuotePriorityFeeMicroLamports(this.rpc),
-        expiresAt: now + PRIORITY_FEE_CACHE_TTL_MS,
-      };
-    }
+    const priorityFeeMicroLamports = await this.getQuotePriorityFee();
 
     // Conditional accounts — checked live when the actor is known,
     // conservative (assume creation) otherwise. All best-effort.
@@ -2256,15 +2303,12 @@ export class SolanaARIOReadable {
       profile.accountBytes.reduce((sum, b) => sum + b, 0) +
       reallocBytes +
       profile.accountBytes.length;
-    let rentLamports = this._rentCache.get(rentKey);
-    if (rentLamports === undefined) {
-      rentLamports = await estimateRentLamports(
-        this.rpc,
-        profile.accountBytes,
-        reallocBytes,
-      );
-      this._rentCache.set(rentKey, rentLamports);
-    }
+    const rentLamports = await memoizeInFlight(
+      this._rentCache,
+      rentKey,
+      Number.POSITIVE_INFINITY,
+      () => estimateRentLamports(this.rpc, profile.accountBytes, reallocBytes),
+    );
 
     // Instant decrease: the second transaction immediately closes the
     // vault created by the first — its deposit round-trips back.
@@ -2282,7 +2326,7 @@ export class SolanaARIOReadable {
       transactionCount: profile.transactionCount,
       rentLamports,
       rentReclaimedLamports,
-      priorityFeeMicroLamports: this._priorityFeeCache.microLamports,
+      priorityFeeMicroLamports,
     });
   }
 

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -796,6 +796,22 @@ export class SolanaARIOReadable {
   // Protocol info
   // =========================================
 
+  /**
+   * Protocol info: on-chain supply/balance figures plus static protocol
+   * metadata.
+   *
+   * COSTS TWO ACCOUNT READS (ArioConfig + EpochSettings), which is worth
+   * knowing because only some of the result comes from chain:
+   *
+   * - From chain: `totalSupply`, `protocolBalance`, `epochSettings`.
+   * - Fixed literals: `Ticker` (`'ARIO'`), `Name` (`'AR.IO'`),
+   *   `Denomination` (`6`), `Handlers` (`[]`), `LastCreatedEpochIndex` (`0`).
+   *
+   * If all you need are the literals — a ticker or denomination for display —
+   * don't call this; hard-code them or read {@link TOKEN_DECIMALS}. Two RPC
+   * round trips for a string constant is a poor trade, and callers have
+   * reached for this method not realising that is what they were paying.
+   */
   async getInfo() {
     const [[configPda], [epochSettingsPda]] = await Promise.all([
       getArioConfigPDA(this.coreProgram),

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -801,11 +801,19 @@ export class SolanaARIOReadable {
       const addr = addressDecoder.decode(
         registryData.subarray(slotOffset, slotOffset + 32),
       );
+      // Decode the i64 as two 32-bit halves rather than via
+      // `readBigInt64LE`. Some browser bundlers (notably arns-react's Vite
+      // output) strip the BigInt readers from the `buffer@6.0.3` shim's
+      // prototype — see the same note in `getTokenBalance`. The high word
+      // carries the sign, and a Unix-seconds timestamp is far below
+      // `Number.MAX_SAFE_INTEGER`, so this is exact.
+      const tsOffset = slotOffset + START_TIMESTAMP_OFFSET;
+      const startTimestamp =
+        registryData.readInt32LE(tsOffset + 4) * 2 ** 32 +
+        registryData.readUInt32LE(tsOffset);
       slots.push({
         address: addr as string,
-        startTimestamp: Number(
-          registryData.readBigInt64LE(slotOffset + START_TIMESTAMP_OFFSET),
-        ),
+        startTimestamp,
       });
     }
     return slots;

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -128,6 +128,7 @@ import {
   ARIO_CORE_PROGRAM_ID,
   ARIO_GAR_PROGRAM_ID,
   ARNS_RECORD_ANT_OFFSET,
+  MAX_GATEWAYS,
   RATE_SCALE,
 } from './constants.js';
 import {
@@ -768,8 +769,20 @@ export class SolanaARIOReadable {
     return out;
   }
 
-  /** Read the gateway registry and return addresses in registry index order */
-  protected async getRegistryGatewayAddresses(): Promise<string[]> {
+  /**
+   * Read the gateway registry and return one entry per active slot, in
+   * registry index order.
+   *
+   * `startTimestamp` comes off the same account read as the address — the
+   * on-chain `GatewaySlot` already carries it — so callers that need to tell
+   * "joined during this epoch" from "was here at the snapshot" pay no extra
+   * RPC for it. Seconds since epoch, matching every other raw on-chain
+   * timestamp (the friendly `getGateway()` view is the one that converts to
+   * milliseconds).
+   */
+  protected async getRegistryGatewaySlots(): Promise<
+    Array<{ address: string; startTimestamp: number }>
+  > {
     const [registryPda] = await getGatewayRegistryPDA(this.garProgram);
     const registryAccount = await this.getAccount(registryPda);
     if (!registryAccount.exists) return [];
@@ -781,15 +794,26 @@ export class SolanaARIOReadable {
     //            + status(1) + _padding(7) = 56 bytes (see ario-gar
     //            state/mod.rs::GatewaySlot).
     const SLOT_STRIDE = 56;
-    const addresses: string[] = [];
-    for (let i = 0; i < count && i < 3000; i++) {
+    const START_TIMESTAMP_OFFSET = 40; // 32 address + 8 composite_weight
+    const slots: Array<{ address: string; startTimestamp: number }> = [];
+    for (let i = 0; i < count && i < MAX_GATEWAYS; i++) {
       const slotOffset = slotsOffset + i * SLOT_STRIDE;
       const addr = addressDecoder.decode(
         registryData.subarray(slotOffset, slotOffset + 32),
       );
-      addresses.push(addr as string);
+      slots.push({
+        address: addr as string,
+        startTimestamp: Number(
+          registryData.readBigInt64LE(slotOffset + START_TIMESTAMP_OFFSET),
+        ),
+      });
     }
-    return addresses;
+    return slots;
+  }
+
+  /** Read the gateway registry and return addresses in registry index order */
+  protected async getRegistryGatewayAddresses(): Promise<string[]> {
+    return (await this.getRegistryGatewaySlots()).map((s) => s.address);
   }
 
   // =========================================
@@ -1822,7 +1846,7 @@ export class SolanaARIOReadable {
   }
 
   /** Fetch and deserialize an Epoch account by index */
-  private async fetchEpoch(epochIndex: number) {
+  protected async fetchEpoch(epochIndex: number) {
     const [pda] = await getEpochPDA(epochIndex, this.garProgram);
     const account = await this.getAccount(pda);
     if (!account.exists) {

--- a/src/solana/io-readable.ts
+++ b/src/solana/io-readable.ts
@@ -1813,7 +1813,7 @@ export class SolanaARIOReadable {
    * - { epochIndex }: returns directly
    * - { timestamp }: computes from genesis timestamp and epoch duration
    */
-  private async resolveEpochIndex(epoch?: EpochInput): Promise<number> {
+  protected async resolveEpochIndex(epoch?: EpochInput): Promise<number> {
     if (epoch && 'epochIndex' in epoch) {
       return epoch.epochIndex;
     }

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -359,10 +359,27 @@ export function selectFinalizeGoneSwapOperator(
 //   - report_tx_id:    [u8; 32]    raw 32-byte Arweave hash (base64url
 //                                  decoded from its 43-char string form).
 
-/** Build the gateway_results bitmap for save_observations.
- *  All bits start as 1 (pass) for the first `registryAddresses.length`
- *  positions; positions named in `failedGateways` get cleared to 0; all
- *  positions beyond `registryAddresses.length` are 0. */
+/**
+ * Build the `gateway_results` bitmap for `save_observations`.
+ *
+ * The bitmap is **positional**: bit `i` is the verdict on the gateway
+ * occupying registry slot `i`, so `registryAddresses` must be the registry in
+ * slot order (`getRegistryGatewaySlots()`), not a sorted or filtered list.
+ * Bits start set (1 = passed), positions named in `failedGateways` are cleared
+ * to 0, and every position at or beyond `activeGatewayCount` is cleared.
+ *
+ * @param registryAddresses - Registry operator addresses in slot order. May be
+ *   longer than `activeGatewayCount` when gateways joined mid-epoch; the extra
+ *   trailing slots are ignored.
+ * @param failedGateways - Addresses to mark failed. Entries not present in
+ *   `registryAddresses` are ignored.
+ * @param activeGatewayCount - The epoch's frozen `active_gateway_count`, which
+ *   is the value the on-chain handler validates `gateway_count` against and the
+ *   point past which trailing bits are cleared. Defaults to the registry length
+ *   for callers that have already truncated it themselves. Passing the LIVE
+ *   registry length for an epoch whose snapshot is smaller produces a bitmap
+ *   the chain rejects — see {@link resolveObservationGatewayCount}.
+ */
 export function buildObservationBitmap(
   registryAddresses: string[],
   failedGateways: string[],

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -207,7 +207,11 @@ import {
 } from '@ar.io/solana-contracts/gar';
 import { getTransferCheckedInstruction } from '@solana-program/token';
 import { SolanaANTRegistryWriteable } from './ant-registry-writeable.js';
-import { ARIO_ANT_PROGRAM_ID, TOKEN_DECIMALS } from './constants.js';
+import {
+  ARIO_ANT_PROGRAM_ID,
+  MAX_GATEWAYS,
+  TOKEN_DECIMALS,
+} from './constants.js';
 import { SolanaARIOReadable } from './io-readable.js';
 import {
   getAntAuthorityPDA,
@@ -362,6 +366,7 @@ export function selectFinalizeGoneSwapOperator(
 export function buildObservationBitmap(
   registryAddresses: string[],
   failedGateways: string[],
+  activeGatewayCount: number = registryAddresses.length,
 ): Buffer {
   const buf = Buffer.alloc(375, 0xff);
   const failedSet = new Set(failedGateways);
@@ -372,10 +377,84 @@ export function buildObservationBitmap(
   }
   // Clear bits beyond the active gateway count so the bitmap is exactly
   // the prescribed shape (1s only at indices < gatewayCount that passed).
-  for (let i = registryAddresses.length; i < 3000; i++) {
+  //
+  // `activeGatewayCount` is the EPOCH's frozen count, which can be smaller
+  // than the live registry when gateways joined mid-epoch. The on-chain
+  // handler only reads bits below `gateway_count`, but leaving stale 1s
+  // above it would make two submissions of the same report differ byte for
+  // byte depending on when the registry was read — so normalize here.
+  for (let i = activeGatewayCount; i < MAX_GATEWAYS; i++) {
     buf[Math.floor(i / 8)] &= ~(1 << (i % 8));
   }
   return buf;
+}
+
+/**
+ * Reconcile the live gateway registry against the epoch's frozen snapshot so
+ * `save_observations` reports the count the on-chain handler expects.
+ *
+ * The observation bitmap is POSITIONAL: bit `i` is the verdict on the gateway
+ * occupying registry slot `i`. The chain validates the submitted
+ * `gateway_count` against `Epoch.active_gateway_count` — the value frozen when
+ * the epoch was created — and rejects any mismatch with
+ * `InvalidObservation` (6041, `ario-gar/src/instructions/observation.rs`).
+ * Reading the count off the LIVE registry therefore breaks every observer for
+ * the whole epoch as soon as one gateway joins or leaves mid-epoch.
+ *
+ * Two distinct kinds of mid-epoch churn have to be told apart:
+ *
+ *   - **Joins are safe.** `join_network` appends to the first free slot, and
+ *     with no removals there are no holes, so slots `0..activeGatewayCount`
+ *     still hold exactly the gateways they held at the snapshot. Truncating
+ *     the count is enough.
+ *   - **Removals are NOT safe.** `finalize_gone` reclaims a slot by moving the
+ *     LAST active slot into it, so every index at or after the freed slot can
+ *     now refer to a different gateway. Submitting a positional bitmap built
+ *     over the reordered registry would silently attribute one gateway's
+ *     failures to another — worse than a rejected transaction, because it
+ *     lands.
+ *
+ * A removal is detectable without any extra RPC: with only appends, the live
+ * length is exactly the snapshot plus however many slots carry a
+ * `startTimestamp` after the epoch began. Any shortfall means at least one
+ * slot was reclaimed and the positional mapping can no longer be trusted.
+ *
+ * @throws when the registry has been reordered by a removal — callers should
+ *   skip the epoch rather than submit misattributed results.
+ */
+export function resolveObservationGatewayCount(opts: {
+  /** Registry slots in index order (`getRegistryGatewaySlots()`). */
+  registrySlots: Array<{ address: string; startTimestamp: number }>;
+  /** `Epoch.active_gateway_count` — the frozen snapshot the chain checks. */
+  activeGatewayCount: number;
+  /** `Epoch.start_timestamp`, seconds, as stored on chain. */
+  epochStartTimestamp: number;
+  /** Epoch index, for the error message only. */
+  epochIndex: number;
+}): { addresses: string[]; gatewayCount: number } {
+  const { registrySlots, activeGatewayCount, epochStartTimestamp, epochIndex } =
+    opts;
+
+  const joinedMidEpoch = registrySlots.filter(
+    (slot) => slot.startTimestamp > epochStartTimestamp,
+  ).length;
+
+  if (registrySlots.length !== activeGatewayCount + joinedMidEpoch) {
+    throw new Error(
+      `saveObservations: the gateway registry was reordered during epoch ` +
+        `${epochIndex} — it holds ${registrySlots.length} slots but the epoch ` +
+        `snapshot recorded ${activeGatewayCount} and only ${joinedMidEpoch} ` +
+        `joined since it began, so at least one slot was reclaimed by ` +
+        `finalize_gone. The observation bitmap is positional, so submitting ` +
+        `it now would attribute results to the wrong gateways. Skip this ` +
+        `epoch.`,
+    );
+  }
+
+  return {
+    addresses: registrySlots.map((slot) => slot.address),
+    gatewayCount: activeGatewayCount,
+  };
 }
 
 /** Encode an Arweave TX ID into the on-chain `[u8; 32]` slot.
@@ -1476,11 +1555,25 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       resultsBuf.set(params.gatewayResults.subarray(0, 375));
       gatewayCount = params.gatewayCount ?? 0;
     } else {
-      const registryAddresses = await this.getRegistryGatewayAddresses();
-      gatewayCount = registryAddresses.length;
+      // The chain checks the submitted count against the epoch's frozen
+      // `active_gateway_count`, NOT the live registry length — see
+      // resolveObservationGatewayCount for why they diverge and when the
+      // divergence is unsafe rather than merely inconvenient.
+      const [epochData, registrySlots] = await Promise.all([
+        this.fetchEpoch(epochIndex),
+        this.getRegistryGatewaySlots(),
+      ]);
+      const resolved = resolveObservationGatewayCount({
+        registrySlots,
+        activeGatewayCount: epochData.activeGatewayCount,
+        epochStartTimestamp: epochData.startTimestamp,
+        epochIndex,
+      });
+      gatewayCount = resolved.gatewayCount;
       resultsBuf = buildObservationBitmap(
-        registryAddresses,
+        resolved.addresses,
         params.failedGateways,
+        resolved.gatewayCount,
       );
     }
 

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -419,7 +419,11 @@ export function buildObservationBitmap(
  * `startTimestamp` after the epoch began. Any shortfall means at least one
  * slot was reclaimed and the positional mapping can no longer be trusted.
  *
- * @throws when the registry has been reordered by a removal — callers should
+ * Slots stamped with the epoch's exact start second are treated as unsafe
+ * rather than assigned to either side — see the inline note below.
+ *
+ * @throws when the registry has been reordered by a removal, or when a slot's
+ *   join time is indistinguishable from the epoch snapshot — callers should
  *   skip the epoch rather than submit misattributed results.
  */
 export function resolveObservationGatewayCount(opts: {
@@ -434,6 +438,30 @@ export function resolveObservationGatewayCount(opts: {
 }): { addresses: string[]; gatewayCount: number } {
   const { registrySlots, activeGatewayCount, epochStartTimestamp, epochIndex } =
     opts;
+
+  // A slot stamped with the epoch's own start second is genuinely ambiguous.
+  // `create_epoch` freezes `active_gateway_count` at whichever slot it landed
+  // in, and a `join_network` in that same second may have executed either side
+  // of it — the second-resolution timestamps cannot say which. Counting such a
+  // slot as pre-existing would let the arithmetic below balance for a registry
+  // where a reclaimed slot was refilled by that join, which is precisely the
+  // reordering this function exists to catch. Refusing costs one epoch's
+  // observation; guessing wrong writes permanent misattributed results, so
+  // treat ambiguity as unsafe.
+  const ambiguous = registrySlots.filter(
+    (slot) => slot.startTimestamp === epochStartTimestamp,
+  ).length;
+
+  if (ambiguous > 0) {
+    throw new Error(
+      `saveObservations: ${ambiguous} gateway registry slot(s) are stamped ` +
+        `with epoch ${epochIndex}'s exact start second ` +
+        `(${epochStartTimestamp}), so it cannot be determined whether they ` +
+        `were captured by the epoch snapshot or joined immediately after it. ` +
+        `The observation bitmap is positional and a miscount could attribute ` +
+        `results to the wrong gateways, so skip this epoch.`,
+    );
+  }
 
   const joinedMidEpoch = registrySlots.filter(
     (slot) => slot.startTimestamp > epochStartTimestamp,

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -1559,20 +1559,15 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
     },
     _options?: WriteOptions,
   ): Promise<MessageResult> {
-    let epochIndex: number;
-    if (params.epochIndex !== undefined) {
-      epochIndex = params.epochIndex;
-    } else {
-      const [settingsPda] = await getEpochSettingsPDA(this.garProgram);
-      const settingsAccount = await fetchEncodedAccount(this.rpc, settingsPda, {
-        commitment: this.commitment,
-      });
-      if (!settingsAccount.exists) throw new Error('EpochSettings not found');
-      const settings = deserializeEpochSettingsFull(
-        Buffer.from(settingsAccount.data),
-      );
-      epochIndex = settings.currentEpochIndex;
-    }
+    // Defaulting read `EpochSettings.current_epoch_index` directly, but that
+    // field is the NEXT epoch to be created — `create_epoch` increments it
+    // after initializing the PDA — so the observable epoch is one back.
+    // Targeting the raw value aimed every default-path submission at an epoch
+    // that does not exist yet, which is what `ar.io save-observations` does
+    // since the CLI never passes an index. `resolveEpochIndex()` already owns
+    // that adjustment (and the pre-bootstrap floor at 0), so defer to it
+    // rather than keep a second, divergent copy of the rule here.
+    const epochIndex = params.epochIndex ?? (await this.resolveEpochIndex());
 
     // Build the [u8; 375] gateway_results bitfield. On-chain convention:
     //   bit set (1) = passed, bit clear (0) = failed.

--- a/src/solana/rpc-circuit-breaker.test.ts
+++ b/src/solana/rpc-circuit-breaker.test.ts
@@ -254,6 +254,130 @@ describe('createCircuitBreakerRpc', () => {
   });
 });
 
+describe('createCircuitBreakerRpc — adaptive throttle', () => {
+  const servers: Array<{ close: () => Promise<void> }> = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.map((s) => s.close()));
+    servers.length = 0;
+  });
+
+  /** A port with nothing listening, so the primary transport always fails. */
+  async function deadUrl(): Promise<string> {
+    const s = await createStatusMockServer(() => ({ statusCode: 200 }));
+    await s.close();
+    return s.url;
+  }
+
+  /** Drive `concurrency` callers for `ms`, swallowing the expected errors. */
+  async function drive(
+    rpc: ReturnType<typeof createCircuitBreakerRpc>,
+    ms: number,
+    concurrency: number,
+  ) {
+    const stop = Date.now() + ms;
+    await Promise.all(
+      Array.from({ length: concurrency }, async () => {
+        while (Date.now() < stop) {
+          try {
+            await rpc
+              .getSlot()
+              .send({ abortSignal: AbortSignal.timeout(5_000) });
+          } catch {
+            /* 429s and dead-primary errors are the point of these tests */
+          }
+        }
+      }),
+    );
+  }
+
+  it('throttles when the FALLBACK 429s and the circuit is open', async () => {
+    // The existing 429 test pins volumeThreshold high to keep the circuit
+    // CLOSED. That path works: opossum emits `failure`, which feeds the
+    // backoff. When the circuit is OPEN it emits `reject` and calls the
+    // fallback directly — no `failure` — so fallback 429s were invisible to
+    // the throttle and it stayed pinned at the ceiling for as long as the
+    // primary was down.
+    let fallbackHits = 0;
+    const fallback = await createStatusMockServer(() => {
+      fallbackHits++;
+      return { statusCode: 429, headers: { 'retry-after': '1' } };
+    });
+    servers.push(fallback);
+
+    const rpc = createCircuitBreakerRpc({
+      primaryUrl: await deadUrl(),
+      fallbackUrl: fallback.url,
+      circuitBreakerOptions: {
+        volumeThreshold: 1,
+        errorThresholdPercentage: 1,
+        timeout: false,
+        maxRequestsPerSecond: 20,
+        resetTimeout: 60_000,
+      },
+    });
+
+    await drive(rpc, 2_500, 4);
+
+    // At 20 r/s with no backoff this is ~50 requests. Backing off on the
+    // fallback's 429s should keep it far below that.
+    assert.ok(
+      fallbackHits < 20,
+      `fallback took ${fallbackHits} requests in 2.5s — the throttle never ` +
+        'saw its 429s (ceiling 20 r/s would allow ~50)',
+    );
+  });
+
+  it('treats an advertised rps-limit as a ceiling, never as permission to keep going', async () => {
+    // A 429 always means slow down. When the provider advertises a limit far
+    // above our ceiling (api.mainnet-beta.solana.com sends 250 against a
+    // default ceiling of 10) the header path resolved to the ceiling itself,
+    // so the rate never moved.
+    //
+    // `retry-after: 0` is deliberate: the per-429 cooldown otherwise dominates
+    // throughput and masks the rate entirely — measured, an absolute-count
+    // assertion could not tell the two cases apart. Removing the cooldown
+    // leaves throughput governed purely by the adaptive rate, which is what
+    // this bug is about. Compared against the known-good headerless case
+    // rather than an absolute number, so the assertion does not depend on
+    // machine speed.
+    async function hitsOver(headers: Record<string, string>): Promise<number> {
+      let hits = 0;
+      const primary = await createStatusMockServer(() => {
+        hits++;
+        return { statusCode: 429, headers: { 'retry-after': '0', ...headers } };
+      });
+      const fallback = await createStatusMockServer(() => ({
+        statusCode: 429,
+        headers: { 'retry-after': '0' },
+      }));
+      servers.push(primary, fallback);
+      const rpc = createCircuitBreakerRpc({
+        primaryUrl: primary.url,
+        fallbackUrl: fallback.url,
+        circuitBreakerOptions: {
+          volumeThreshold: 100, // keep the circuit closed so the primary keeps 429ing
+          timeout: false,
+          maxRequestsPerSecond: 20,
+          resetTimeout: 60_000,
+        },
+      });
+      await drive(rpc, 3_000, 4);
+      return hits;
+    }
+
+    const headerless = await hitsOver({});
+    const advertised = await hitsOver({ 'x-ratelimit-rps-limit': '250' });
+
+    assert.ok(
+      advertised <= headerless * 2,
+      `429s advertising rps-limit 250 served ${advertised} requests versus ` +
+        `${headerless} for identical headerless 429s — the advertised limit ` +
+        'is holding the rate at the ceiling instead of lowering it',
+    );
+  });
+});
+
 describe('defaultFallbackUrl', () => {
   it('returns devnet URL for devnet primary', () => {
     assert.equal(

--- a/src/solana/rpc-circuit-breaker.test.ts
+++ b/src/solana/rpc-circuit-breaker.test.ts
@@ -378,6 +378,71 @@ describe('createCircuitBreakerRpc — adaptive throttle', () => {
   });
 });
 
+describe('createCircuitBreakerRpc — optional fallback', () => {
+  const servers: Array<{ close: () => Promise<void> }> = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.map((s) => s.close()));
+    servers.length = 0;
+  });
+
+  it('works with no fallbackUrl at all', async () => {
+    const primary = await createStatusMockServer(() => ({
+      statusCode: 200,
+      result: { value: 'primary' },
+    }));
+    servers.push(primary);
+
+    const rpc = createCircuitBreakerRpc({ primaryUrl: primary.url });
+    const r = await rpc
+      .getLatestBlockhash()
+      .send({ abortSignal: AbortSignal.timeout(10_000) });
+    assert.deepStrictEqual(r, { value: 'primary' });
+  });
+
+  it('fails fast instead of routing anywhere when the circuit opens', async () => {
+    // The point of making fallbackUrl optional: a consumer with one endpoint
+    // should be able to decline a fallback rather than be pushed onto public
+    // infrastructure whenever their primary degrades.
+    let primaryHits = 0;
+    const primary = await createStatusMockServer(() => {
+      primaryHits++;
+      return { statusCode: 500 };
+    });
+    servers.push(primary);
+
+    const rpc = createCircuitBreakerRpc({
+      primaryUrl: primary.url,
+      circuitBreakerOptions: {
+        volumeThreshold: 1,
+        errorThresholdPercentage: 1,
+        timeout: false,
+        maxRequestsPerSecond: 50,
+        resetTimeout: 60_000,
+      },
+    });
+
+    // Trip the circuit.
+    for (let i = 0; i < 3; i++) {
+      await assert.rejects(() =>
+        rpc.getSlot().send({ abortSignal: AbortSignal.timeout(5_000) }),
+      );
+    }
+    const hitsWhenOpen = primaryHits;
+
+    // Open circuit: the call must reject rather than resolve via some other
+    // endpoint, and must not keep hammering the primary either.
+    await assert.rejects(() =>
+      rpc.getSlot().send({ abortSignal: AbortSignal.timeout(5_000) }),
+    );
+    assert.equal(
+      primaryHits,
+      hitsWhenOpen,
+      'an open circuit should not forward to the primary',
+    );
+  });
+});
+
 describe('defaultFallbackUrl', () => {
   it('returns devnet URL for devnet primary', () => {
     assert.equal(

--- a/src/solana/rpc-circuit-breaker.ts
+++ b/src/solana/rpc-circuit-breaker.ts
@@ -296,14 +296,25 @@ export function createCircuitBreakerRpc({
     if (!headers) return; // only adapt to rate-limit (429) failures
     successStreak = 0;
 
+    // A 429 ALWAYS means slow down, so an advertised limit may only pull the
+    // rate further DOWN — it must never hold it up.
+    //
+    // This used to be `min(ceiling, advertised * SAFETY)`, which resolves to
+    // the ceiling itself whenever the provider advertises a limit above ours.
+    // api.mainnet-beta.solana.com sends `x-ratelimit-rps-limit: 250` against a
+    // default ceiling of 10, so the header path was a no-op there: the rate
+    // stayed pinned at the ceiling and only the cooldown applied. Measured
+    // with the cooldown removed, that served 68 requests where identical
+    // headerless 429s served 9.
     const advertised = parseRpsLimit(headers);
-    const next =
+    const fromHeader =
       advertised !== null
-        ? Math.min(
-            ceilingRate,
-            Math.max(MIN_RATE, advertised * RATE_SAFETY_FACTOR),
-          )
-        : Math.max(MIN_RATE, currentRate * AIMD_DECREASE);
+        ? advertised * RATE_SAFETY_FACTOR
+        : Number.POSITIVE_INFINITY;
+    const next = Math.max(
+      MIN_RATE,
+      Math.min(fromHeader, currentRate * AIMD_DECREASE),
+    );
     if (next !== currentRate) {
       currentRate = next;
       gate.setRate(currentRate);
@@ -339,7 +350,27 @@ export function createCircuitBreakerRpc({
     },
   );
 
-  breaker.fallback((request: TransportRequest) => fallbackTransport(request));
+  // The fallback's OWN failures have to feed the backoff too.
+  //
+  // opossum only emits `failure` on the closed-circuit path (`fail()` in
+  // lib/circuit.js). Once the circuit is OPEN it emits `reject` and calls this
+  // fallback directly, so nothing the fallback returns — 429s included — ever
+  // reached `onError`. The rate gate therefore stayed pinned at its ceiling
+  // for exactly as long as the primary was down, which is when backpressure
+  // matters most. Measured before this fix: a fallback returning nothing but
+  // 429s absorbed 58 requests in 2.5s at a ceiling of 20 r/s.
+  //
+  // Note both transports share one rate gate, so backing off on the fallback
+  // also slows primary retries. That is the conservative direction, but a
+  // per-transport gate would be a reasonable follow-up.
+  breaker.fallback(async (request: TransportRequest) => {
+    try {
+      return await fallbackTransport(request);
+    } catch (err) {
+      onError(err);
+      throw err;
+    }
+  });
 
   breaker.on('open', () => {
     logger.warn('[rpc-circuit-breaker] circuit OPEN — routing to fallback RPC');
@@ -358,6 +389,10 @@ export function createCircuitBreakerRpc({
   // fallback then masks it by resolving `fire()`, and `success` fires on a
   // healthy primary call. A plain try/catch around `fire()` would miss the
   // fallback-masked 429s entirely.
+  //
+  // This covers the CLOSED-circuit path only. Once the circuit opens, opossum
+  // stops emitting `failure` altogether — the fallback wrapper above is what
+  // keeps the backoff alive in that state.
   breaker.on('failure', (err: unknown) => onError(err));
   breaker.on('success', () => onSuccess());
 

--- a/src/solana/rpc-circuit-breaker.ts
+++ b/src/solana/rpc-circuit-breaker.ts
@@ -29,9 +29,16 @@
  * ```ts
  * import { ARIO, createCircuitBreakerRpc } from '@ar.io/sdk';
  *
+ * // With a second endpoint to fall back to:
  * const rpc = createCircuitBreakerRpc({
  *   primaryUrl: 'https://my-premium-rpc.example.com',
- *   fallbackUrl: 'https://api.mainnet-beta.solana.com',
+ *   fallbackUrl: 'https://my-other-rpc.example.com',
+ * });
+ *
+ * // With only one endpoint — the circuit still protects it, and open-circuit
+ * // calls fail fast rather than being routed onto someone else's RPC:
+ * const rpc = createCircuitBreakerRpc({
+ *   primaryUrl: 'https://my-premium-rpc.example.com',
  * });
  *
  * const ario = ARIO.init({ rpc });
@@ -112,8 +119,21 @@ export interface CircuitBreakerRpcOptions {
 export interface CircuitBreakerRpcConfig {
   /** URL for the primary (preferred) RPC endpoint. */
   primaryUrl: string;
-  /** URL for the fallback RPC endpoint (used when the circuit opens). */
-  fallbackUrl: string;
+  /**
+   * URL for the fallback RPC endpoint, used while the circuit is open.
+   *
+   * OPTIONAL. Omit it when you have no second endpoint: the circuit still
+   * protects the primary, and calls made while it is open reject immediately
+   * (fail fast) instead of being routed anywhere else.
+   *
+   * Requiring this used to be a forcing function — a consumer with a single
+   * paid endpoint had nowhere to point it but a public RPC, so a degraded
+   * primary quietly turned into traffic aimed at shared infrastructure. Pass a
+   * fallback only when you actually have one to spare; {@link
+   * defaultFallbackUrl} exists for that case but is deliberately not applied
+   * for you.
+   */
+  fallbackUrl?: string;
   /** Opossum circuit-breaker tuning knobs. */
   circuitBreakerOptions?: CircuitBreakerRpcOptions;
 }
@@ -275,7 +295,10 @@ export function createCircuitBreakerRpc({
   circuitBreakerOptions: opts = {},
 }: CircuitBreakerRpcConfig): SolanaRpc {
   const primaryTransport = createDefaultRpcTransport({ url: primaryUrl });
-  const fallbackTransport = createDefaultRpcTransport({ url: fallbackUrl });
+  const fallbackTransport =
+    fallbackUrl !== undefined
+      ? createDefaultRpcTransport({ url: fallbackUrl })
+      : undefined;
 
   type TransportRequest = Parameters<typeof primaryTransport>[0];
 
@@ -363,17 +386,25 @@ export function createCircuitBreakerRpc({
   // Note both transports share one rate gate, so backing off on the fallback
   // also slows primary retries. That is the conservative direction, but a
   // per-transport gate would be a reasonable follow-up.
-  breaker.fallback(async (request: TransportRequest) => {
-    try {
-      return await fallbackTransport(request);
-    } catch (err) {
-      onError(err);
-      throw err;
-    }
-  });
+  // With no fallback configured we register none at all, so opossum rejects
+  // open-circuit calls outright rather than routing them anywhere.
+  if (fallbackTransport !== undefined) {
+    breaker.fallback(async (request: TransportRequest) => {
+      try {
+        return await fallbackTransport(request);
+      } catch (err) {
+        onError(err);
+        throw err;
+      }
+    });
+  }
 
   breaker.on('open', () => {
-    logger.warn('[rpc-circuit-breaker] circuit OPEN — routing to fallback RPC');
+    logger.warn(
+      fallbackTransport !== undefined
+        ? '[rpc-circuit-breaker] circuit OPEN — routing to fallback RPC'
+        : '[rpc-circuit-breaker] circuit OPEN — failing fast (no fallback configured)',
+    );
   });
   breaker.on('halfOpen', () => {
     logger.info(

--- a/src/solana/save-observations.test.ts
+++ b/src/solana/save-observations.test.ts
@@ -18,13 +18,18 @@ import {
   type Address,
   address,
   createSolanaRpc,
+  generateKeyPairSigner,
   getAddressEncoder,
 } from '@solana/kit';
 import bs58 from 'bs58';
 
-import { getEpochEncoder } from '@ar.io/solana-contracts/gar';
+import {
+  getEpochEncoder,
+  getSaveObservationsInstructionDataDecoder,
+} from '@ar.io/solana-contracts/gar';
 import { MAX_GATEWAYS } from './constants.js';
 import { SolanaARIOReadable } from './io-readable.js';
+import { SolanaARIOWriteable } from './io-writeable.js';
 import {
   buildObservationBitmap,
   encodeReportTxId,
@@ -809,6 +814,131 @@ describe('buildObservationBitmap with an explicit active count', () => {
     const withDefault = buildObservationBitmap([PUBKEY_1, PUBKEY_2], []);
     const explicit = buildObservationBitmap([PUBKEY_1, PUBKEY_2], [], 2);
     assert.deepEqual(withDefault, explicit);
+  });
+});
+
+// =========================================================================
+// saveObservations wiring
+// =========================================================================
+//
+// The resolver + bitmap are unit-tested above; this covers the part that
+// actually regressed on mainnet — which value `saveObservations` puts on the
+// wire. Stubbing the two protected account reads keeps the test focused on
+// the wiring rather than re-testing decoders that have their own coverage.
+
+describe('SolanaARIOWriteable.saveObservations wiring', () => {
+  class StubWriteable extends SolanaARIOWriteable {
+    sentGatewayCount: number | undefined;
+    sentEpochIndex: bigint | undefined;
+    resolvedEpochCalls = 0;
+
+    constructor(
+      signer: Awaited<ReturnType<typeof generateKeyPairSigner>>,
+      private readonly stub: {
+        activeGatewayCount: number;
+        epochStartTimestamp: number;
+        slots: Array<{ address: string; startTimestamp: number }>;
+        currentEpochIndexMinusOne: number;
+      },
+    ) {
+      super({
+        rpc: {} as ReturnType<typeof createSolanaRpc>,
+        rpcSubscriptions: {} as any,
+        signer,
+      });
+    }
+
+    protected async resolveEpochIndex(): Promise<number> {
+      this.resolvedEpochCalls++;
+      return this.stub.currentEpochIndexMinusOne;
+    }
+
+    protected async fetchEpoch(_epochIndex: number): Promise<any> {
+      return {
+        activeGatewayCount: this.stub.activeGatewayCount,
+        startTimestamp: this.stub.epochStartTimestamp,
+      };
+    }
+
+    protected async getRegistryGatewaySlots(): Promise<
+      Array<{ address: string; startTimestamp: number }>
+    > {
+      return this.stub.slots;
+    }
+
+    protected async sendTransaction(instructions: any[]): Promise<string> {
+      const decoded = getSaveObservationsInstructionDataDecoder().decode(
+        instructions[0].data,
+      );
+      this.sentGatewayCount = decoded.gatewayCount;
+      this.sentEpochIndex = decoded.epochIndex;
+      return 'stub-signature';
+    }
+  }
+
+  it('puts the epoch snapshot count on the wire, not the live registry length', async () => {
+    // The mainnet epoch-523 shape: snapshot 3, one mid-epoch join, live 4.
+    // Sending 4 is what the chain rejected with InvalidObservation.
+    const signer = await generateKeyPairSigner();
+    const w = new StubWriteable(signer, {
+      activeGatewayCount: 3,
+      epochStartTimestamp: EPOCH_START,
+      slots: [
+        ...[PUBKEY_1, PUBKEY_2, PUBKEY_3].map(preExistingSlot),
+        joinedMidEpochSlot(PUBKEY_4),
+      ],
+      currentEpochIndexMinusOne: 523,
+    });
+
+    await w.saveObservations({
+      reportTxId: VALID_ARWEAVE_TX,
+      failedGateways: [PUBKEY_2],
+      epochIndex: 523,
+    });
+
+    assert.equal(w.sentGatewayCount, 3);
+  });
+
+  it('targets the active epoch, not EpochSettings.current_epoch_index', async () => {
+    // current_epoch_index is the NEXT epoch to create, so the default path
+    // must go through resolveEpochIndex(). The CLI relies on this — it never
+    // passes an index.
+    const signer = await generateKeyPairSigner();
+    const w = new StubWriteable(signer, {
+      activeGatewayCount: 2,
+      epochStartTimestamp: EPOCH_START,
+      slots: [PUBKEY_1, PUBKEY_2].map(preExistingSlot),
+      currentEpochIndexMinusOne: 523,
+    });
+
+    await w.saveObservations({
+      reportTxId: VALID_ARWEAVE_TX,
+      failedGateways: [],
+    });
+
+    assert.equal(w.resolvedEpochCalls, 1);
+    assert.equal(w.sentEpochIndex, 523n);
+  });
+
+  it('refuses to submit when the registry was reordered', async () => {
+    const signer = await generateKeyPairSigner();
+    const w = new StubWriteable(signer, {
+      activeGatewayCount: 3,
+      epochStartTimestamp: EPOCH_START,
+      slots: [PUBKEY_1, PUBKEY_2].map(preExistingSlot),
+      currentEpochIndexMinusOne: 523,
+    });
+
+    await assert.rejects(
+      () =>
+        w.saveObservations({
+          reportTxId: VALID_ARWEAVE_TX,
+          failedGateways: [],
+          epochIndex: 523,
+        }),
+      /reordered during epoch 523/,
+    );
+    assert.equal(w.sentGatewayCount, undefined);
   });
 });
 

--- a/src/solana/save-observations.test.ts
+++ b/src/solana/save-observations.test.ts
@@ -25,7 +25,11 @@ import bs58 from 'bs58';
 import { getEpochEncoder } from '@ar.io/solana-contracts/gar';
 import { MAX_GATEWAYS } from './constants.js';
 import { SolanaARIOReadable } from './io-readable.js';
-import { buildObservationBitmap, encodeReportTxId } from './io-writeable.js';
+import {
+  buildObservationBitmap,
+  encodeReportTxId,
+  resolveObservationGatewayCount,
+} from './io-writeable.js';
 
 const PUBKEY_1 = 'GatewayAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 const PUBKEY_2 = 'GatewayBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
@@ -614,6 +618,156 @@ describe('SolanaARIOReadable.getEpoch(undefined) — current_epoch_index off-by-
     // currentEpochIndex = 0 → floors at 0, fetches Epoch[0] (which may
     // or may not exist; for this test we mock its presence).
     assert.equal(epoch.epochIndex, 0);
+  });
+});
+
+// =========================================================================
+// resolveObservationGatewayCount — epoch snapshot vs live registry
+// =========================================================================
+//
+// Regression cover for the mainnet epoch-523 outage: the SDK sent the LIVE
+// registry length as `gateway_count`, the chain compares it against the
+// epoch's frozen `active_gateway_count`, and one gateway joining mid-epoch
+// made every observer's `save_observations` revert with InvalidObservation
+// (6041) for the entire epoch.
+
+const EPOCH_START = 1_787_529_850; // seconds, as stored on chain
+
+/** Registry slot that was present when the epoch snapshot was taken. */
+function preExistingSlot(address: string) {
+  return { address, startTimestamp: EPOCH_START - 86_400 };
+}
+
+/** Registry slot for a gateway that joined after the epoch began. */
+function joinedMidEpochSlot(address: string) {
+  return { address, startTimestamp: EPOCH_START + 3_600 };
+}
+
+describe('resolveObservationGatewayCount', () => {
+  it('returns the snapshot count when the registry has not changed', () => {
+    const slots = [PUBKEY_1, PUBKEY_2, PUBKEY_3].map(preExistingSlot);
+    const resolved = resolveObservationGatewayCount({
+      registrySlots: slots,
+      activeGatewayCount: 3,
+      epochStartTimestamp: EPOCH_START,
+      epochIndex: 523,
+    });
+    assert.equal(resolved.gatewayCount, 3);
+    assert.deepEqual(resolved.addresses, [PUBKEY_1, PUBKEY_2, PUBKEY_3]);
+  });
+
+  it('reports the epoch snapshot, not the live length, after a mid-epoch join', () => {
+    // The exact mainnet epoch-523 shape: snapshot 644, one gateway joined
+    // mid-epoch, live registry 645. Sending 645 is what the chain rejected.
+    const slots = [
+      ...[PUBKEY_1, PUBKEY_2, PUBKEY_3].map(preExistingSlot),
+      joinedMidEpochSlot(PUBKEY_4),
+    ];
+    const resolved = resolveObservationGatewayCount({
+      registrySlots: slots,
+      activeGatewayCount: 3,
+      epochStartTimestamp: EPOCH_START,
+      epochIndex: 523,
+    });
+    assert.equal(resolved.gatewayCount, 3);
+    // Addresses stay full-length: slots below the snapshot are unmoved, so
+    // the positional bitmap is still built over the whole registry and then
+    // truncated by gatewayCount.
+    assert.equal(resolved.addresses.length, 4);
+    assert.equal(resolved.addresses[3], PUBKEY_4);
+  });
+
+  it('throws when a slot was reclaimed (registry shorter than the snapshot)', () => {
+    const slots = [PUBKEY_1, PUBKEY_2].map(preExistingSlot);
+    assert.throws(
+      () =>
+        resolveObservationGatewayCount({
+          registrySlots: slots,
+          activeGatewayCount: 3,
+          epochStartTimestamp: EPOCH_START,
+          epochIndex: 523,
+        }),
+      /reordered during epoch 523/,
+    );
+  });
+
+  it('throws when a join masks a removal and the counts happen to match', () => {
+    // The dangerous case: finalize_gone swap-removed a slot and a join
+    // refilled the count, so a naive length check sees 3 === 3 and submits a
+    // bitmap whose indices now point at different gateways.
+    const slots = [
+      ...[PUBKEY_1, PUBKEY_2].map(preExistingSlot),
+      joinedMidEpochSlot(PUBKEY_4),
+    ];
+    assert.throws(
+      () =>
+        resolveObservationGatewayCount({
+          registrySlots: slots,
+          activeGatewayCount: 3,
+          epochStartTimestamp: EPOCH_START,
+          epochIndex: 523,
+        }),
+      /attribute results to the wrong gateways/,
+    );
+  });
+
+  it('treats a gateway that joined and left within the epoch as append-only', () => {
+    // A mid-epoch joiner occupies the LAST slot, so finalize_gone reclaims it
+    // without swapping anything — indices below the snapshot are untouched
+    // and the submission is still safe.
+    const slots = [PUBKEY_1, PUBKEY_2, PUBKEY_3].map(preExistingSlot);
+    const resolved = resolveObservationGatewayCount({
+      registrySlots: slots,
+      activeGatewayCount: 3,
+      epochStartTimestamp: EPOCH_START,
+      epochIndex: 523,
+    });
+    assert.equal(resolved.gatewayCount, 3);
+  });
+
+  it('uses the epoch start as the boundary, not the observer clock', () => {
+    // A slot whose startTimestamp equals the epoch start was present at the
+    // snapshot — strictly-after is the correct comparison.
+    const slots = [
+      preExistingSlot(PUBKEY_1),
+      { address: PUBKEY_2, startTimestamp: EPOCH_START },
+    ];
+    const resolved = resolveObservationGatewayCount({
+      registrySlots: slots,
+      activeGatewayCount: 2,
+      epochStartTimestamp: EPOCH_START,
+      epochIndex: 523,
+    });
+    assert.equal(resolved.gatewayCount, 2);
+  });
+});
+
+describe('buildObservationBitmap with an explicit active count', () => {
+  it('clears bits above the epoch snapshot count', () => {
+    // 4 live gateways but the epoch froze at 3: bit 3 must be cleared even
+    // though that gateway did not fail, so the payload is identical no
+    // matter when the registry was read.
+    const bitmap = buildObservationBitmap(
+      [PUBKEY_1, PUBKEY_2, PUBKEY_3, PUBKEY_4],
+      [],
+      3,
+    );
+    assert.equal(bitmap[0], 0b00000111);
+  });
+
+  it('still records failures for slots below the snapshot count', () => {
+    const bitmap = buildObservationBitmap(
+      [PUBKEY_1, PUBKEY_2, PUBKEY_3, PUBKEY_4],
+      [PUBKEY_2],
+      3,
+    );
+    assert.equal(bitmap[0], 0b00000101);
+  });
+
+  it('defaults to the registry length when no count is given', () => {
+    const withDefault = buildObservationBitmap([PUBKEY_1, PUBKEY_2], []);
+    const explicit = buildObservationBitmap([PUBKEY_1, PUBKEY_2], [], 2);
+    assert.deepEqual(withDefault, explicit);
   });
 });
 

--- a/src/solana/save-observations.test.ts
+++ b/src/solana/save-observations.test.ts
@@ -725,20 +725,61 @@ describe('resolveObservationGatewayCount', () => {
     assert.equal(resolved.gatewayCount, 3);
   });
 
-  it('uses the epoch start as the boundary, not the observer clock', () => {
-    // A slot whose startTimestamp equals the epoch start was present at the
-    // snapshot — strictly-after is the correct comparison.
+  it('refuses a slot stamped with the epoch start second as ambiguous', () => {
+    // create_epoch and join_network can land in the same second, and
+    // second-resolution timestamps cannot say which ran first. Assuming the
+    // slot pre-existed would let the count equation balance for a registry
+    // where a reclaimed slot was refilled by that join — the exact silent
+    // reordering this guard exists to catch.
     const slots = [
       preExistingSlot(PUBKEY_1),
       { address: PUBKEY_2, startTimestamp: EPOCH_START },
     ];
+    assert.throws(
+      () =>
+        resolveObservationGatewayCount({
+          registrySlots: slots,
+          activeGatewayCount: 2,
+          epochStartTimestamp: EPOCH_START,
+          epochIndex: 523,
+        }),
+      /exact start second/,
+    );
+  });
+
+  it('still refuses the boundary slot when the counts look append-only', () => {
+    // snapshot 1 + one boundary slot = live 2, which the arithmetic alone
+    // would happily accept as a clean mid-epoch join.
+    const slots = [
+      preExistingSlot(PUBKEY_1),
+      { address: PUBKEY_2, startTimestamp: EPOCH_START },
+    ];
+    assert.throws(
+      () =>
+        resolveObservationGatewayCount({
+          registrySlots: slots,
+          activeGatewayCount: 1,
+          epochStartTimestamp: EPOCH_START,
+          epochIndex: 523,
+        }),
+      /exact start second/,
+    );
+  });
+
+  it('accepts a join one second after the epoch start', () => {
+    // The boundary is exact: one second later is unambiguously a mid-epoch
+    // join and must not trip the ambiguity guard.
+    const slots = [
+      preExistingSlot(PUBKEY_1),
+      { address: PUBKEY_2, startTimestamp: EPOCH_START + 1 },
+    ];
     const resolved = resolveObservationGatewayCount({
       registrySlots: slots,
-      activeGatewayCount: 2,
+      activeGatewayCount: 1,
       epochStartTimestamp: EPOCH_START,
       epochIndex: 523,
     });
-    assert.equal(resolved.gatewayCount, 2);
+    assert.equal(resolved.gatewayCount, 1);
   });
 });
 

--- a/src/solana/single-flight.test.ts
+++ b/src/solana/single-flight.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { describe, it, mock } from 'node:test';
+import { describe, it } from 'node:test';
 
 import { type InFlightStore, memoizeInFlight } from './single-flight.js';
 
@@ -105,39 +105,37 @@ describe('memoizeInFlight', () => {
   });
 
   it('a late settlement never evicts a newer entry for the same key', async () => {
-    mock.timers.enable({ apis: ['Date'] });
-    try {
-      const store: InFlightStore<string, string> = new Map();
-      const slow = deferred<string>();
-      let calls = 0;
+    // Real timers rather than `mock.timers`: that API needs Node >= 20.4 and
+    // this package supports Node >= 18. A short TTL plus a real sleep gets the
+    // same interleaving without the version floor.
+    const store: InFlightStore<string, string> = new Map();
+    const slow = deferred<string>();
+    let calls = 0;
 
-      const first = memoizeInFlight(store, 'k', 1_000, () => {
-        calls++;
-        return slow.promise;
-      });
-      const firstSettled = first.catch(() => 'failed');
+    const first = memoizeInFlight(store, 'k', 10, () => {
+      calls++;
+      return slow.promise;
+    });
+    const firstSettled = first.catch(() => 'failed');
 
-      // TTL lapses while the first request is still in flight.
-      mock.timers.tick(2_000);
-      const second = await memoizeInFlight(store, 'k', 1_000, async () => {
-        calls++;
-        return 'fresh';
-      });
-      assert.equal(second, 'fresh');
-      assert.equal(calls, 2);
+    // Let the TTL lapse while the first request is still in flight.
+    await sleep(30);
+    const second = await memoizeInFlight(store, 'k', 60_000, async () => {
+      calls++;
+      return 'fresh';
+    });
+    assert.equal(second, 'fresh');
+    assert.equal(calls, 2);
 
-      // The stale request now fails. Its eviction must not drop 'fresh'.
-      slow.reject(new Error('stale'));
-      await firstSettled;
+    // The stale request now fails. Its eviction must not drop 'fresh'.
+    slow.reject(new Error('stale'));
+    await firstSettled;
 
-      const third = await memoizeInFlight(store, 'k', 1_000, async () => {
-        calls++;
-        return 'should not happen';
-      });
-      assert.equal(third, 'fresh', 'newer entry survived the stale eviction');
-      assert.equal(calls, 2);
-    } finally {
-      mock.timers.reset();
-    }
+    const third = await memoizeInFlight(store, 'k', 60_000, async () => {
+      calls++;
+      return 'should not happen';
+    });
+    assert.equal(third, 'fresh', 'newer entry survived the stale eviction');
+    assert.equal(calls, 2);
   });
 });

--- a/src/solana/single-flight.test.ts
+++ b/src/solana/single-flight.test.ts
@@ -104,38 +104,80 @@ describe('memoizeInFlight', () => {
     assert.equal(calls, 2);
   });
 
-  it('a late settlement never evicts a newer entry for the same key', async () => {
-    // Real timers rather than `mock.timers`: that API needs Node >= 20.4 and
-    // this package supports Node >= 18. A short TTL plus a real sleep gets the
-    // same interleaving without the version floor.
-    const store: InFlightStore<string, string> = new Map();
-    const slow = deferred<string>();
+  it('does not start a duplicate request while one is still in flight, even past the TTL', async () => {
+    // Reported by CodeRabbit on #712. The TTL used to be measured from when
+    // the request STARTED, so a request slower than its own TTL was treated as
+    // expired while still in flight and later callers began a second one —
+    // reopening the exact stampede this helper exists to close.
+    //
+    // Not theoretical: CLUSTER_CLOCK_CACHE_TTL_MS is 1s and the cluster-clock
+    // read is two SEQUENTIAL RPCs, each wrapped in withRetry (3 attempts, 1s
+    // base backoff). One retry is enough to exceed the TTL.
+    const store: InFlightStore<string, number> = new Map();
     let calls = 0;
-
-    const first = memoizeInFlight(store, 'k', 10, () => {
+    const slow = deferred<number>();
+    const produce = () => {
       calls++;
       return slow.promise;
-    });
-    const firstSettled = first.catch(() => 'failed');
+    };
 
-    // Let the TTL lapse while the first request is still in flight.
-    await sleep(30);
-    const second = await memoizeInFlight(store, 'k', 60_000, async () => {
+    const first = memoizeInFlight(store, 'k', 10, produce);
+    await sleep(40); // TTL has lapsed, but the request has NOT settled
+    const second = memoizeInFlight(store, 'k', 10, produce);
+
+    slow.resolve(5);
+    assert.equal(await first, 5);
+    assert.equal(await second, 5);
+    assert.equal(
+      calls,
+      1,
+      'a caller arriving during a slow request must join it, not start another',
+    );
+  });
+
+  it('starts the TTL when the request settles, not when it began', async () => {
+    const store: InFlightStore<string, number> = new Map();
+    let calls = 0;
+    const produce = async () => {
       calls++;
-      return 'fresh';
-    });
-    assert.equal(second, 'fresh');
-    assert.equal(calls, 2);
+      await sleep(40);
+      return calls;
+    };
 
-    // The stale request now fails. Its eviction must not drop 'fresh'.
+    // ttl 60ms against a 40ms request: measured from the start it would have
+    // only ~20ms of life left, measured from settlement it has the full 60ms.
+    assert.equal(await memoizeInFlight(store, 'k', 60, produce), 1);
+    await sleep(30);
+    assert.equal(
+      await memoizeInFlight(store, 'k', 60, produce),
+      1,
+      'the settled value should still be within its TTL',
+    );
+    assert.equal(calls, 1);
+  });
+
+  it('a late settlement never evicts a newer entry for the same key', async () => {
+    // Now that pending entries never expire, two promises can only coexist for
+    // a key if one is swapped in directly — so drive that explicitly rather
+    // than via a TTL race, to keep the identity guard covered.
+    const store: InFlightStore<string, string> = new Map();
+    const slow = deferred<string>();
+    const stale = memoizeInFlight(store, 'k', 60_000, () => slow.promise);
+    const staleSettled = stale.catch(() => 'failed');
+
+    // Replace the entry as though a newer request had taken over the key.
+    const fresh = Promise.resolve('fresh');
+    store.set('k', { promise: fresh, expiresAt: Date.now() + 60_000 });
+
     slow.reject(new Error('stale'));
-    await firstSettled;
+    await staleSettled;
 
-    const third = await memoizeInFlight(store, 'k', 60_000, async () => {
+    let calls = 0;
+    const after = await memoizeInFlight(store, 'k', 60_000, async () => {
       calls++;
       return 'should not happen';
     });
-    assert.equal(third, 'fresh', 'newer entry survived the stale eviction');
-    assert.equal(calls, 2);
+    assert.equal(after, 'fresh', 'newer entry survived the stale eviction');
+    assert.equal(calls, 0);
   });
 });

--- a/src/solana/single-flight.test.ts
+++ b/src/solana/single-flight.test.ts
@@ -1,0 +1,143 @@
+import { strict as assert } from 'node:assert';
+import { describe, it, mock } from 'node:test';
+
+import { type InFlightStore, memoizeInFlight } from './single-flight.js';
+
+/** A promise whose settlement the test controls explicitly. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('memoizeInFlight', () => {
+  it('collapses concurrent callers onto a single producer call', async () => {
+    const store: InFlightStore<string, number> = new Map();
+    let calls = 0;
+    const d = deferred<number>();
+    const produce = () => {
+      calls++;
+      return d.promise;
+    };
+
+    const all = Promise.all(
+      Array.from({ length: 10 }, () =>
+        memoizeInFlight(store, 'k', 60_000, produce),
+      ),
+    );
+    d.resolve(7);
+
+    assert.deepEqual(await all, Array(10).fill(7));
+    assert.equal(calls, 1, '10 concurrent callers should produce once');
+  });
+
+  it('reuses a settled value for the TTL, then re-produces once expired', async () => {
+    const store: InFlightStore<string, number> = new Map();
+    let calls = 0;
+    const produce = async () => ++calls;
+
+    assert.equal(await memoizeInFlight(store, 'k', 50, produce), 1);
+    assert.equal(await memoizeInFlight(store, 'k', 50, produce), 1, 'cached');
+
+    await sleep(70);
+    assert.equal(
+      await memoizeInFlight(store, 'k', 50, produce),
+      2,
+      'expired entry should be replaced',
+    );
+  });
+
+  it('does not cache rejections, and every concurrent caller sees the error', async () => {
+    const store: InFlightStore<string, number> = new Map();
+    let calls = 0;
+    const produce = async () => {
+      calls++;
+      throw new Error(`boom ${calls}`);
+    };
+
+    const settled = await Promise.allSettled(
+      Array.from({ length: 5 }, () =>
+        memoizeInFlight(store, 'k', 60_000, produce),
+      ),
+    );
+    assert.equal(calls, 1, 'the failing fetch is still shared');
+    for (const s of settled) {
+      assert.equal(s.status, 'rejected');
+      assert.match((s as PromiseRejectedResult).reason.message, /boom 1/);
+    }
+    assert.equal(store.size, 0, 'a rejection must be evicted, not cached');
+
+    // A transient failure must not poison the key for the rest of the TTL.
+    await assert.rejects(() => memoizeInFlight(store, 'k', 60_000, produce), {
+      message: 'boom 2',
+    });
+    assert.equal(calls, 2, 'next caller retries after a failure');
+  });
+
+  it('shares an in-flight value that keep() rejects, but does not retain it', async () => {
+    const store: InFlightStore<string, { exists: boolean }> = new Map();
+    let calls = 0;
+    const produce = async () => {
+      calls++;
+      return { exists: false };
+    };
+    const keep = (v: { exists: boolean }) => v.exists;
+
+    // This is the "misses are not cached" rule from getCachedAccount: the
+    // concurrent burst still costs ONE fetch...
+    await Promise.all(
+      Array.from({ length: 4 }, () =>
+        memoizeInFlight(store, 'k', 60_000, produce, keep),
+      ),
+    );
+    assert.equal(calls, 1);
+    assert.equal(store.size, 0, 'a non-kept value is evicted once settled');
+
+    // ...but a later caller re-checks rather than trusting a stale miss.
+    await memoizeInFlight(store, 'k', 60_000, produce, keep);
+    assert.equal(calls, 2);
+  });
+
+  it('a late settlement never evicts a newer entry for the same key', async () => {
+    mock.timers.enable({ apis: ['Date'] });
+    try {
+      const store: InFlightStore<string, string> = new Map();
+      const slow = deferred<string>();
+      let calls = 0;
+
+      const first = memoizeInFlight(store, 'k', 1_000, () => {
+        calls++;
+        return slow.promise;
+      });
+      const firstSettled = first.catch(() => 'failed');
+
+      // TTL lapses while the first request is still in flight.
+      mock.timers.tick(2_000);
+      const second = await memoizeInFlight(store, 'k', 1_000, async () => {
+        calls++;
+        return 'fresh';
+      });
+      assert.equal(second, 'fresh');
+      assert.equal(calls, 2);
+
+      // The stale request now fails. Its eviction must not drop 'fresh'.
+      slow.reject(new Error('stale'));
+      await firstSettled;
+
+      const third = await memoizeInFlight(store, 'k', 1_000, async () => {
+        calls++;
+        return 'should not happen';
+      });
+      assert.equal(third, 'fresh', 'newer entry survived the stale eviction');
+      assert.equal(calls, 2);
+    } finally {
+      mock.timers.reset();
+    }
+  });
+});

--- a/src/solana/single-flight.ts
+++ b/src/solana/single-flight.ts
@@ -34,6 +34,7 @@
 /** A cached in-flight or already-settled request. */
 type InFlightEntry<V> = {
   promise: Promise<V>;
+  /** Infinity while the request is in flight; a real deadline once settled. */
   expiresAt: number;
 };
 
@@ -62,12 +63,20 @@ export function memoizeInFlight<K, V>(
   produce: () => Promise<V>,
   keep: (value: V) => boolean = () => true,
 ): Promise<V> {
-  const now = Date.now();
   const hit = store.get(key);
-  if (hit !== undefined && hit.expiresAt > now) return hit.promise;
+  if (hit !== undefined && hit.expiresAt > Date.now()) return hit.promise;
 
+  // A PENDING entry never expires — its `expiresAt` stays at Infinity until it
+  // settles, and the TTL is measured from settlement below.
+  //
+  // Measuring the TTL from when the request STARTED meant a request slower
+  // than its own TTL looked expired while still in flight, so later callers
+  // began a second one — reopening the very stampede this helper closes. That
+  // is reachable in practice: CLUSTER_CLOCK_CACHE_TTL_MS is 1s and the
+  // cluster-clock read is two sequential RPCs, each wrapped in withRetry with
+  // a 1s base backoff, so a single retry exceeds it.
   const promise = produce();
-  store.set(key, { promise, expiresAt: now + ttlMs });
+  store.set(key, { promise, expiresAt: Number.POSITIVE_INFINITY });
 
   // Only ever evict OUR entry: by the time this settles the key may already
   // hold a newer promise (TTL expired, another caller started a fresh fetch),
@@ -81,7 +90,13 @@ export function memoizeInFlight<K, V>(
   // reporting an unhandled rejection for the cached promise; callers await the
   // ORIGINAL promise, so they still observe the error.
   void promise.then((value) => {
-    if (!keep(value)) evictSelf();
+    if (!keep(value)) {
+      evictSelf();
+      return;
+    }
+    // Settled and worth keeping: start the TTL now.
+    const entry = store.get(key);
+    if (entry?.promise === promise) entry.expiresAt = Date.now() + ttlMs;
   }, evictSelf);
 
   return promise;

--- a/src/solana/single-flight.ts
+++ b/src/solana/single-flight.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2022-2024 Permanent Data Solutions, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Single-flight (a.k.a. request-coalescing) memoization for RPC reads.
+ *
+ * The SDK's short-TTL caches used to store the RESOLVED value, which meant
+ * they only ever helped SEQUENTIAL callers: N concurrent callers all miss the
+ * cache before any of them fills it, so all N hit the network. That is exactly
+ * backwards — the burst is the case worth collapsing. Measured against devnet,
+ * ten concurrent `getGasEstimate()` calls issued 43 requests / 200 KiB where
+ * ten sequential calls issued 14 / 21 KiB, and the burst tripped a 429.
+ *
+ * Storing the PROMISE instead of the value fixes that: the first caller starts
+ * the work, everyone else awaits the same promise, and the resolved value is
+ * still reused for `ttlMs` afterwards.
+ *
+ * Internal helper — deliberately not re-exported from `./index.ts`, so it adds
+ * nothing to the package's public surface.
+ */
+
+/** A cached in-flight or already-settled request. */
+type InFlightEntry<V> = {
+  promise: Promise<V>;
+  expiresAt: number;
+};
+
+/** Backing store for {@link memoizeInFlight}. Callers own the Map instance. */
+export type InFlightStore<K, V> = Map<K, InFlightEntry<V>>;
+
+/**
+ * Return the cached promise for `key`, or start one with `produce()`.
+ *
+ * @param store - caller-owned Map holding the cached promises.
+ * @param key - cache key.
+ * @param ttlMs - how long a SETTLED value stays reusable. Use
+ *   `Number.POSITIVE_INFINITY` for values that never change (e.g. a mint
+ *   address). The in-flight window is always shared regardless of `ttlMs`.
+ * @param produce - starts the underlying work. Called at most once per
+ *   (key, TTL window).
+ * @param keep - decides, after resolution, whether the value is worth
+ *   retaining. Returning `false` evicts it once settled, so later callers
+ *   re-fetch — while concurrent callers still shared the single request. This
+ *   is how "misses are not cached" survives coalescing.
+ */
+export function memoizeInFlight<K, V>(
+  store: InFlightStore<K, V>,
+  key: K,
+  ttlMs: number,
+  produce: () => Promise<V>,
+  keep: (value: V) => boolean = () => true,
+): Promise<V> {
+  const now = Date.now();
+  const hit = store.get(key);
+  if (hit !== undefined && hit.expiresAt > now) return hit.promise;
+
+  const promise = produce();
+  store.set(key, { promise, expiresAt: now + ttlMs });
+
+  // Only ever evict OUR entry: by the time this settles the key may already
+  // hold a newer promise (TTL expired, another caller started a fresh fetch),
+  // and dropping that one would silently defeat the cache.
+  const evictSelf = () => {
+    if (store.get(key)?.promise === promise) store.delete(key);
+  };
+
+  // A rejection must not be cached — otherwise one transient 429 poisons the
+  // key for the whole TTL. Attaching the handler here also keeps Node from
+  // reporting an unhandled rejection for the cached promise; callers await the
+  // ORIGINAL promise, so they still observe the error.
+  void promise.then((value) => {
+    if (!keep(value)) evictSelf();
+  }, evictSelf);
+
+  return promise;
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.2.0-alpha.2';
+export const version = '4.2.0-alpha.3';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.1.4-alpha.2';
+export const version = '4.1.4-alpha.3';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.1.4-alpha.3';
+export const version = '4.2.0-alpha.1';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.1.4-alpha.1';
+export const version = '4.1.4-alpha.2';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.2.0-alpha.1';
+export const version = '4.2.0-alpha.2';


### PR DESCRIPTION
Promotes `alpha` (`4.2.0-alpha.2`) to `main`, cutting **4.2.0** on the npm `latest` tag.

This is a **minor** release — it carries the observation fix plus the RPC-resilience and performance work that has been sitting on `alpha`.

## Observation submission (#717) — the reason for cutting now

`saveObservations` derived `gateway_count` from a **live** registry read, but the chain validates it against the epoch's frozen `Epoch.active_gateway_count`. One gateway joining mid-epoch desynced the two and rejected **every observer's** submission with `InvalidObservation` (6041) for the rest of the epoch.

Mainnet epoch 523 closed with `observations_submitted = 0` across all 50 prescribed observers. Isolated by simulation: 644 (the snapshot) succeeds, 643/645 revert.

- `4820c3bf` — send the epoch snapshot count, and refuse when a `finalize_gone` swap-remove has reordered registry slots (positional bitmap would otherwise misattribute results — silent corruption, worse than a revert)
- `fdbf20af` — refuse slots stamped with the epoch's exact start second, which are ambiguous between "in the snapshot" and "joined immediately after"
- `450c9f6c` — target the *active* epoch when `epochIndex` is defaulted; `current_epoch_index` is the **next** epoch to be created, so `ar.io save-observations` (which never passes an index) was aiming at an epoch that doesn't exist yet
- `f821226d` — decode registry slot timestamps without BigInt `Buffer` readers, which arns-react's Vite output strips from the `buffer@6.0.3` shim
- `d5d11ed0` — document the bitmap's positional contract

**Timing matters:** 248 gateways sit in `leaving` with no delegated stake, and the first becomes `finalize_gone`-eligible on **2026-09-10**. Once those drain, the registry count moves most epochs and the join+removal case — the silently-wrong one — becomes reachable.

## Also riding along

- `a1020c22` — `feat`: let consumers decline a public RPC fallback
- `2fbe69bf`, `e89a8717`, `01792556` — coalesce concurrent RPC reads behind in-flight caches; batch gateway metadata; bounded-pool account fetching
- `70dd2f6b`, `fa48766c`, `ab1b7fc9` — RPC throttle backoff; single-flight TTL measured from settlement; don't report zero funding sources when discovery fails
- `26d37c1c` — drop `mock.timers` so the suite honors the Node 18 floor
- `77490579`, `05348200` — run build/test on PRs targeting `main`; enable CodeRabbit on the branches we ship from

## Verification

Every change was green on its own PR before merging to `alpha` — note `build.yml` does not run on `main`/`alpha`, so this PR gets only CodeQL/CodeRabbit by design.

At `alpha` head: 520 tests (519 pass, 0 fail, 1 pre-existing skip), lint delta zero, format clean, `tsc` clean, build OK. `4.2.0-alpha.2` published successfully to the `alpha` dist-tag.

The observation fix was additionally replayed against **live mainnet**: it returns 644 for epoch 523 where the released code returns 645, and correctly identifies `ar.ant.ovh` as the single mid-epoch joiner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kexn8mPZfVRHiWCW2k4kU3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Solana performance through concurrent account and gateway data retrieval.
  * Added request deduplication to reduce duplicate network calls during simultaneous reads.
  * Added resilient funding-source discovery with retries and graceful fallback behavior.
  * Improved gateway and observation handling across registry and epoch changes.
  * RPC fallback configuration is now optional, with faster failure when unavailable.

* **Bug Fixes**
  * Corrected ordering of batched account results.
  * Improved rate-limit backoff behavior for throttled requests.

* **Release**
  * Updated version to 4.2.0-alpha.3 and expanded release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->