### PR TITLE
chore: merge main back into alpha after the 4.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [4.3.0](https://github.com/ar-io/ar-io-sdk/compare/v4.2.0...v4.3.0) (2026-08-31)
+
+
+### Features
+
+* **solana:** allow a spawned ANT's owner to differ from the payer ([e5f3d57](https://github.com/ar-io/ar-io-sdk/commit/e5f3d57025d6e42f77153de8dd04fd179cfaba9d))
+* **solana:** route epoch rent to the creator (ADR-0029) ([cc69c37](https://github.com/ar-io/ar-io-sdk/commit/cc69c379639f5f14e8d8f24d47fb950fc1bad58e)), closes [#121](https://github.com/ar-io/ar-io-sdk/issues/121)
+
 # [4.3.0-alpha.2](https://github.com/ar-io/ar-io-sdk/compare/v4.3.0-alpha.1...v4.3.0-alpha.2) (2026-08-30)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar.io/sdk",
-  "version": "4.3.0-alpha.2",
+  "version": "4.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ar-io/ar-io-sdk.git"

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,4 +15,4 @@
  */
 
 // AUTOMATICALLY GENERATED FILE - DO NOT TOUCH
-export const version = '4.3.0-alpha.2';
+export const version = '4.3.0';


### PR DESCRIPTION
CONTRIBUTING's post-release step — *"After release, `main` should be merged back into `alpha`, so future PR's will be based on the latest code."* It was missed after **4.3.0**, and it now blocks two fixes: #726 and #727 target `alpha` and come up `CONFLICTING` until this lands.

## What's in it

Unlike #720, this one **did conflict**: `alpha` cut `4.3.0-alpha.3` (#725) *after* 4.3.0 was released from `main`, so both branches rewrote the same generated release metadata. **No source files changed** — the diff against `alpha` is exactly these three:

- `package.json` / `src/version.ts` → **4.3.0**, matching `main` (the same resolution #720 took). semantic-release derives the next prerelease from git tags rather than this field — after #720, the next alpha was cut against `v4.2.0`.
- `CHANGELOG.md` → keeps **both** new entries, newest first: `4.3.0-alpha.3` (2026-09-10) above `4.3.0` (2026-08-31). The shared history below them was identical on both branches, so nothing else moves.

## Verification

547 tests, 546 pass, 0 fail (1 pre-existing skip). `tsc` clean, lint 19 warnings (no source touched), format clean.

A trial merge of each dependent PR onto this branch is clean and touches only its own files:
- #726 → `src/solana/io-writeable.ts`, `src/solana/crank-epoch-step.test.ts`, `src/solana/registry-gateway-pdas.test.ts`
- #727 → `src/cli/cli.ts`, `src/cli/options.ts`, `src/cli/commands/gatewayWriteCommands.ts`, `src/cli/write-command-options.test.ts`

## Merge order

1. **This PR**
2. #726 and #727, in either order — they share no files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J84bGS2Pi5xXGerjPUoAJJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Promoted version 4.3.0 from prerelease to stable release.

- **New Features**
  - Spawned ANT ownership can differ from the payer on Solana.
  - Epoch rent is routed to the creator under ADR-0029.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->