### PR TITLE
chore(release): alpha → main (4.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [4.3.0-alpha.1](https://github.com/ar-io/ar-io-sdk/compare/v4.2.0...v4.3.0-alpha.1) (2026-08-28)
+
+
+### Features
+
+* **solana:** allow a spawned ANT's owner to differ from the payer ([e5f3d57](https://github.com/ar-io/ar-io-sdk/commit/e5f3d57025d6e42f77153de8dd04fd179cfaba9d))
+
 # [4.2.0](https://github.com/ar-io/ar-io-sdk/compare/v4.1.5...v4.2.0) (2026-08-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [4.3.0-alpha.2](https://github.com/ar-io/ar-io-sdk/compare/v4.3.0-alpha.1...v4.3.0-alpha.2) (2026-08-30)
+
+
+### Features
+
+* **solana:** route epoch rent to the creator (ADR-0029) ([cc69c37](https://github.com/ar-io/ar-io-sdk/commit/cc69c379639f5f14e8d8f24d47fb950fc1bad58e)), closes [#121](https://github.com/ar-io/ar-io-sdk/issues/121)
+
 # [4.3.0-alpha.1](https://github.com/ar-io/ar-io-sdk/compare/v4.2.0...v4.3.0-alpha.1) (2026-08-28)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.3.0-alpha.1",
+  "version": "4.3.0-alpha.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.2.0",
+  "version": "4.3.0-alpha.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@ar.io/solana-contracts": "1.1.0",
+    "@ar.io/solana-contracts": "1.2.0",
     "@noble/hashes": "^1.8.0",
     "@solana-program/address-lookup-table": "^0.11.0",
     "@solana-program/compute-budget": "^0.15.0",

--- a/src/solana/constants.ts
+++ b/src/solana/constants.ts
@@ -77,6 +77,17 @@ export const WITHDRAWAL_SEED = Buffer.from('withdrawal');
 export const WITHDRAWAL_COUNTER_SEED = Buffer.from('withdrawal_counter');
 export const ALLOWLIST_SEED = Buffer.from('allowlist');
 export const EPOCH_SEED = Buffer.from('epoch');
+/**
+ * Seed for the `EpochRentReceipt` PDA (ADR-0029). The receipt records which
+ * account funded an Epoch's rent so `close_epoch` can refund the creator
+ * rather than whoever wins the race to sign the close.
+ *
+ * Derived by hand rather than with a generated helper: the account is reached
+ * only through `remaining_accounts` and `admin_close_orphaned_epoch_rent_receipt`,
+ * so the IDL carries no seed metadata for it and Codama emits no
+ * `findEpochRentReceiptPda`.
+ */
+export const EPOCH_RENT_RECEIPT_SEED = Buffer.from('epoch_rent_receipt');
 export const EPOCH_SETTINGS_SEED = Buffer.from('epoch_settings');
 export const OBSERVATION_SEED = Buffer.from('observation');
 export const REDELEGATION_SEED = Buffer.from('redelegation');

--- a/src/solana/epoch-rent-receipt.test.ts
+++ b/src/solana/epoch-rent-receipt.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the ADR-0029 epoch-rent-receipt client surface:
+ *
+ *   - `getEpochRentReceiptPDA` — the hand-rolled PDA derivation. Codama emits
+ *     no finder for `EpochRentReceipt` (the account is reached only through
+ *     `remaining_accounts` and `admin_close_orphaned_epoch_rent_receipt`, so
+ *     the IDL carries no seed metadata), which makes this derivation the one
+ *     place a typo would silently produce a wrong-but-valid address.
+ *   - `buildCloseEpochRentAccounts` — the `remaining_accounts` tail for
+ *     `close_epoch`.
+ *
+ * Mirrors `programs/ario-gar/src/instructions/epoch.rs`:
+ *   create_epoch: `ctx.remaining_accounts.first()` is the receipt; when absent
+ *                 the epoch is created with `has_rent_receipt = 0`.
+ *   close_epoch:  branches on `epoch.has_rent_receipt != 0` — NOT on what the
+ *                 caller passed — then requires
+ *                 `remaining_accounts = [receipt, creator]`, both writable.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { AccountRole, type Address, getAddressDecoder } from '@solana/kit';
+
+import { buildCloseEpochRentAccounts } from './io-writeable.js';
+import { getEpochPDA, getEpochRentReceiptPDA } from './pda.js';
+
+const dec = getAddressDecoder();
+function pk(tag: number): Address {
+  const u = new Uint8Array(32);
+  u[0] = tag & 0xff;
+  u[31] = 0x2a;
+  return dec.decode(u);
+}
+const GAR = 'ARioGarProgramXXXXXXXXXXXXXXXXXXXXXXXXXXXXX' as Address;
+const RECEIPT = pk(7);
+const CREATOR = pk(8);
+
+describe('getEpochRentReceiptPDA', () => {
+  it('is deterministic for a given index', async () => {
+    const [a] = await getEpochRentReceiptPDA(42, GAR);
+    const [b] = await getEpochRentReceiptPDA(42, GAR);
+    assert.equal(a, b);
+  });
+
+  it('differs per epoch index', async () => {
+    const [a] = await getEpochRentReceiptPDA(42, GAR);
+    const [b] = await getEpochRentReceiptPDA(43, GAR);
+    assert.notEqual(a, b);
+  });
+
+  it('accepts number and bigint identically (u64 LE seed)', async () => {
+    const [a] = await getEpochRentReceiptPDA(780, GAR);
+    const [b] = await getEpochRentReceiptPDA(780n, GAR);
+    assert.equal(a, b);
+  });
+
+  it('is NOT the Epoch PDA for the same index (distinct seed prefix)', async () => {
+    const [receipt] = await getEpochRentReceiptPDA(780, GAR);
+    const [epoch] = await getEpochPDA(780, GAR);
+    assert.notEqual(receipt, epoch);
+  });
+
+  it('is program-scoped', async () => {
+    const [a] = await getEpochRentReceiptPDA(1, GAR);
+    const [b] = await getEpochRentReceiptPDA(1, pk(123));
+    assert.notEqual(a, b);
+  });
+});
+
+describe('buildCloseEpochRentAccounts', () => {
+  it('returns no extra accounts for a pre-ADR-0029 epoch (flag clear)', () => {
+    // This is what keeps un-upgraded crankers working through the transition.
+    assert.deepEqual(buildCloseEpochRentAccounts(0, RECEIPT, null, 100), []);
+  });
+
+  it('ignores a creator that happens to be known when the flag is clear', () => {
+    // The program refunds `payer` in this branch; passing extras would be wrong.
+    assert.deepEqual(buildCloseEpochRentAccounts(0, RECEIPT, CREATOR, 100), []);
+  });
+
+  it('returns [receipt, creator] in that exact order when the flag is set', () => {
+    const got = buildCloseEpochRentAccounts(1, RECEIPT, CREATOR, 100);
+    assert.equal(got.length, 2);
+    assert.equal(
+      got[0].address,
+      RECEIPT,
+      'receipt must be remaining_accounts[0]',
+    );
+    assert.equal(
+      got[1].address,
+      CREATOR,
+      'creator must be remaining_accounts[1]',
+    );
+  });
+
+  it('marks both accounts writable — the program drains both', () => {
+    const got = buildCloseEpochRentAccounts(1, RECEIPT, CREATOR, 100);
+    assert.equal(got[0].role, AccountRole.WRITABLE);
+    assert.equal(got[1].role, AccountRole.WRITABLE);
+  });
+
+  it('treats any non-zero flag byte as set, matching `has_rent_receipt != 0`', () => {
+    for (const flag of [1, 2, 255]) {
+      assert.equal(
+        buildCloseEpochRentAccounts(flag, RECEIPT, CREATOR, 100).length,
+        2,
+        `flag ${flag} should take the receipted branch`,
+      );
+    }
+  });
+
+  it('throws a diagnosable error when the flag is set but the receipt is gone', () => {
+    assert.throws(
+      () => buildCloseEpochRentAccounts(1, RECEIPT, null, 4242),
+      /Epoch 4242 .*flagged.*rent receipt.*MissingEpochRentReceipt/s,
+    );
+  });
+});

--- a/src/solana/index.ts
+++ b/src/solana/index.ts
@@ -142,13 +142,26 @@ export type {
   EscrowNetwork,
 } from './canonical-message.js';
 
-// ANT spawn (mint MPL Core asset + initialize ario-ant state in one tx)
+// ANT spawn (mint MPL Core asset + initialize ario-ant state in one tx).
+//
+// `buildSpawnAntInstructions` / `buildCreateAntInstruction` are exported for
+// callers who need to bundle a spawn into a larger transaction rather than send
+// it — notably a SPONSORED spawn, where one wallet pays and another owns. Both
+// were already public within the module and documented as such; without the
+// re-export, a consumer wanting that shape has to hand-copy the `CreateV1`
+// builder, and a copy silently drifts from the Attributes-plugin/ADR-028
+// authority shape that `ario_arns::buy_name` depends on (a mismatch surfaces
+// only later, as MPL Core 0x4 "Plugin not found", at purchase time).
 export {
   spawnSolanaANT,
+  buildSpawnAntInstructions,
+  buildCreateAntInstruction,
   ARIO_LOGO_TX_ID,
   DEFAULT_ANT_TRANSACTION_ID,
 } from './spawn-ant.js';
 export type {
+  AntAttribute,
+  SpawnAntInstructions,
   SpawnSolanaANTParams,
   SpawnSolanaANTResult,
   SpawnSolanaANTState,
@@ -272,6 +285,10 @@ export {
   estimatePriorityFeeMicroLamports,
   estimateQuotePriorityFeeMicroLamports,
   estimateWalletPriorityFeeMicroLamports,
+  // Consumers assembling their own instruction bundles (see
+  // `buildSpawnAntInstructions`) need the same send path the SDK uses
+  // internally, including its compute-budget and wallet-rewrite handling.
+  sendAndConfirm,
 } from './send.js';
 export {
   ACL_BOOTSTRAP_ACCOUNT_BYTES,

--- a/src/solana/io-writeable.ts
+++ b/src/solana/io-writeable.ts
@@ -174,6 +174,8 @@ import {
 } from '@ar.io/solana-contracts/gar';
 import {
   Protocol,
+  fetchMaybeEpoch,
+  fetchMaybeEpochRentReceipt,
   getAdminSetRewardRatiosInstructionAsync,
   getAllowDelegateInstructionAsync,
   getCancelWithdrawalInstruction,
@@ -224,6 +226,7 @@ import {
   getDelegationPDA,
   getDemandFactorPDA,
   getEpochPDA,
+  getEpochRentReceiptPDA,
   getEpochSettingsPDA,
   getGarSettingsPDA,
   getGatewayPDA,
@@ -289,6 +292,52 @@ function withRemainingAccounts<I extends Instruction>(
     ...remaining,
   ];
   return { ...ix, accounts } as I;
+}
+
+/**
+ * Build the `remaining_accounts` tail that `close_epoch` requires (ADR-0029).
+ *
+ * Mirrors `programs/ario-gar/src/instructions/epoch.rs::close_epoch`, which
+ * branches on `Epoch.has_rent_receipt` — **program-controlled state, never
+ * "did the caller pass a receipt?"**. That distinction is the whole security
+ * property: if the branch keyed off account presence, a scavenger would simply
+ * omit the receipt to fall through to the legacy `close = payer` path and
+ * pocket rent the epoch's creator paid for.
+ *
+ * - flag clear (every pre-ADR-0029 epoch) → no extra accounts; the program
+ *   refunds `payer` exactly as before, which is what lets un-upgraded crankers
+ *   keep closing old epochs during the ~8-day transition window.
+ * - flag set → exactly two accounts, in this order, both writable because both
+ *   are drained: `[receipt, creator]`. The program rejects a missing or
+ *   read-only entry with `MissingEpochRentReceipt`, a wrong-PDA or
+ *   foreign-owned receipt with `InvalidEpochRentReceipt`, and a creator that
+ *   does not match `receipt.creator` with `WrongEpochCreator`.
+ *
+ * @param hasRentReceipt `Epoch.hasRentReceipt`. Any non-zero value counts — the
+ *   byte was padding before ADR-0029 and the program itself treats it as
+ *   boolean (`epoch.has_rent_receipt != 0`).
+ * @param creator `EpochRentReceipt.creator`, or `null` if no receipt account
+ *   exists at the derived address.
+ */
+export function buildCloseEpochRentAccounts(
+  hasRentReceipt: number,
+  receiptPda: Address,
+  creator: Address | null,
+  epochIndex: number,
+): AccountMeta[] {
+  if (hasRentReceipt === 0) return [];
+  if (creator === null) {
+    throw new Error(
+      `Epoch ${epochIndex} is flagged as having a rent receipt but none exists ` +
+        `at ${receiptPda}. close_epoch would fail with MissingEpochRentReceipt; ` +
+        `an authority can clear the orphan with ` +
+        `admin_close_orphaned_epoch_rent_receipt.`,
+    );
+  }
+  return [
+    { address: receiptPda, role: AccountRole.WRITABLE },
+    { address: creator, role: AccountRole.WRITABLE },
+  ];
 }
 
 /**
@@ -4117,7 +4166,27 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       { programAddress: this.garProgram },
     );
 
-    const sig = await this.sendTransaction([ix], 1_000_000);
+    // ADR-0029: record who funded the Epoch's rent so `close_epoch` can refund
+    // the creator instead of whoever wins the race to sign the close.
+    //
+    // The receipt rides as a trailing `remaining_accounts` entry, NOT a declared
+    // account, so `create_epoch`'s IDL account list is unchanged and crankers
+    // running an older client keep working — they simply omit it and the epoch
+    // is created with `has_rent_receipt = 0`, taking the legacy refund path.
+    // On-chain: `create_epoch` reads `ctx.remaining_accounts.first()`.
+    const [receiptPda] = await getEpochRentReceiptPDA(
+      epochIndex,
+      this.garProgram,
+    );
+
+    const sig = await this.sendTransaction(
+      [
+        withRemainingAccounts(ix, [
+          { address: receiptPda, role: AccountRole.WRITABLE },
+        ]),
+      ],
+      1_000_000,
+    );
     return { id: sig };
   }
 
@@ -4286,7 +4355,51 @@ export class SolanaARIOWriteable extends SolanaARIOReadable {
       { programAddress: this.garProgram },
     );
 
-    const sig = await this.sendTransaction([ix]);
+    // ADR-0029: `close_epoch` decides where the rent goes by reading
+    // `Epoch.hasRentReceipt` — program-controlled state, deliberately NOT
+    // "did the caller pass a receipt?" (that would let a scavenger omit the
+    // receipt to force the legacy `close = payer` branch and pocket the rent).
+    //
+    // So mirror the program: read the flag, and only when it is set append the
+    // two accounts the receipted branch requires, in this exact order:
+    //   remaining_accounts[0] = the EpochRentReceipt PDA   (writable — closed)
+    //   remaining_accounts[1] = receipt.creator            (writable — paid)
+    // Both are mandatory in that branch; omitting either is
+    // `MissingEpochRentReceipt`. Epochs created before this upgrade have the
+    // flag clear and need no extra accounts, which is what keeps the ~8-day
+    // mixed-version transition window working in both directions.
+    const [epochPda] = await getEpochPDA(params.epochIndex, this.garProgram);
+    const epochAccount = await fetchMaybeEpoch(this.rpc, epochPda, {
+      commitment: this.commitment,
+    });
+    const hasRentReceipt = epochAccount.exists
+      ? epochAccount.data.hasRentReceipt
+      : 0;
+
+    const [receiptPda] = await getEpochRentReceiptPDA(
+      params.epochIndex,
+      this.garProgram,
+    );
+    let creator: Address | null = null;
+    if (hasRentReceipt !== 0) {
+      const receipt = await fetchMaybeEpochRentReceipt(this.rpc, receiptPda, {
+        commitment: this.commitment,
+      });
+      creator = receipt.exists ? receipt.data.creator : null;
+    }
+
+    const remainingAccounts = buildCloseEpochRentAccounts(
+      hasRentReceipt,
+      receiptPda,
+      creator,
+      params.epochIndex,
+    );
+
+    const sig = await this.sendTransaction([
+      remainingAccounts.length > 0
+        ? withRemainingAccounts(ix, remainingAccounts)
+        : ix,
+    ]);
     return { id: sig };
   }
 

--- a/src/solana/pda.ts
+++ b/src/solana/pda.ts
@@ -51,6 +51,7 @@ import {
   BALANCE_SEED,
   DELEGATION_SEED,
   DEMAND_FACTOR_SEED,
+  EPOCH_RENT_RECEIPT_SEED,
   EPOCH_SEED,
   EPOCH_SETTINGS_SEED,
   ESCROW_ANT_SEED,
@@ -259,6 +260,28 @@ export async function getEpochPDA(
   return getProgramDerivedAddress({
     programAddress: programId,
     seeds: [EPOCH_SEED, indexBuf],
+  });
+}
+
+/**
+ * `EpochRentReceipt` PDA for an epoch (ADR-0029) — seeds
+ * `["epoch_rent_receipt", u64_le(epochIndex)]`.
+ *
+ * `create_epoch` initialises this as a trailing `remaining_accounts` entry and
+ * sets `Epoch.hasRentReceipt`; `close_epoch` then refunds the Epoch's rent to
+ * the recorded `creator` instead of the closing signer. Hand-rolled because the
+ * account never appears in a declared `Accounts` struct for those two
+ * instructions, so the IDL has no seeds for it and Codama generates no finder.
+ */
+export async function getEpochRentReceiptPDA(
+  epochIndex: number | bigint,
+  programId: Address = ARIO_GAR_PROGRAM_ID,
+): Promise<Pda> {
+  const indexBuf = Buffer.alloc(8);
+  indexBuf.writeBigUInt64LE(BigInt(epochIndex));
+  return getProgramDerivedAddress({
+    programAddress: programId,
+    seeds: [EPOCH_RENT_RECEIPT_SEED, indexBuf],
   });
 }
 

--- a/src/solana/spawn-ant-owner.test.ts
+++ b/src/solana/spawn-ant-owner.test.ts
@@ -1,0 +1,106 @@
+/**
+ * A spawned ANT's OWNER may differ from the wallet that pays for it.
+ *
+ * `buildSpawnAntInstructions({ owner })` separates the two roles the spawn
+ * really has: `signer` funds the MPL Core asset's rent and signs `CreateV1`,
+ * while `owner` receives the NFT and signs `ario_ant::initialize`. That is what
+ * a sponsored spawn needs — a service pays, the end user owns — and the chain
+ * already supports it (`CreateV1` takes `payer` and `owner` as separate
+ * accounts, and `owner` is not a signer there).
+ *
+ * These tests pin the ACCOUNT ROLES rather than the byte layout, which
+ * `spawn-ant.test.ts` already covers: the failure mode this guards against is a
+ * silent swap of payer and owner, which would hand custody to the wrong wallet
+ * while still producing a perfectly well-formed transaction.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  type Address,
+  address,
+  createNoopSigner,
+  generateKeyPairSigner,
+} from '@solana/kit';
+
+import { buildSpawnAntInstructions } from './spawn-ant.js';
+
+const OWNER: Address = address('11111111111111111111111111111113');
+
+/** MPL Core `CreateV1` account order: asset, collection, authority, payer, owner. */
+const CREATE_V1_PAYER_INDEX = 3;
+const CREATE_V1_OWNER_INDEX = 4;
+
+async function build(withOwner: boolean) {
+  const signer = await generateKeyPairSigner();
+  const { instructions } = await buildSpawnAntInstructions({
+    signer,
+    state: { name: 'sponsored-name' },
+    ...(withOwner ? { owner: createNoopSigner(OWNER) } : {}),
+  });
+  const [createIx, initIx] = instructions;
+  assert.ok(createIx.accounts, 'CreateV1 must carry accounts');
+  assert.ok(initIx.accounts, 'initialize must carry accounts');
+  return { signer, createIx, initIx };
+}
+
+describe('buildSpawnAntInstructions owner/payer separation', () => {
+  it('defaults the owner to the signer, unchanged from before', async () => {
+    const { signer, createIx, initIx } = await build(false);
+    const accounts = createIx.accounts as readonly { address: Address }[];
+
+    assert.equal(accounts[CREATE_V1_PAYER_INDEX].address, signer.address);
+    assert.equal(accounts[CREATE_V1_OWNER_INDEX].address, signer.address);
+    assert.ok(
+      (initIx.accounts as readonly { address: Address }[]).some(
+        (a) => a.address === signer.address,
+      ),
+      'initialize must be signed by the signer when no owner is given',
+    );
+  });
+
+  it('mints to `owner` while `signer` still pays', async () => {
+    const { signer, createIx } = await build(true);
+    const accounts = createIx.accounts as readonly { address: Address }[];
+
+    assert.equal(
+      accounts[CREATE_V1_PAYER_INDEX].address,
+      signer.address,
+      'the sponsor must remain the payer',
+    );
+    assert.equal(
+      accounts[CREATE_V1_OWNER_INDEX].address,
+      OWNER,
+      'the ANT must be minted to the supplied owner, not the payer',
+    );
+    assert.notEqual(
+      accounts[CREATE_V1_OWNER_INDEX].address,
+      signer.address,
+      'payer and owner must not collapse — that silently hands over custody',
+    );
+  });
+
+  // `ario_ant::initialize` declares `owner: Signer` and creates AntConfig,
+  // AntControllers and the root AntRecord with `payer = owner`. Signing it with
+  // the sponsor would both fail on chain and charge the wrong account.
+  it('signs `initialize` as the OWNER, not the payer', async () => {
+    const { signer, initIx } = await build(true);
+    const addresses = (initIx.accounts as readonly { address: Address }[]).map(
+      (a) => a.address,
+    );
+
+    assert.ok(addresses.includes(OWNER), 'initialize must reference the owner');
+    assert.ok(
+      !addresses.includes(signer.address),
+      'initialize must NOT reference the sponsor — it pins payer = owner',
+    );
+  });
+
+  it('accepts a noop signer, so a sponsor can build for a remote owner', async () => {
+    const { createIx } = await build(true);
+    const accounts = createIx.accounts as readonly { address: Address }[];
+    // The point of a noop signer: the sponsor assembles and partially signs the
+    // transaction without holding the owner's key, and the owner adds theirs.
+    assert.equal(accounts[CREATE_V1_OWNER_INDEX].address, OWNER);
+  });
+});

--- a/src/solana/spawn-ant.ts
+++ b/src/solana/spawn-ant.ts
@@ -361,11 +361,33 @@ export async function buildSpawnAntInstructions(params: {
   state: SpawnSolanaANTState;
   antProgramId?: Address;
   mintSigner?: KeyPairSigner;
+  /**
+   * Wallet that will OWN the new ANT. Defaults to `signer`, which is the
+   * existing behaviour — omitting it changes nothing.
+   *
+   * Supplying a different signer separates the two roles the spawn actually
+   * has: `signer` stays the fee payer and `CreateV1` authority (it funds the
+   * MPL Core asset's rent), while `owner` receives the NFT and signs
+   * `ario_ant::initialize`. That split is what a sponsored spawn needs — a
+   * service pays, the end user owns — and it is available on chain today:
+   * `CreateV1` takes `payer` and `owner` as separate accounts and `owner` is
+   * not a signer there.
+   *
+   * `owner` must still be a signer, because `ario_ant::initialize` declares
+   * `owner: Signer` and pins `payer = owner` for the three PDAs it creates
+   * (`AntConfig`, `AntControllers`, the root `AntRecord`). A sponsor
+   * therefore also has to fund those lamports on the owner's account — most
+   * simply with a `SystemTransfer` earlier in the same transaction. Callers
+   * assembling a partially-signed transaction for a remote owner can pass
+   * `createNoopSigner(ownerAddress)` and let the owner add the signature.
+   */
+  owner?: SolanaSigner;
 }): Promise<SpawnAntInstructions> {
   if (!params.state?.name || params.state.name.length === 0) {
     throw new Error('buildSpawnAntInstructions: state.name is required');
   }
   const { signer, state, antProgramId = ARIO_ANT_PROGRAM_ID } = params;
+  const owner = params.owner ?? signer;
   const mintSigner = params.mintSigner ?? (await generateKeyPairSigner());
   const mint = mintSigner.address;
 
@@ -392,8 +414,9 @@ export async function buildSpawnAntInstructions(params: {
   //
   // ADR-028: the asset's UpdateAuthority is the per-asset `ant_authority` PDA
   // and the Attributes plugin authority is `UpdateAuthority` (→ that PDA), so
-  // all MPL Core updates route through the ario-ant program. The owner (the
-  // spawning signer) keeps custody of the NFT.
+  // all MPL Core updates route through the ario-ant program. The owner keeps
+  // custody of the NFT — by default the spawning signer, or `params.owner`
+  // when a sponsor is paying on someone else's behalf.
   const [antAuthority] = await getAntAuthorityPDA(mint, antProgramId);
   const createIx = getCreateV1Instruction({
     asset: mintSigner,
@@ -401,9 +424,8 @@ export async function buildSpawnAntInstructions(params: {
     authority: signer,
     // `owner` MUST be explicit. MPL Core defaults owner to updateAuthority when
     // omitted, so with updateAuthority = the ant_authority PDA an omitted owner
-    // would make the PROGRAM PDA the NFT owner (user loses custody). Pin it to
-    // the spawning wallet.
-    owner: signer.address,
+    // would make the PROGRAM PDA the NFT owner (user loses custody).
+    owner: owner.address,
     updateAuthority: antAuthority,
     dataState: DataState.AccountState,
     name: state.name,
@@ -428,7 +450,9 @@ export async function buildSpawnAntInstructions(params: {
   const initIx = await buildInitializeAntIx({
     programId: antProgramId,
     mint,
-    signer,
+    // `ario_ant::initialize` declares `owner: Signer` and creates its PDAs with
+    // `payer = owner`, so this must be the OWNER, not the fee payer.
+    signer: owner,
     state,
   });
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.2.0';
+export const version = '4.3.0-alpha.1';

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.3.0-alpha.1';
+export const version = '4.3.0-alpha.2';

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,10 @@
   resolved "https://registry.yarnpkg.com/@actions/io/-/io-3.0.2.tgz#6f89b27a159d109836d983efa283997c23b92284"
   integrity sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==
 
-"@ar.io/solana-contracts@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.1.0.tgz#900784dad9b0867ae76678dc177d346692f5e61f"
-  integrity sha512-qX8ttp5GoZYMMNNgVzGMdBmaym3g1XL3Y7GyApbbXo4e4SSgt3DXMKl6PCISij5snhkec21LAhHxzHuLyoOe8w==
+"@ar.io/solana-contracts@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/solana-contracts/-/solana-contracts-1.2.0.tgz#3e56cdbce36c295001572a105fe689690cb77236"
+  integrity sha512-g/zqlYNK3geFzjaiYhicFniGsBu2T3MDM+Gh7IuOmQXV1HSPakib3oP1p0wWeJ0ho1SipoPvW+KncUaM9KVQHA==
   dependencies:
     "@noble/hashes" "^1.5.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
Promotes `alpha` to `main`, publishing **4.3.0** to the `latest` dist-tag.

## What ships

**ADR-0029 — epoch rent refunds the creator** (#723). `close_epoch` now refunds the Epoch account's ~0.0664 SOL rent to the account that *created* the epoch rather than whoever signs the close. Both instructions are permissionless, so a close-only bot was collecting rent funded by operators doing the mandatory work — measured on mainnet as **8 of 8 closes taken by one address that created zero epochs**, ~24.2 SOL/year.

Client side: `getEpochRentReceiptPDA`, the receipt attached to `createEpoch` as a trailing `remaining_accounts` entry, and `closeEpoch` branching on `Epoch.hasRentReceipt` to append `[receipt, creator]`. `crankEpochStep` needed no change — it routes through both.

**Spawned ANT owner distinct from payer** (#721).

## Why now

The `ario-gar` contract is **already deployed on mainnet** (slot `442893933`, `sha256 7f09326f…`), byte-verified against the artifact validated end-to-end on staging. So `latest` describes behaviour mainnet has — the release rule is satisfied.

More pressingly: **caret ranges exclude prereleases.** `^4.1.0` / `^4.1.4` do not satisfy `4.3.0-alpha.2` and silently resolve to `4.2.0`. Until 4.3.0 ships stable, no caret-pinned consumer — cranker, observer, or third party — can reach this change at all.

## Validated on a real cluster

Full matrix against a deployed ADR-0029 program on staging: receipt written with the correct creator; **rent lands with the creator on close (+0.067567680 SOL, closer paid only a 0.000005173 fee)**, deliberately signed by a different key so it proves redirection rather than a self-refund; receipt closed with no orphan; legacy epochs still close via `close = payer`; the M8 gate still blocks; an un-upgraded cranker kept operating throughout; and an old-client close is rejected with `MissingEpochRentReceipt (6093)` rather than falling through to `close = payer`.

## Note for consumers

Receipted epochs can only be closed by upgraded clients. An un-upgraded cranker attempting one fails inside `crankEpochStep`'s own catch — no wedge, nothing surfaced, the epoch simply stays open until an upgraded client closes it. Requires `@ar.io/solana-contracts@^1.2.0`, already on `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKeNoHyV6m1Z3sh81Jykkf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for sponsored ANT creation, allowing the payer and NFT owner to differ.
  - Added epoch rent tracking and refunds to the account that funded the epoch.
  - Exposed additional Solana instruction-building and transaction utilities.
  - Added helpers for deriving epoch rent receipt addresses.

- **Documentation**
  - Added release notes for versions 4.3.0-alpha.1 and 4.3.0-alpha.2.

- **Chores**
  - Updated the SDK version to 4.3.0-alpha.2 and refreshed Solana contract compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->