### PR TITLE
feat(solana): allow a spawned ANT's owner to differ from the payer

### DIFF
--- a/src/solana/index.ts
+++ b/src/solana/index.ts
@@ -142,13 +142,26 @@ export type {
   EscrowNetwork,
 } from './canonical-message.js';
 
-// ANT spawn (mint MPL Core asset + initialize ario-ant state in one tx)
+// ANT spawn (mint MPL Core asset + initialize ario-ant state in one tx).
+//
+// `buildSpawnAntInstructions` / `buildCreateAntInstruction` are exported for
+// callers who need to bundle a spawn into a larger transaction rather than send
+// it — notably a SPONSORED spawn, where one wallet pays and another owns. Both
+// were already public within the module and documented as such; without the
+// re-export, a consumer wanting that shape has to hand-copy the `CreateV1`
+// builder, and a copy silently drifts from the Attributes-plugin/ADR-028
+// authority shape that `ario_arns::buy_name` depends on (a mismatch surfaces
+// only later, as MPL Core 0x4 "Plugin not found", at purchase time).
 export {
   spawnSolanaANT,
+  buildSpawnAntInstructions,
+  buildCreateAntInstruction,
   ARIO_LOGO_TX_ID,
   DEFAULT_ANT_TRANSACTION_ID,
 } from './spawn-ant.js';
 export type {
+  AntAttribute,
+  SpawnAntInstructions,
   SpawnSolanaANTParams,
   SpawnSolanaANTResult,
   SpawnSolanaANTState,
@@ -272,6 +285,10 @@ export {
   estimatePriorityFeeMicroLamports,
   estimateQuotePriorityFeeMicroLamports,
   estimateWalletPriorityFeeMicroLamports,
+  // Consumers assembling their own instruction bundles (see
+  // `buildSpawnAntInstructions`) need the same send path the SDK uses
+  // internally, including its compute-budget and wallet-rewrite handling.
+  sendAndConfirm,
 } from './send.js';
 export {
   ACL_BOOTSTRAP_ACCOUNT_BYTES,

--- a/src/solana/spawn-ant-owner.test.ts
+++ b/src/solana/spawn-ant-owner.test.ts
@@ -1,0 +1,106 @@
+/**
+ * A spawned ANT's OWNER may differ from the wallet that pays for it.
+ *
+ * `buildSpawnAntInstructions({ owner })` separates the two roles the spawn
+ * really has: `signer` funds the MPL Core asset's rent and signs `CreateV1`,
+ * while `owner` receives the NFT and signs `ario_ant::initialize`. That is what
+ * a sponsored spawn needs — a service pays, the end user owns — and the chain
+ * already supports it (`CreateV1` takes `payer` and `owner` as separate
+ * accounts, and `owner` is not a signer there).
+ *
+ * These tests pin the ACCOUNT ROLES rather than the byte layout, which
+ * `spawn-ant.test.ts` already covers: the failure mode this guards against is a
+ * silent swap of payer and owner, which would hand custody to the wrong wallet
+ * while still producing a perfectly well-formed transaction.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  type Address,
+  address,
+  createNoopSigner,
+  generateKeyPairSigner,
+} from '@solana/kit';
+
+import { buildSpawnAntInstructions } from './spawn-ant.js';
+
+const OWNER: Address = address('11111111111111111111111111111113');
+
+/** MPL Core `CreateV1` account order: asset, collection, authority, payer, owner. */
+const CREATE_V1_PAYER_INDEX = 3;
+const CREATE_V1_OWNER_INDEX = 4;
+
+async function build(withOwner: boolean) {
+  const signer = await generateKeyPairSigner();
+  const { instructions } = await buildSpawnAntInstructions({
+    signer,
+    state: { name: 'sponsored-name' },
+    ...(withOwner ? { owner: createNoopSigner(OWNER) } : {}),
+  });
+  const [createIx, initIx] = instructions;
+  assert.ok(createIx.accounts, 'CreateV1 must carry accounts');
+  assert.ok(initIx.accounts, 'initialize must carry accounts');
+  return { signer, createIx, initIx };
+}
+
+describe('buildSpawnAntInstructions owner/payer separation', () => {
+  it('defaults the owner to the signer, unchanged from before', async () => {
+    const { signer, createIx, initIx } = await build(false);
+    const accounts = createIx.accounts as readonly { address: Address }[];
+
+    assert.equal(accounts[CREATE_V1_PAYER_INDEX].address, signer.address);
+    assert.equal(accounts[CREATE_V1_OWNER_INDEX].address, signer.address);
+    assert.ok(
+      (initIx.accounts as readonly { address: Address }[]).some(
+        (a) => a.address === signer.address,
+      ),
+      'initialize must be signed by the signer when no owner is given',
+    );
+  });
+
+  it('mints to `owner` while `signer` still pays', async () => {
+    const { signer, createIx } = await build(true);
+    const accounts = createIx.accounts as readonly { address: Address }[];
+
+    assert.equal(
+      accounts[CREATE_V1_PAYER_INDEX].address,
+      signer.address,
+      'the sponsor must remain the payer',
+    );
+    assert.equal(
+      accounts[CREATE_V1_OWNER_INDEX].address,
+      OWNER,
+      'the ANT must be minted to the supplied owner, not the payer',
+    );
+    assert.notEqual(
+      accounts[CREATE_V1_OWNER_INDEX].address,
+      signer.address,
+      'payer and owner must not collapse — that silently hands over custody',
+    );
+  });
+
+  // `ario_ant::initialize` declares `owner: Signer` and creates AntConfig,
+  // AntControllers and the root AntRecord with `payer = owner`. Signing it with
+  // the sponsor would both fail on chain and charge the wrong account.
+  it('signs `initialize` as the OWNER, not the payer', async () => {
+    const { signer, initIx } = await build(true);
+    const addresses = (initIx.accounts as readonly { address: Address }[]).map(
+      (a) => a.address,
+    );
+
+    assert.ok(addresses.includes(OWNER), 'initialize must reference the owner');
+    assert.ok(
+      !addresses.includes(signer.address),
+      'initialize must NOT reference the sponsor — it pins payer = owner',
+    );
+  });
+
+  it('accepts a noop signer, so a sponsor can build for a remote owner', async () => {
+    const { createIx } = await build(true);
+    const accounts = createIx.accounts as readonly { address: Address }[];
+    // The point of a noop signer: the sponsor assembles and partially signs the
+    // transaction without holding the owner's key, and the owner adds theirs.
+    assert.equal(accounts[CREATE_V1_OWNER_INDEX].address, OWNER);
+  });
+});

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -361,11 +361,33 @@ export async function buildSpawnAntInstructions(params: {
   state: SpawnSolanaANTState;
   antProgramId?: Address;
   mintSigner?: KeyPairSigner;
+  /**
+   * Wallet that will OWN the new ANT. Defaults to `signer`, which is the
+   * existing behaviour — omitting it changes nothing.
+   *
+   * Supplying a different signer separates the two roles the spawn actually
+   * has: `signer` stays the fee payer and `CreateV1` authority (it funds the
+   * MPL Core asset's rent), while `owner` receives the NFT and signs
+   * `ario_ant::initialize`. That split is what a sponsored spawn needs — a
+   * service pays, the end user owns — and it is available on chain today:
+   * `CreateV1` takes `payer` and `owner` as separate accounts and `owner` is
+   * not a signer there.
+   *
+   * `owner` must still be a signer, because `ario_ant::initialize` declares
+   * `owner: Signer` and pins `payer = owner` for the three PDAs it creates
+   * (`AntConfig`, `AntControllers`, the root `AntRecord`). A sponsor
+   * therefore also has to fund those lamports on the owner's account — most
+   * simply with a `SystemTransfer` earlier in the same transaction. Callers
+   * assembling a partially-signed transaction for a remote owner can pass
+   * `createNoopSigner(ownerAddress)` and let the owner add the signature.
+   */
+  owner?: SolanaSigner;
 }): Promise<SpawnAntInstructions> {
   if (!params.state?.name || params.state.name.length === 0) {
     throw new Error('buildSpawnAntInstructions: state.name is required');
   }
   const { signer, state, antProgramId = ARIO_ANT_PROGRAM_ID } = params;
+  const owner = params.owner ?? signer;
   const mintSigner = params.mintSigner ?? (await generateKeyPairSigner());
   const mint = mintSigner.address;
 
@@ -392,8 +414,9 @@ export async function buildSpawnAntInstructions(params: {
   //
   // ADR-028: the asset's UpdateAuthority is the per-asset `ant_authority` PDA
   // and the Attributes plugin authority is `UpdateAuthority` (→ that PDA), so
-  // all MPL Core updates route through the ario-ant program. The owner (the
-  // spawning signer) keeps custody of the NFT.
+  // all MPL Core updates route through the ario-ant program. The owner keeps
+  // custody of the NFT — by default the spawning signer, or `params.owner`
+  // when a sponsor is paying on someone else's behalf.
   const [antAuthority] = await getAntAuthorityPDA(mint, antProgramId);
   const createIx = getCreateV1Instruction({
     asset: mintSigner,
@@ -401,9 +424,8 @@ export async function buildSpawnAntInstructions(params: {
     authority: signer,
     // `owner` MUST be explicit. MPL Core defaults owner to updateAuthority when
     // omitted, so with updateAuthority = the ant_authority PDA an omitted owner
-    // would make the PROGRAM PDA the NFT owner (user loses custody). Pin it to
-    // the spawning wallet.
-    owner: signer.address,
+    // would make the PROGRAM PDA the NFT owner (user loses custody).
+    owner: owner.address,
     updateAuthority: antAuthority,
     dataState: DataState.AccountState,
     name: state.name,
@@ -428,7 +450,9 @@ export async function buildSpawnAntInstructions(params: {
   const initIx = await buildInitializeAntIx({
     programId: antProgramId,
     mint,
-    signer,
+    // `ario_ant::initialize` declares `owner: Signer` and creates its PDAs with
+    // `payer = owner`, so this must be the OWNER, not the fee payer.
+    signer: owner,
     state,
   });
 


### PR DESCRIPTION
## Problem

`buildSpawnAntInstructions` pins the new ANT's owner to the signing wallet:

```ts
owner: signer.address,
```

So the wallet that **pays** for a spawn is always the wallet that **owns** the result. That rules out the sponsored shape — a service pays the rent and fees, an end user owns the name — even though the chain supports it directly: `mpl_core::CreateV1` takes `payer` and `owner` as separate accounts, and `owner` is not a signer there.

Neither `buildSpawnAntInstructions` nor `buildCreateAntInstruction` is exported from the package index either, so a consumer wanting that shape has to hand-copy the `CreateV1` builder. **That copy is the real hazard.** It has to reproduce the Attributes plugin carrying the `ANT Program` entry and the ADR-028 `updateAuthority` = `ant_authority` PDA. If either drifts, nothing fails at build time — it fails later, at `ario_arns::buy_name`, with MPL Core `0x4` "Plugin not found", *after* funds have moved. The builder's own comments call this out.

## Change

- Optional `owner` on `buildSpawnAntInstructions`, defaulting to `signer`. Omitting it is byte-for-byte the previous behaviour.
- When supplied: `signer` stays fee payer + `CreateV1` authority; `owner` receives the NFT and signs `ario_ant::initialize`.
- Export `buildSpawnAntInstructions`, `buildCreateAntInstruction` and `sendAndConfirm` from the index. All three were already public within their modules and documented for exactly this use, just unreachable from outside.

`owner` must remain a **signer**, because `initialize` declares `owner: Signer` and pins `payer = owner` for the three PDAs it creates (`AntConfig`, `AntControllers`, root `AntRecord`). A sponsor therefore also funds those lamports on the owner's account — most simply a `SystemTransfer` earlier in the same transaction. A caller assembling a partially-signed transaction for a remote owner passes `createNoopSigner(ownerAddress)`.

```ts
const { instructions, mintSigner } = await buildSpawnAntInstructions({
  signer: sponsor,                            // pays
  owner: createNoopSigner(customerAddress),   // owns, signs initialize
  state: { name },
});
```

## Tests

`src/solana/spawn-ant-owner.test.ts` pins the **account roles** rather than the byte layout (`spawn-ant.test.ts` already covers the wire format), because the failure being guarded is a silent swap of payer and owner — which hands custody to the wrong wallet while still producing a perfectly well-formed transaction.

- the default still mints to the signer (no behaviour change)
- a supplied owner receives the asset while the signer keeps paying
- `initialize` is signed by the owner and **not** the payer
- a noop signer works, so a sponsor can build for a remote owner

Full unit suite: **529 passing, 0 failing.** `yarn lint:fix` clean; hooks (lint-staged + commitlint) passed on commit.

## Context

Found while building sponsored self-custody ArNS purchases in `ar-io/ar-io-bundler`, where Turbo pays the Solana fees and rent and the buyer owns the ANT from the moment it is minted. That implementation currently carries a hand-copied `CreateV1` builder purely because of this gap; this change lets it be deleted.

## Checklist

- [x] My PR is against the correct branch (`alpha`, per CONTRIBUTING.md)
- [x] My commit messages follow conventional commits style
- [x] My commit messages clearly explain the reasons for the changes
- [x] I have followed the architecture guidelines
- [x] I have run lint and format checks
- [x] I have run all tests
- [x] I have checked for existing issues/PRs to avoid duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTi1Pd388d9Kh11oU98aES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a separate owner when spawning an ANT.
  - Exposed utilities for building spawn instructions and creating ANT instructions for custom transaction flows.
  - Exposed the send-and-confirm transaction utility.

- **Bug Fixes**
  - Ensured the designated owner receives the ANT while the payer remains responsible for transaction creation and fees.

- **Tests**
  - Added coverage for owner assignment, signer roles, and remote-owner scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->